### PR TITLE
Addition of image upload feature for markdown editors

### DIFF
--- a/Portal/src/Datahub.Core/Components/DHMarkdown.razor.js
+++ b/Portal/src/Datahub.Core/Components/DHMarkdown.razor.js
@@ -1,6 +1,6 @@
 export function styleCodeblocks(element) {
     try {
-        if (hljs && element && element.querySelectorAll) {
+        if (typeof hljs !== 'undefined' && element && element.querySelectorAll) {
             element.querySelectorAll('pre code:not(.copy-icon-added)')
                 .forEach(el => {
                     hljs.highlightElement(el);
@@ -12,7 +12,7 @@ export function styleCodeblocks(element) {
     }
 
     try {
-        if (mermaid && element && element.querySelectorAll) {
+        if (typeof mermaid !== 'undefined' && element && element.querySelectorAll) {
             mermaid.mermaidAPI.initialize({});
             element.querySelectorAll('code.language-mermaid')
                 .forEach(el => {

--- a/Portal/src/Datahub.Portal/Components/Markdown/DHMarkdownEditor.razor
+++ b/Portal/src/Datahub.Portal/Components/Markdown/DHMarkdownEditor.razor
@@ -1,17 +1,22 @@
 @using Datahub.Infrastructure.Services.Azure
+@using Datahub.Portal.Controllers
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.Identity.Web
-@inject IHttpContextAccessor _HttpContext
+
+@implements IDisposable
+
+@inject NavigationManager _navigationManager
 @*Markdown.razor*@
 
 
-<MarkdownEditor Value="@MarkdownValue"
+<MarkdownEditor Value="@_markdownValue"
                 ValueChanged="OnMarkdownValueChanged"
-                ValueHTML="@MarkdownHtml"
+                ValueHTML="@_markdownHtml"
                 ValueHTMLChanged="OnMarkdownValueHTMLChanged"
-                ImageUploadEndpoint="https://localhost:5001/api/media/upload"
+                ImageUploadEndpoint="@_imageUploadEndpoint"
                 UploadImage="true"
                 ImageUploadAuthenticationSchema="Bearer"
+                ImageUploadAuthenticationToken="@MediaController.PostMediaSaltySecret"
                 ImageUploadChanged="@OnImageUploadChanged"
                 ImageUploadStarted="@OnImageUploadStarted"
                 ImageUploadProgressed="@OnImageUploadProgressed"
@@ -28,75 +33,54 @@
 
     private MarkdownEditor _elementRef;
     private DotNetObjectReference<DHMarkdownEditor> _dotNetObjectRef;
-    public string MarkdownValue { get; set; }
-    public string MarkdownHtml { get; set; }
-    private bool _isInitialized = false;
+    private string _markdownValue;
+    private string _markdownHtml;
+    private string _imageUploadEndpoint => $"{_navigationManager.BaseUri}api/media/upload";
 
     // Sets the initial value of what the markdown editor should contain
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        MarkdownValue = InitialValue;
+        _markdownValue = InitialValue;
     }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (!firstRender && !_isInitialized)
-        {
-            _elementRef.ImageUploadAuthenticationToken = await GetAccessToken();
-            _isInitialized = true;
-        }
-    }
-
-    private async Task<string> GetAccessToken()
-    {
-        Console.WriteLine(_HttpContext.HttpContext.Request.Headers["authorization"]);
-        var token = "";
-        return token;
-    }
-
 
     // Whenever the markdown text is updated, we update our internal value and call the provided method
     public async Task OnMarkdownValueChanged(string value)
     {
-        MarkdownValue = value;
+        _markdownValue = value;
         await ValueChanged.InvokeAsync(value);
     }
 
     // Whenever the markdown html is changed, we update our internal value
     public Task OnMarkdownValueHTMLChanged(string value)
     {
-        MarkdownHtml = value;
+        _markdownHtml = value;
         return Task.CompletedTask;
     }
 
-    async Task OnImageUploadChanged(FileChangedEventArgs e)
+    private Task OnImageUploadChanged(FileChangedEventArgs e)
     {
-        this.StateHasChanged();
+        return Task.CompletedTask;;
     }
 
-    Task OnImageUploadStarted(FileStartedEventArgs e)
+    private Task OnImageUploadStarted(FileStartedEventArgs e)
     {
-        Console.WriteLine($"Started Image: {e.File.Name}");
         return Task.CompletedTask;
     }
 
     Task OnImageUploadProgressed(FileProgressedEventArgs e)
     {
-        Console.WriteLine($"Image: {e.File.Name} Progress: {(int)e.Percentage}");
         return Task.CompletedTask;
     }
 
     Task OnImageUploadEnded(FileEndedEventArgs e)
     {
-        Console.WriteLine($"Finished Image: {e.File.Name}, Success: {e.Success}");
         return Task.CompletedTask;
     }
 
-    public async void Dispose()
+    public void Dispose()
     {
         _elementRef?.Dispose();
         _dotNetObjectRef?.Dispose();
     }
-
 }

--- a/Portal/src/Datahub.Portal/Components/Markdown/DHMarkdownEditor.razor
+++ b/Portal/src/Datahub.Portal/Components/Markdown/DHMarkdownEditor.razor
@@ -1,4 +1,9 @@
+@using Datahub.Infrastructure.Services.Azure
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.Identity.Web
+@inject IHttpContextAccessor _HttpContext
 @*Markdown.razor*@
+
 
 <MarkdownEditor Value="@MarkdownValue"
                 ValueChanged="OnMarkdownValueChanged"
@@ -6,16 +11,18 @@
                 ValueHTMLChanged="OnMarkdownValueHTMLChanged"
                 ImageUploadEndpoint="https://localhost:5001/api/media/upload"
                 UploadImage="true"
+                ImageUploadAuthenticationSchema="Bearer"
                 ImageUploadChanged="@OnImageUploadChanged"
                 ImageUploadStarted="@OnImageUploadStarted"
                 ImageUploadProgressed="@OnImageUploadProgressed"
                 ImageUploadEnded="@OnImageUploadEnded"
-                />
+                @ref="_elementRef"/>
 
 @code {
+
     [Parameter]
     public string InitialValue { get; set; }
-    
+
     [Parameter]
     public EventCallback<string> ValueChanged { get; set; }
 
@@ -23,7 +30,8 @@
     private DotNetObjectReference<DHMarkdownEditor> _dotNetObjectRef;
     public string MarkdownValue { get; set; }
     public string MarkdownHtml { get; set; }
-    
+    private bool _isInitialized = false;
+
     // Sets the initial value of what the markdown editor should contain
     protected override async Task OnInitializedAsync()
     {
@@ -31,20 +39,37 @@
         MarkdownValue = InitialValue;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender && !_isInitialized)
+        {
+            _elementRef.ImageUploadAuthenticationToken = await GetAccessToken();
+            _isInitialized = true;
+        }
+    }
+
+    private async Task<string> GetAccessToken()
+    {
+        Console.WriteLine(_HttpContext.HttpContext.Request.Headers["authorization"]);
+        var token = "";
+        return token;
+    }
+
+
     // Whenever the markdown text is updated, we update our internal value and call the provided method
     public async Task OnMarkdownValueChanged(string value)
     {
         MarkdownValue = value;
         await ValueChanged.InvokeAsync(value);
     }
-    
+
     // Whenever the markdown html is changed, we update our internal value
     public Task OnMarkdownValueHTMLChanged(string value)
     {
         MarkdownHtml = value;
         return Task.CompletedTask;
     }
-    
+
     async Task OnImageUploadChanged(FileChangedEventArgs e)
     {
         this.StateHasChanged();
@@ -73,5 +98,5 @@
         _elementRef?.Dispose();
         _dotNetObjectRef?.Dispose();
     }
-    
+
 }

--- a/Portal/src/Datahub.Portal/Components/Markdown/DHMarkdownEditor.razor
+++ b/Portal/src/Datahub.Portal/Components/Markdown/DHMarkdownEditor.razor
@@ -1,6 +1,16 @@
 @*Markdown.razor*@
 
-<MarkdownEditor Value="@MarkdownValue" ValueChanged="OnMarkdownValueChanged" ValueHTML="@MarkdownHtml" ValueHTMLChanged="OnMarkdownValueHTMLChanged" @ref="_elementRef"/>
+<MarkdownEditor Value="@MarkdownValue"
+                ValueChanged="OnMarkdownValueChanged"
+                ValueHTML="@MarkdownHtml"
+                ValueHTMLChanged="OnMarkdownValueHTMLChanged"
+                ImageUploadEndpoint="https://localhost:5001/api/media/upload"
+                UploadImage="true"
+                ImageUploadChanged="@OnImageUploadChanged"
+                ImageUploadStarted="@OnImageUploadStarted"
+                ImageUploadProgressed="@OnImageUploadProgressed"
+                ImageUploadEnded="@OnImageUploadEnded"
+                />
 
 @code {
     [Parameter]
@@ -20,7 +30,7 @@
         await base.OnInitializedAsync();
         MarkdownValue = InitialValue;
     }
-    
+
     // Whenever the markdown text is updated, we update our internal value and call the provided method
     public async Task OnMarkdownValueChanged(string value)
     {
@@ -32,6 +42,29 @@
     public Task OnMarkdownValueHTMLChanged(string value)
     {
         MarkdownHtml = value;
+        return Task.CompletedTask;
+    }
+    
+    async Task OnImageUploadChanged(FileChangedEventArgs e)
+    {
+        this.StateHasChanged();
+    }
+
+    Task OnImageUploadStarted(FileStartedEventArgs e)
+    {
+        Console.WriteLine($"Started Image: {e.File.Name}");
+        return Task.CompletedTask;
+    }
+
+    Task OnImageUploadProgressed(FileProgressedEventArgs e)
+    {
+        Console.WriteLine($"Image: {e.File.Name} Progress: {(int)e.Percentage}");
+        return Task.CompletedTask;
+    }
+
+    Task OnImageUploadEnded(FileEndedEventArgs e)
+    {
+        Console.WriteLine($"Finished Image: {e.File.Name}, Success: {e.Success}");
         return Task.CompletedTask;
     }
 

--- a/Portal/src/Datahub.Portal/Controllers/MediaController.cs
+++ b/Portal/src/Datahub.Portal/Controllers/MediaController.cs
@@ -52,12 +52,16 @@ public class MediaController : Controller
     }
 
     [HttpPost("api/media/upload")]
-    // [Authorize]
+    //[Authorize]
     public async Task<IActionResult> PostMedia()
     {
         if (Request.Form.Files.Count == 0)
         {
             return BadRequest("No files uploaded");
+        }
+        if (Request.Form.Files.Count > 1)
+        {
+            return BadRequest("Cannot upload more than one file at a time");
         }
         
         // validate the jwt bearer token to ensure the user is authenticated


### PR DESCRIPTION
Will upload files copy-pasted or drag and dropped into a markdown editor to our fsdhstaticassets azure blob storage in the media container and with a path of "/uploads/upload-<guid>.<file-extension>". Only accepts jpg, jpeg, png and gif and it is secure using a class secret.

Also fixed console warnings present when loading markdown editors