### PR TITLE
Removing SSC email exclusion from "Copy to clipboard" button in Users tool

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Tools/Users/UsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Users/UsersPage.razor
@@ -45,8 +45,7 @@ else
         new string[]
         {
             "@gmail",
-            "@apption",
-            "@ssc-spc"
+            "@apption"
         });
 
     private List<UserWorkspaces> _userWorkspaces;


### PR DESCRIPTION
We now have ssc-spc users outside of our team and as such, that button should no longer exclude all ssc emails since it is used to send communications