### PR TITLE
Add profile page link to member list in project page

### DIFF
--- a/Datahub.Core/wwwroot/css/site.css
+++ b/Datahub.Core/wwwroot/css/site.css
@@ -5478,12 +5478,44 @@ code {
 .project-page .project-members .member-list .members li {
   padding: 0.5rem;
   display: grid;
-  grid-template-columns: 2rem 1fr 2rem;
+  grid-template-columns: 2rem 1fr 2rem 2rem;
   gap: 0.5rem;
   align-items: baseline;
 }
 .project-page .project-members .member-list .members li:hover {
   background-color: #e2e8f0;
+}
+.project-page .project-members .member-list .members li .profile-icon {
+    color: #94a3b8;
+    border-radius: 8px;
+    width: 2rem;
+    height: 2rem;
+    font-size: 1rem;
+    text-decoration: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    opacity: 0.8;
+    transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.project-page .project-members .member-list .members li .profile-icon:hover:not(.active) {
+    cursor: pointer;
+    color: #1e293b;
+    opacity: 1;
+    background-color: #e2e8f0;
+    transform: translateY(-1px);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.02), 0 1px 2px rgba(0, 0, 0, 0.14);
+}
+
+.project-page .project-members .member-list .members li .profile-icon.active {
+    color: #1e293b;
+    opacity: 1;
+    background-color: #e2e8f0;
+    box-shadow: inset 4px 8px 8px -8px rgba(0, 0, 0, 0.16) !important;
+}
+
+.project-page .project-members .member-list .members li .profile-icon:hover {
+    background-color: #f1f5f9 !important;
 }
 .project-page .project-members .member-list .members li .email-icon {
   color: #94a3b8;

--- a/WebPortal/Pages/Project/DataProject/ProjectMembers.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectMembers.razor
@@ -1,5 +1,6 @@
 @using Datahub.Core.Data.DTO
 @using Datahub.Core.Components.Skeleton
+@using System
 
 @inject ServiceAuthManager _serviceAuthManager
 @inject IDbContextFactory<DatahubProjectDBContext> _dbFactoryProject
@@ -70,7 +71,9 @@ else
                             <li>
                                 <ProfileCircle FullName="@admin.Name"/>
                                 <AeTypography class="name">@admin.Name</AeTypography>
-
+                                <a class="profile-icon" href="/profile/@System.Convert.ToBase64String(@System.Text.Encoding.UTF8.GetBytes(@admin.UserId))">
+                                    <i class="fa-solid fa-user"></i>
+                                </a>
                                 <a class="email-icon" href="@($"mailto:{admin.Email}")">
                                     <i class="fas fa-envelope"></i>
                                 </a>
@@ -90,7 +93,9 @@ else
                             <li>
                                 <ProfileCircle FullName="@member.Name"/>
                                 <AeTypography class="name">@member.Name</AeTypography>
-
+                                <a class="profile-icon" href="/profile/@System.Convert.ToBase64String(@System.Text.Encoding.UTF8.GetBytes(@member.UserId))">
+                                    <i class="fa-solid fa-user"></i>
+                                </a>
                                 <a class="email-icon" href="@($"mailto:{member.Email}")">
                                     <i class="fas fa-envelope"></i>
                                 </a>


### PR DESCRIPTION
Closes #79.

Adds a link to a user's profile page next to their name in the member list of a project page:
![image](https://user-images.githubusercontent.com/56747050/198936776-cc152972-c28d-4159-93e5-925cc75faf06.png)
Proper styling is added to match the styling on the email icon:
![image](https://user-images.githubusercontent.com/56747050/198936862-91fc7a0c-6bd3-4b1a-8d4b-dde65f4e49b0.png)
This also appears on the members list (not just admin list):
![image](https://user-images.githubusercontent.com/56747050/198937045-344e2aed-f972-449f-b9fc-437c72af88ea.png)

