### PR TITLE
Help Form and Notification popover changes

### DIFF
--- a/Portal/src/Datahub.Portal/Layout/Topbar/HelpDialog.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/HelpDialog.razor
@@ -46,14 +46,20 @@
         {
             <MudText Typo="Typo.body2" Class="py-3">@Localizer["Please provide additional information that we can use to investigate this issue."]</MudText>
             <MudTextField T="string" @bind-Value="_ticketDescription" Label=@Localizer["Detailed description"] Required="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Description" Variant="Variant.Outlined" Lines="5" />
-            @if (_ticketTopics["Workspace"] || _ticketTopics["Databricks"] || _ticketTopics["Storage"] || _ticketTopics["User Management"] || _ticketTopics["Tool Requesting"])
+            
+            <MudText Typo="Typo.body2" Class="py-3">@Localizer["Please indicate which workspaces you have this issue in. (Please select all that apply)"]</MudText>
+            @foreach (var workspace in _ticketWorkspaces)
             {
-                <MudText Typo="Typo.body2" Class="py-3">@Localizer["Please indicate which workspaces you have this issue in. (Please select all that apply)"]</MudText>
-                @foreach (var workspace in _ticketWorkspaces)
-                {
-                    <MudCheckBox @bind-Checked="@_ticketWorkspaces[workspace.Key]" Label="@Localizer[workspace.Key]" Color="Color.Primary"></MudCheckBox>
-                }
+                <MudCheckBox @bind-Checked="@_ticketWorkspaces[workspace.Key]" Label="@Localizer[workspace.Key]" Color="Color.Primary"></MudCheckBox>
             }
+        }
+        else if (_currentStep == 3)
+        {
+        <MudText Typo="Typo.body2" Class="py-3">@Localizer["Please indicate which language you would like to be contacted in."]</MudText>
+            <MudRadioGroup T="int" @bind-SelectedOption="_ticketPreferredLanguage">
+                <MudRadio Option="1" Color="Color.Default" UnCheckedColor="Color.Default">@Localizer["English"]</MudRadio>
+                <MudRadio Option="2" Color="Color.Default" UnCheckedColor="Color.Default">@Localizer["French"]</MudRadio>
+            </MudRadioGroup>
         }
         <MudGrid>
             <MudItem xs="6" Align="Align.Start" Class="py-6">
@@ -67,11 +73,11 @@
                 }
             </MudItem>
             <MudItem xs="6" Align="Align.End" Class="py-6">
-                @if (_currentStep < 2 && _currentStep > 0)
+                @if (_currentStep < 3 && _currentStep > 0)
                 {
                 <MudButton Type="Button" Variant="Variant.Filled" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward" OnClick="NextStep">@Localizer["Next"]</MudButton>
                 }
-                else if (_currentStep >= 2)
+                else if (_currentStep >= 3)
                 {
                     <MudButton Type="Button" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.CheckCircleOutline" OnClick="SubmitForm">@Localizer["Submit"]</MudButton>
                 }
@@ -89,8 +95,10 @@
     // Variables used for the form that can be passed in the bug report.
     private String _ticketName = new String("");
     private String _ticketEmail = new String("");
-    private String _ticketPreferredLanguage = new string("");
+    private String _ticketPortalLanguage = new string("");
     private String _ticketDescription = new String("");
+    private String _ticketOrg = new string("");
+    private int _ticketPreferredLanguage = 1;
     private List<Datahub_Project_User> _userRoles;
     private IJSObjectReference _module;
 
@@ -119,17 +127,17 @@
             var url = _navigationManager.Uri; // Retrieve the active URL
             var useragent = await _module.InvokeAsync<string>("retrieveUserAgent"); // Call our JS functions for user agent + resolution
             var resolution = await _module.InvokeAsync<string>("retrieveResolution");
+            var timezone = await _module.InvokeAsync<string>("retrieveTimeZone");
+            var preferredLanguage = (_ticketPreferredLanguage == 1) ? "en" : "fr";
 
             // Retrieve all local storage data
             var allKeys = await _localStorage.KeysAsync();
             var dataDict = new Dictionary<string, string>();
