### PR TITLE
Fix for Custom Project Acronyms

### DIFF
--- a/Portal/src/Datahub.Portal/Views/Modals/CreateProjectDialog.razor
+++ b/Portal/src/Datahub.Portal/Views/Modals/CreateProjectDialog.razor
@@ -55,6 +55,8 @@
     private const string AcronymExists = "Workspace Acronym already exists";
     private const string WorkspaceRequiredToGenerateAcronym = "Workspace Title is required to generate an acronym";
     
+    private const string DefaultOrganizationName = "Unspecified";
+    
     private string? _errorMessage;
     private string _projectTitle = string.Empty;
     private string _projectAcronym = string.Empty;
@@ -116,7 +118,7 @@
             StateHasChanged();
             await Task.Delay(1);
             // TODO: Get Organization name?
-            var isAdded = await ProjectCreationService.CreateProjectAsync(_projectTitle, _projectAcronym);
+            var isAdded = await ProjectCreationService.CreateProjectAsync(_projectTitle, _projectAcronym, DefaultOrganizationName);
             _isCreating = false;
             if (isAdded)
             {


### PR DESCRIPTION
Closes #410 

Acronyms were being used for organizations, and the project acronyms were being overridden in the ProjectCreationService.

Added default organization name to the `CreateProjectDialog` component. We may want to decouple the organization from project creation in the future, since it is being collected at the metadata stage of a workspace.