### PR TITLE
Fixing login page translation

### DIFF
--- a/Portal/src/Datahub.Portal/i18n/ssc/registration.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/ssc/registration.fr.json
@@ -2,8 +2,8 @@
   "DataHub | Registration": "DataHub | Inscription",
   "Welcome to the Government of Canada's digital hub for science data solutions.": "Bienvenue au centre numérique du gouvernement du Canada pour les solutions de données scientifiques.",
   "Hosted by SSC (Proof-of-Concept Phase 2)": "Hebergé par le SPC (phase 2 de la validation du concept)",
-  "Register here to escape the silos. On the Federal Science DataHub you can:": "Inscrivez-vous ici pour échapper aux silos. Sur le Federal Science DataHub vous pouvez :",
-  "Federal Science DataHub": "Centre fédéral de données scientifiques",
+  "Register here to escape the silos. On the Federal Science DataHub you can:": "Inscrivez-vous ici pour échapper aux silos. Sur le Datahub scientifique fédéral vous pouvez :",
+  "Federal Science DataHub": "Datahub scientifique fédéral",
   "Access fit-for-purpose, scalable storage for GC science data": "Accédez à un stockage adapté et évolutif pour les données scientifiques du GC.",
   "Easily share your data with your GC colleagues": "Partagez facilement vos données avec vos collègues du GC.",
   "Perform analytics and collaborate with your GC science partners in an interactive environment": "Effectuez des analyses et collaborez avec vos partenaires scientifiques du GC dans un environnement interactif.",
@@ -14,11 +14,11 @@
   "Selected Government of Canada Department/Agency": "Ministère/organisme sélectionné du gouvernement du Canada",
   "Government of Canada Department/Agency is required.": "Un ministère/agence du gouvernement du Canada est requis.",
   "Agreement with the Terms and conditions is required": "L'accord avec les termes et conditions est requis",
-  "Register for the Federal Science DataHub": "Inscrivez-vous pour le Federal Science DataHub",
+  "Register for the Federal Science DataHub": "Inscrivez-vous pour le Datahub scientifique fédéral",
   "Register": "S'inscrire",
   "Registering": "Inscription en cours",
   "I agree to the ": "Je suis d'accord avec les ",
   " of use for the FSDH Proof-of-Concept Phase 2": " d'utilisation pour la phase 2 de la démonstration de concept de la DHSF",
   "Terms and conditions": "modalités et conditions",
-  "(Optional) How did you hear about the Federal Science DataHub?" : "(Optionnel) Comment avez-vous entendu parler du Federal Science DataHub?"
+  "(Optional) How did you hear about the Federal Science DataHub?": "(Optionnel) Comment avez-vous entendu parler du Datahub scientifique fédéral?"
 }


### PR DESCRIPTION
Fixes 3 mis-translated lines on the registration/login pages

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/38243e6f-3820-457a-9c89-9e3dcc8a530c)