-
             foreach (var key in allKeys)
             {
                 var value = await _localStorage.GetItemAsStringAsync(key);
                 dataDict.Add(key, value);
             }
-
             var localStorageData = Newtonsoft.Json.JsonConvert.SerializeObject(dataDict);
 
             // We retrieve the selected checkboxes that indicate the issue topics
@@ -147,14 +155,14 @@
             }
 
             // We set up the title and description to be submitted in the issue.
-            String title = $"{topics} submitted by {_ticketName}";
-            String description = $"<b>Issue submitted by:</b> {_ticketName}<br /><b>Contact email:</b> {_ticketEmail}<br /><br /><b>Topics:</b> {topics}<br /><b>Workspace:</b> {workspaces}<br /><b>Description:</b> {_ticketDescription}<br /><br /><b>Language:</b> {_ticketPreferredLanguage}<br /><b>Active URL:</b> {url}<br /><b>User Agent:</b> {useragent}<br /><b>Resolution:</b> {resolution}<br /><b>Local Storage:</b><br />{localStorageData}";
+            String title = $"{topics} in {workspaces}";
+            String description = $"<b>Issue submitted by:</b> {_ticketName}<br /><b>Contact email:</b> {_ticketEmail}<br /><b>Organization:</b> {_ticketOrg}<br /><b>Preferred Language:</b> {preferredLanguage} <br /><b>Time Zone:</b> {timezone}<br /><br /><b>Topics:</b> {topics}<br /><b>Workspace:</b> {workspaces}<br /><b>Description:</b> {_ticketDescription}<br /><br /><b>Portal Language:</b> {_ticketPortalLanguage}<br /><b>Active URL:</b> {url}<br /><b>User Agent:</b> {useragent}<br /><b>Resolution:</b> {resolution}<br /><b>Local Storage:</b><br />{localStorageData}";
 
             // Retrieve key and call CreateIssue function
             var creds = await _keyVaultService.GetSecret(_portalConfiguration.AdoServiceUser.PatSecretName);
             var org = _portalConfiguration.AdoOrg.OrgName;
             var project = _portalConfiguration.AdoOrg.ProjectName;
-            await CreateIssue(title, description, topics, org, project, creds);
+            await CreateIssue(title, description, topics, org, project, creds, _ticketName, _ticketEmail, workspaces, _ticketOrg, preferredLanguage, timezone);
 
             // After the issue is created, we close the Help page.
             if (ToggleHelp.HasDelegate)
@@ -162,6 +170,20 @@
                 await ToggleHelp.InvokeAsync();
             }
         }
+    }
+
+    private string getOrg(string email)
+    {
+        var org = "";
+        try
+        {
+            org = email.Split("@")[1].Split('.')[0];
+        }
+        catch (Exception e)
+        {
+            org = "unknown";
+        }
+        return org;
     }
 
     protected override async Task OnInitializedAsync()
@@ -173,7 +195,8 @@
             _viewedUser = await _userInformationService.GetCurrentPortalUserAsync();
             _ticketName = _viewedUser.DisplayName;
             _ticketEmail = _viewedUser.Email;
-            _ticketPreferredLanguage = _viewedUser.Language;
+            _ticketOrg = getOrg(_ticketEmail);
+            _ticketPortalLanguage = _viewedUser.Language;
 
             // Retrieve the list of workspaces
             await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
@@ -215,9 +238,10 @@
     private static readonly HttpClient client = new HttpClient();
     private const string devOpsUrl = "https://dev.azure.com/{organization}/{project}/_apis/wit/workitems/${workItemTypeName}?api-version=6.0";
 
