### PR TITLE
:bug: Making Databricks open in new tab

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/DatabricksCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/DatabricksCard.razor
@@ -14,6 +14,7 @@
         <MudElement HtmlTag="div">
             <MudButton
                 Href="@GetDatabricksUrl()"
+                Target="_blank"
                 Color="Color.Primary"
                 Variant="@Variant.Text"
                 EndIcon="@Icons.Material.Outlined.OpenInNew">


### PR DESCRIPTION
Makes Databricks open in a new tab by adding `Target="_blank"` to the card.