### PR TITLE
Fix for ResourcePages in FileExplorerPage

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Project/FileExplorer/FileExplorerPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Project/FileExplorer/FileExplorerPage.razor
@@ -13,6 +13,7 @@
 @using Datahub.Infrastructure.Services.Storage;
 @using Datahub.Portal.Components.Dialogs;
 @using Datahub.Portal.Pages.Project.FileExplorer.Storage;
+@using Datahub.Portal.Pages.Project.FileExplorer.ResourcePages;
 @using Microsoft.Graph.Models
 @using Datahub.Application.Services
 @using Datahub.Core.Model.Projects


### PR DESCRIPTION
🐛 Added using statement for ResourcePages so that they are resolved as components in FileExplorerPage.razor