### PR TITLE
:hammer: Fixing an error when loading the home page

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Home/WelcomeBanner.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/WelcomeBanner.razor
@@ -40,12 +40,19 @@ else
     protected override async Task OnInitializedAsync()
     {
         var portalUser = await _userInformationService.GetCurrentPortalUserAsync();
-        _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Home/WelcomeBanner.razor.js");
         _userBackgroundUrl = _datahubPortalConfiguration.Media.GetAchievementImageUrl(portalUser.BannerPictureUrl);
         _previews = await _announcementService.GetActivePreviews(_cultureService.IsFrench);
         _isLoading = false;
-        _greeting = await GetGreeting();
         StateHasChanged();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstrender)
+    {
+        if (firstrender)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Home/WelcomeBanner.razor.js");
+            _greeting = await GetGreeting();
+        }
     }
 
     private string GetBackground()


### PR DESCRIPTION
When loading the home page of DataHub, this error briefly appears before getting replaced with the actual page.

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/ffa1fe36-2f78-4dd0-ac2f-959c2aba7570)

I've moved the two uses of JSInterop into an OnAfterRenderAsync method, this resolves the issue.