### PR TITLE
Fix for error when trying to register a disabled account

### DIFF
--- a/Portal/src/Datahub.Functions/AzureConfig.cs
+++ b/Portal/src/Datahub.Functions/AzureConfig.cs
@@ -52,6 +52,7 @@ public class EmailNotification
     public string? SenderName { get; set; }
     public string? SenderAddress { get; set; }
     public string? NotificationsCCAddress { get; set; }
+    public string? AdminEmail { get; set; }
     public bool IsValid => !string.IsNullOrEmpty(SmtpHost) && 
                            !string.IsNullOrEmpty(SmtpUsername) && 
                            !string.IsNullOrEmpty(SmtpPassword) && 


### PR DESCRIPTION
Registering a disabled account will now fail the CreateGraphUser function run, with proper logging, and will notify us by email (datasolutions mailbox)

THIS REQUIRES A CHANGE TO `local.appsettings.json` IN `Datahub.Functions`!