### PR TITLE
Adding way to add new user from project page

### DIFF
--- a/Datahub.Core/wwwroot/css/site.css
+++ b/Datahub.Core/wwwroot/css/site.css
@@ -3772,6 +3772,27 @@ code {
   display: none;
 }
 
+.add-member-button {
+    display: flex;
+    flex-direction: row;
+    margin-top: 2em;
+    padding: 10px 10px 10px 10px;
+    align-items: center;
+    background-color: rgb(51,65,85);
+    border-radius: 20px;
+    transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.add-member-button:hover:not(.active) {
+    cursor: pointer;
+    transform: translateY(-1px);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.02), 0 1px 2px rgba(0, 0, 0, 0.14);
+}
+
+.add-member-button.active {
+    box-shadow: 4px 8px 8px 8px rgba(0, 0, 0, 0.16) !important;
+}
+
 .icon-color {
   color: #57C4EC;
 }

--- a/WebPortal/Pages/Project/DataProject/ProjectAddMemberButton.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectAddMemberButton.razor
@@ -1,0 +1,32 @@
+@inherits HtmlElement
+
+@inject IDialogService _dialogService
+
+<div class="@_classname" @attributes="InputAttributesWithoutClass">
+    <MudIcon Icon="@Icons.Filled.Add" Title="Add Member" Size="Size.Medium"/>
+</div>
+<AeTypography class="name">@Localizer["Add New Member"]</AeTypography>
+<a/>
+<a class="email-icon" @onclick="OpenDialog">
+    <i class="fas fa-plus"></i>
+</a>
+
+@code {
+    // TODO : Plus icon is dark
+
+    private string _classname => $"profile-circle {_inputClass}";
+
+    private void OpenDialog()
+    {
+        var closeOnEscapeKey = new DialogOptions()
+        {
+            CloseOnEscapeKey = true,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true,
+            CloseButton = true
+        };
+
+        _dialogService.Show<ProjectAddMemberDialog>("Invite New User", closeOnEscapeKey);
+    }
+
+}

--- a/WebPortal/Pages/Project/DataProject/ProjectAddMemberButton.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectAddMemberButton.razor
@@ -2,19 +2,15 @@
 
 @inject IDialogService _dialogService
 
-<div class="@_classname" @attributes="InputAttributesWithoutClass">
-    <MudIcon Icon="@Icons.Filled.Add" Title="Add Member" Size="Size.Medium"/>
-</div>
-<AeTypography class="name">@Localizer["Add New Member"]</AeTypography>
-<a/>
-<a class="email-icon" @onclick="OpenDialog">
-    <i class="fas fa-plus"></i>
+<a class="add-member-button" @onclick="OpenDialog">
+    <AeTypography class="name" style="color:white; font-weight:bold; width:95%">@Localizer["Add New Member"]</AeTypography>
+    <i class="fas fa-plus" style="color:white; justify-self:flex-end"></i>
 </a>
