### PR TITLE
Updated Achievement Toast

### DIFF
--- a/Datahub.Core/Layout/DatahubAchievementProvider.razor
+++ b/Datahub.Core/Layout/DatahubAchievementProvider.razor
@@ -55,7 +55,18 @@
 
     private void OnAchievementEarned(object sender, AchievementEarnedEventArgs e)
     {
-        _snackbar.Add(e.Achievement!.Name, Severity.Normal, config => { config.Icon = e.Achievement!.Icon; });
+        var message = $"<ul><li><h3>{Localizer["Achievement Unlocked"]}!</h3></li><li><h4>{e.Achievement!.Name}</h4></li><li>{e.Achievement!.Description}</li></ul>";
+        _snackbar.Add(message, Severity.Normal, config =>
+        {
+            config.Icon = e.Achievement!.Icon;
+            config.IconColor = Color.Tertiary;
+            config.ShowCloseIcon = false;
+            config.Onclick = delegate
+            {
+                _navigationManager.NavigateTo("/profile");
+                return Task.CompletedTask;
+            };
+        });
     }
 
     private void OnLocationChanged(object sender, LocationChangedEventArgs e)


### PR DESCRIPTION
closes #80 
- changed to look more like cards on the profile page
- added redirect to profile

Screenshot:
![image](https://user-images.githubusercontent.com/15817372/196529394-e97d487d-0c6e-42da-98a6-efcc4ef007eb.png)

Achievement Card Reference:
![image](https://user-images.githubusercontent.com/15817372/196529578-ecad153b-ac35-4c89-8fc3-63da33aae5cf.png)