-    public async Task CreateIssue(string title, string description, string topics, string organization, string project, string personalAccessToken)
+    public async Task CreateIssue(string title, string description, string topics, string organization, string project, string personalAccessToken, string name, string email, string workspaces, string orgname, string languagePref, string timezone)
     {
-        var url = devOpsUrl.Replace("{organization}", organization).Replace("{project}", project).Replace("{workItemTypeName}", "Task");
+        title = "TEST ISSUE " + title;
+        var url = devOpsUrl.Replace("{organization}", organization).Replace("{project}", project).Replace("{workItemTypeName}", "Issue");
 
         // Content of the issue. Possible additions: New tags (topics?), AssignedTo, State, Reason.
         var body = new object[]
@@ -226,7 +250,13 @@
             new { op = "add", path = "/fields/System.Description", value = description },
             new { op = "add", path = "/fields/System.AreaPath", value = $"{project}\\FSDH Support Team" },
             new { op = "add", path = "/fields/System.IterationPath", value = $"{project}\\POC 2" },
-            new { op = "add", path = "/fields/System.Tags", value = $"UserSubmitted; {topics}"}, // Separate tags by ;
+            new { op = "add", path = "/fields/System.Tags", value = $"UserSubmitted; {name.Replace(",", " ")};{topics}"},
+            new { op = "add", path = "/fields/Submitted By", value = name},
+            new { op = "add", path = "/fields/Email", value = email},
+            new { op = "add", path = "/fields/Workspaces", value=workspaces},
+            new { op = "add", path = "/fields/Organization", value=orgname},
+            new { op = "add", path = "/fields/Timezone", value=timezone},
+            new { op = "add", path = "/fields/Preferred Language", value=languagePref},
             new
             {
                 op = "add",

--- a/Portal/src/Datahub.Portal/Layout/Topbar/HelpDialog.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/HelpDialog.razor
@@ -217,14 +217,27 @@
 
     public async Task CreateIssue(string title, string description, string topics, string organization, string project, string personalAccessToken)
     {
-        var url = devOpsUrl.Replace("{organization}", organization).Replace("{project}", project).Replace("{workItemTypeName}", "Issue");
+        var url = devOpsUrl.Replace("{organization}", organization).Replace("{project}", project).Replace("{workItemTypeName}", "Task");
 
         // Content of the issue. Possible additions: New tags (topics?), AssignedTo, State, Reason.
         var body = new object[]
         {
             new { op = "add", path = "/fields/System.Title", value = title },
             new { op = "add", path = "/fields/System.Description", value = description },
-            new { op = "add", path = "/fields/System.Tags", value = $"UserSubmitted; {topics}"} // Separate tags by ;
+            new { op = "add", path = "/fields/System.AreaPath", value = $"{project}\\FSDH Support Team" },
+            new { op = "add", path = "/fields/System.IterationPath", value = $"{project}\\POC 2" },
+            new { op = "add", path = "/fields/System.Tags", value = $"UserSubmitted; {topics}"}, // Separate tags by ;
+            new
+            {
+                op = "add",
+                path = "/relations/-",
+                value = new
+                {
+                    rel = "System.LinkTypes.Hierarchy-Reverse",
+                    url = $"https://dev.azure.com/{organization}/{project}/_apis/wit/workItems/1230",
+                    attributes = new { comment = "Parent work item for user generated issue" }
+                }
+            }
         };
 
         var jsonContent = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json-patch+json");

--- a/Portal/src/Datahub.Portal/Layout/Topbar/HelpDialog.razor.js
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/HelpDialog.razor.js
@@ -6,3 +6,7 @@ export function retrieveResolution() {
     const height = window.screen.height;
     return `${width}x${height}`;
 }
+export function retrieveTimeZone() {
+    let date = new Date();
+    return date.toLocaleDateString(undefined, { day: '2-digit', timeZoneName: 'long' }).substring(4)
+}

--- a/Portal/src/Datahub.Portal/Layout/Topbar/HelpPopup.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/HelpPopup.razor
@@ -8,13 +8,13 @@
             aria-label="Help toggle"
             ToggledIcon="@Icons.Material.Filled.Help"
             ToggledChanged="@ToggleHelp"
-            Toggled="_showHelp"
+            Toggled="IsHelpPopupOpen"
             Icon="@Icons.Material.Outlined.HelpOutline"/>
         </MudTooltip>
 
     <MudPopover
         Style="@_style"
-        Open="@_showHelp"
+                Open="@IsHelpPopupOpen"
                 Class="overflow-scroll "
         AnchorOrigin="Origin.BottomRight"
         TransformOrigin="Origin.TopRight">
@@ -54,9 +54,13 @@
 
 @code {
     [Parameter]
-    public string SupportFormUrl { get; set; }
-    private string _style;
+    public bool IsHelpPopupOpen { get; set; }
+
+    [Parameter]
+    public Action ToggleHelp { get; set; }
+
     private bool _showHelp;
+    private string _style;
     private string _datahubEmail;
     private const string TOOLTIP_TEXT = "Help";
 
@@ -70,10 +74,4 @@
             .AddStyle("width", "550px").AddStyle("overflow-y", "auto").AddStyle("max-height", "90vh")
             .Build();
     }
-
-    private void ToggleHelp()
-    {
-        _showHelp = !_showHelp;
-    }
-
 }

--- a/Portal/src/Datahub.Portal/Layout/Topbar/NotificationsList.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/NotificationsList.razor
@@ -47,11 +47,21 @@
 
         @if (_notifications == null || _isLoading)
         {
-            @for (var i = 0; i < 3; i++)
+            @for (var i = 0; i < 1; i++)
             {
                 <MudSkeleton/>
                 <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="300px" Height="110px"/>
             }
+        }
+        else if (_notifications.Count == 0)
+        {
+            <MudCard>
+                <MudCardContent>
+                    <MudText>
+                        @Localizer["You have no notifications."]
+                    </MudText>
+                </MudCardContent>
+            </MudCard>
         }
         else
         {
@@ -90,15 +100,15 @@
                     </MudExpansionPanel>
                 }
             </MudExpansionPanels>
+            <MudStack Row>
+                <MudCheckBox Checked=@_unreadOnly CheckedChanged=@ToggleUnreadOnly T="bool" Label=@Localizer[$"{LocalizationPrefix}.ShowUnreadOnly"] />
+                <MudPagination
+                    Color="Color.Primary"
+                    Count="_totalNotificationCount"
+                    Selected="@_currentPage"
+                    SelectedChanged="PageChanged"/>
+            </MudStack>
         }
-        <MudStack Row>
-            <MudCheckBox Checked=@_unreadOnly CheckedChanged=@ToggleUnreadOnly T="bool" Label=@Localizer[$"{LocalizationPrefix}.ShowUnreadOnly"] />
-            <MudPagination
-                Color="Color.Primary"
-                Count="_totalNotificationCount"
-                Selected="@_currentPage"
-                SelectedChanged="PageChanged"/>
-        </MudStack>
         
     </MudPopover>
 </span>

--- a/Portal/src/Datahub.Portal/Layout/Topbar/NotificationsList.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/NotificationsList.razor
@@ -19,8 +19,8 @@
                 <MudToggleIconButton
                     aria-label="Notifications toggle"
                     ToggledIcon="@Icons.Material.Filled.Notifications"
-                    ToggledChanged="@ToggleNotifications"
-                    Toggled="_showNotifications"
+                    ToggledChanged="@ToggleNotificationsList"
+                    Toggled="IsNotificationsListOpen"
                     Icon="@Icons.Material.Outlined.Notifications"/>
             </MudTooltip>
         </MudBadge>
@@ -31,8 +31,8 @@
             <MudToggleIconButton
                 aria-label="Notifications toggle"
                 ToggledIcon="@Icons.Material.Filled.Notifications"
-                ToggledChanged="@ToggleNotifications"
-                Toggled="_showNotifications"
+                ToggledChanged="@ToggleNotificationsList"
+                Toggled="IsNotificationsListOpen"
                 Icon="@Icons.Material.Outlined.Notifications"/>
         </MudTooltip>
     }
