### PR TITLE
:gem: Adding spacing around typography elements within markdown containers

### DIFF
--- a/Portal/src/Datahub.Core/Components/DHMarkdown.razor
+++ b/Portal/src/Datahub.Core/Components/DHMarkdown.razor
@@ -105,7 +105,7 @@
         var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import",
             "./_content/Datahub.Core/Components/DHMarkdown.razor.js");
         await module.InvokeVoidAsync("styleCodeblocks", _elementReference);
-        
+        await module.InvokeVoidAsync("addStyleSheetRule", ".markdown-content .mud-typography { margin-bottom: 1em!important; margin-top: 1em!important; }");
     }
 
 }

--- a/Portal/src/Datahub.Core/Components/DHMarkdown.razor.js
+++ b/Portal/src/Datahub.Core/Components/DHMarkdown.razor.js
@@ -65,3 +65,22 @@ function toggleClassList(el, classes = []){
         el.classList.toggle(name);
     })
 }
+
+let ruleAdded = false;
+
+export function addStyleSheetRule(rule) {
+    if (!ruleAdded) {
+        var stylesheet = document.createElement("style");
+        stylesheet.type = "text/css";
+        document.head.appendChild(stylesheet);
+
+        if (stylesheet.sheet) {
+            if (stylesheet.sheet.insertRule) {
+                stylesheet.sheet.insertRule(rule, 0);
+            } else if (stylesheet.sheet.addRule) {
+                stylesheet.sheet.addRule(rule.split("{")[0].trim(), rule.split("{")[1].trim(), 0);
+            }
+        }
+    }
+    ruleAdded = true;
+}


### PR DESCRIPTION
Uses Javascript to add a rule applying to mud-typography elements to add margin-top and margin-bottom attributes.

**Before**

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/5b805890-d785-40b9-860b-9122ba800af4)

**After**

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/0fbb5fca-91e1-489a-a707-408f1934b678)