### PR TITLE
📜 Reworded 'Reset alert settings' button and localization

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Account/PublicProfile/AccountPublicProfileSettings.razor
+++ b/Portal/src/Datahub.Portal/Pages/Account/PublicProfile/AccountPublicProfileSettings.razor
@@ -34,7 +34,7 @@
     </SettingsField>
     <SettingsField Label="@Localizer["Display page alerts and tutorials"]" Description="@Localizer["Choose whether or not to display alert and tutorial dialogs in Datahub."]">
         <MudSwitch T="bool" Label="@Localizer["Show alerts and tutorials"]" Checked="@(!ViewedUser.UserSettings.HideAlerts)" Color="Color.Primary" UnCheckedColor="Color.Dark" CheckedChanged="HandleHideAlertsChanged"/>
-        <MudButton OnClick="@ClearAlerts">@Localizer["Clear viewed alerts"]</MudButton>
+        <MudButton OnClick="@ClearAlerts">@Localizer["Reset alert settings"]</MudButton>
     </SettingsField>
 </MudStack>
 
@@ -45,8 +45,6 @@
 
     [Parameter]
     public EventCallback<PortalUser> OnViewedUserChanged { get; set; }
-
-    private string BackgroundUrl => _datahubPortalConfiguration?.Media.GetAchievementThumbnailUrl(ViewedUser?.BannerPictureUrl);
 
     private async Task HandleImageSelected(string code, bool isProfilePicture)
     {

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -1985,5 +1985,6 @@
   "Achievements": "Réalisations",
   "User information updated": "Informations utilisateur mises à jour",
   "Initializing Profile...": "Initialisation du profil...",
-  "Create Workspace": "Créer un espace de travail"
+  "Create Workspace": "Créer un espace de travail",
+  "Reset alert settings": "Réinitialiser les paramètres d'alerte"
 }

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1257,5 +1257,6 @@
   "Tool is being provisioned": "Tool is being provisioned",
   "Initializing Profile...": "Initializing Profile...",
   "Open Workspace": "Open Workspace",
-  "Create Workspace": "Create Workspace"
+  "Create Workspace": "Create Workspace",
+  "Reset alert settings": "Reset alert settings"
 }


### PR DESCRIPTION
A 'Reset alert settings' button has been added to the account public profile settings page. The corresponding text for this option, both in English and French, has been added to the localization files. Unrelated, unused code related to backgroundUrl is removed.