@@ -40,7 +40,7 @@
     <MudPopover
         Style="@_style"
         Class="pa-8"
-        Open="@_showNotifications"
+        Open="@IsNotificationsListOpen"
         AnchorOrigin="Origin.BottomRight"
         TransformOrigin="Origin.TopRight">
 
@@ -105,6 +105,12 @@
 
 
 @code {
+    [Parameter]
+    public bool IsNotificationsListOpen { get; set; }
+
+    [Parameter]
+    public Action ToggleNotificationsList { get; set; }
+
     private string _currentUserId;
 
     private static readonly string LocalizationPrefix = "SYSTEM-NOTIFICATION";
@@ -123,7 +129,6 @@
     private string _style;
     private string _notificationsStyle;
     private bool _showNotifications;
-    private void ToggleNotifications() => _showNotifications = !_showNotifications;
     private int _notificationBadge;
     private bool _showNotificationBadge => _unreadNotificationCount > 0;
     private string _notificationIcon => _showNotificationBadge ? Icons.Material.Filled.Notifications : Icons.Material.Outlined.Notifications;

--- a/Portal/src/Datahub.Portal/Layout/Topbar/Topbar.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/Topbar.razor
@@ -11,8 +11,8 @@
 <HomeSearch />
 <MudSpacer/>
 
-<NotificationsList/>
-<HelpPopup SupportFormUrl="@SupportFormUrl"/>
+<NotificationsList IsNotificationsListOpen="@IsNotificationsListOpen" ToggleNotificationsList="ToggleNotificationsList" />
+<HelpPopup IsHelpPopupOpen="@IsHelpPopupOpen" ToggleHelp="ToggleHelp"/>
 <TopBarProfileButton />
 
 @code {
@@ -21,6 +21,21 @@
     public string SupportFormUrl { get; set; }
     
     private string _titleStyle;
+
+    private bool IsNotificationsListOpen { get; set; }
+    private bool IsHelpPopupOpen { get; set; }
+
+    private void ToggleNotificationsList()
+    {
+        IsNotificationsListOpen = !IsNotificationsListOpen;
+        IsHelpPopupOpen = false;
+    }
+
+    private void ToggleHelp()
+    {
+        IsNotificationsListOpen = false;
+        IsHelpPopupOpen = !IsHelpPopupOpen;
+    }
 
     protected override void OnInitialized()
     {

--- a/Portal/src/Datahub.Portal/i18n/localization3.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization3.fr.json
@@ -175,5 +175,10 @@
   "Get Started": "Commencer",
   "User Management": "Gestion des utilisateurs",
   "Documentation": "Documentation",
-  "Tool Requesting": "Demande d'outils"
+  "Tool Requesting": "Demande d'outils",
+  "Please indicate which language you would like to be contacted in.": "Veuillez indiquer la langue dans laquelle vous aimeriez être contacté(e).",
+  "English": "Anglais",
+  "French": "Français",
+  "Success": "Succès",
+  "Your support ticket has been created. Thank you!": "Votre ticket d'assistance a été créé. Merci!"
 }

--- a/Portal/src/Datahub.Portal/i18n/localization3.json
+++ b/Portal/src/Datahub.Portal/i18n/localization3.json
@@ -175,5 +175,10 @@
   "Get Started": "Get Started",
   "User Management": "User Management",
   "Documentation": "Documentation",
-  "Tool Requesting": "Tool Requesting"
+  "Tool Requesting": "Tool Requesting",
+  "Please indicate which language you would like to be contacted in.": "Please indicate which language you would like to be contacted in.",
+  "English": "English",
+  "French": "French",
+  "Success": "Success",
+  "Your support ticket has been created. Thank you!": "Your support ticket has been created. Thank you!"
 }


### PR DESCRIPTION
Pull request for various changes involving the Help Form.

- Adds some ticket information that was previously missing (Organization, Time Zone, Preferred Language)
- Updated to use the custom fields in ADO for Issues.
- Fixed a bug what the notification/help popovers can be opened at the same time. Opening one now closes the other.
- Fixed a UI issue when no notifications are present. If _unreadNotifications is 0, we simply display a message.