+
+
 
 @code {
     // TODO : Plus icon is dark
-
-    private string _classname => $"profile-circle {_inputClass}";
 
     private void OpenDialog()
     {

--- a/WebPortal/Pages/Project/DataProject/ProjectAddMemberDialog.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectAddMemberDialog.razor
@@ -1,0 +1,27 @@
+@using Microsoft.Graph
+<MudDialog>
+    <DialogContent>
+        <span style="display: grid; align: center; height: 2rem">
+            <MudText>Email</MudText>
+            <MudTextField Required="true" Label="Email" @bind-Value="user.Mail"/>
+        </span>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    // TODO : Email overlaps buttons
+
+    [CascadingParameter]
+    MudDialogInstance MudDialog { get; set; }
+
+    [Parameter]
+    public User user { get; set; } = new User();
+
+    void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    void Cancel() => MudDialog.Cancel();
+
+}

--- a/WebPortal/Pages/Project/DataProject/ProjectAddMemberDialog.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectAddMemberDialog.razor
@@ -1,27 +1,41 @@
 @using Microsoft.Graph
 <MudDialog>
     <DialogContent>
-        <span style="display: grid; align: center; height: 2rem">
-            <MudText>Email</MudText>
+        <MudContainer Class="mb-5">
+            <MudText>Email Address</MudText>
             <MudTextField Required="true" Label="Email" @bind-Value="user.Mail"/>
-        </span>
+        </MudContainer>
+        <MudContainer Class="mb-5">
+            <MudText>Select Role</MudText>
+            <MudSelect Required="true" T = "string" Label="Role" Variant="Variant.Outlined">
+                <MudSelectItem Value="@("Member")"/>
+                <MudSelectItem Value="@("Admin")"/>
+            </MudSelect>
+        </MudContainer>
+        <MudContainer Class="mb-5">
+            <MudText>Shareable Link</MudText>
+            <MudTextField @bind-Value="roMsg" ReadOnly="true" T="string" Label="Link"/>
+        </MudContainer>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="Submit">Ok</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">Confirm</MudButton>
     </DialogActions>
 </MudDialog>
 
 @code {
-    // TODO : Email overlaps buttons
-
+    static HttpClient http = new HttpClient();
     [CascadingParameter]
     MudDialogInstance MudDialog { get; set; }
 
     [Parameter]
     public User user { get; set; } = new User();
+    public string roMsg { get; set; } = "Currently Disabled.";
 
-    void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    void Submit()
+    {
+        MudDialog.Close(DialogResult.Ok(true));
+    }
     void Cancel() => MudDialog.Cancel();
 
 }

--- a/WebPortal/Pages/Project/DataProject/ProjectMembers.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectMembers.razor
@@ -1,7 +1,4 @@
 @using Datahub.Core.Data.DTO
-@using Datahub.Core.Components.Skeleton
-@using System
-
 @inject ServiceAuthManager _serviceAuthManager
 @inject IDbContextFactory<DatahubProjectDBContext> _dbFactoryProject
 @inject IUserInformationService _userInformationService
@@ -10,7 +7,7 @@
 @if (_isLoading)
 {
     <span class="project-members-skeleton-positioning">
-        <Skeleton Width="100px" Height="1.5rem" />
+        <Skeleton Width="100px" Height="1.5rem"/>
         <span style="display: flex; margin: 1rem 0">
             <Skeleton Circle Width="2rem" Height="2rem"/>
             <span style="display: block; width: .5rem"></span>
@@ -21,10 +18,10 @@
             <span style="display: block; width: .5rem"></span>
             <Skeleton Width="150px" Height="2rem"/>
         </span>
-        
+
         <span style="display: block; height: 2rem"></span>
-        
-        <Skeleton Width="100px" Height="1.5rem" />
+
+        <Skeleton Width="100px" Height="1.5rem"/>
         @for (var i = 0; i < 10; i++)
         {
             <span style="display: flex; margin: 1rem 0">
@@ -84,6 +81,9 @@ else
                                 </a>
                             </li>
                         }
+                        <li class="add-member">
+                            <ProjectAddMemberButton/>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -117,7 +117,8 @@ else
         {
             _authorizedRoles.Add(RoleConstants.DATAHUB_ROLE_ADMIN);
         }
-        
+
         _isLoading = false;
     }
+
 }

--- a/WebPortal/Pages/Project/DataProject/ProjectMembers.razor
+++ b/WebPortal/Pages/Project/DataProject/ProjectMembers.razor
@@ -81,10 +81,10 @@ else
                                 </a>
                             </li>
                         }
-                        <li class="add-member">
-                            <ProjectAddMemberButton/>
-                        </li>
                     </ul>
+                    <div class="add-member">
+                            <ProjectAddMemberButton/>
+                    </div>
                 </div>
             </div>
         </Authorized>


### PR DESCRIPTION
In order to close #95 .

Added a button at the end of member list on project page:
![image](https://user-images.githubusercontent.com/56747050/202342575-ed775fa5-bb3a-4ec5-9a87-71bfe00f064b.png)
It's styling follow the other buttons in the member list (hover effect + cursor type). Clicking on the button brings up this dialog:
![image](https://user-images.githubusercontent.com/56747050/202342769-cfb052bf-a6e2-4770-bcf2-233dd85a4285.png)
The role option could be implemented in the future for making another user admin directly (if requester is also admin) but for now it will not be used and will be locked on "Member". In addition a public shareable link option could be added here (currently disabled).

All that is left for now is to connect the confirm button to an http request to the appropriate Graph function.
@yjmrobert I am unsure how to properly use the graph function, moreso I am unsure how they are setup: is there a graph function for each project? Is making a post request to the proper port through the CreateGraphUser API enough (with the proper body)? How does the API know which project to add the user to? You don't have to answer all these questions, but just not too sure how to do the next step on this. @MatteoGisondi ideas?