### PR TITLE
Refactor KeyVaultCoreService

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/Security/KeyVaultCoreService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Security/KeyVaultCoreService.cs
@@ -15,15 +15,13 @@ namespace Datahub.Infrastructure.Services.Security;
 
 public class KeyVaultCoreService : IKeyVaultService
 {
-    private IConfiguration _configuration;
     private DatahubPortalConfiguration _portalConfiguration;
     private ILogger<KeyVaultCoreService> _logger;
     private KeyVaultClient _keyVaultClient;
     private IOptions<APITarget> _targets;
 
-    public KeyVaultCoreService(IConfiguration configureOptions, IOptions<APITarget> targets, ILogger<KeyVaultCoreService> logger, DatahubPortalConfiguration portalConfiguration)
+    public KeyVaultCoreService(IOptions<APITarget> targets, ILogger<KeyVaultCoreService> logger, DatahubPortalConfiguration portalConfiguration)
     {
-        _configuration = configureOptions;
         _logger = logger;
         _portalConfiguration = portalConfiguration;
         _targets = targets;
@@ -88,8 +86,7 @@ public class KeyVaultCoreService : IKeyVaultService
 
     private void SetKeyVaultClient()
     {
-        if (_configuration["PortalRunAsManagedIdentity"]
-                 .Equals("enabled", StringComparison.InvariantCultureIgnoreCase))
+        if (_portalConfiguration.PortalRunAsManagedIdentity.Equals("enabled", StringComparison.InvariantCultureIgnoreCase))
         {
             _logger.LogInformation("Entering key vault production with Managed Identity");
             var azureServiceTokenProvider = new AzureServiceTokenProvider("RunAs=App");

--- a/Portal/src/Datahub.Infrastructure/Services/Security/KeyVaultCoreService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Security/KeyVaultCoreService.cs
@@ -88,19 +88,7 @@ public class KeyVaultCoreService : IKeyVaultService
 
     private void SetKeyVaultClient()
     {
-        _logger.LogInformation("Entering setting Key Vault");
-        if (_portalConfiguration.Hosting.EnvironmentName.Equals("dev", StringComparison.InvariantCultureIgnoreCase))
-        {
-            _logger.LogInformation("Entering key vault development");
-
-            var tenantId = _configuration["AzureAd:TenantId"];
-            var clientId = _configuration["AzureAd:ClientId"];
-            var clientSecret = _configuration["AzureAd:ClientSecret"];
-
-            var azureServiceTokenProvider = new AzureServiceTokenProvider($"RunAs=App;AppId={clientId};TenantId={tenantId};AppKey={clientSecret}");
-            _keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
-        }
-        else if (_configuration["PortalRunAsManagedIdentity"]
+        if (_configuration["PortalRunAsManagedIdentity"]
                  .Equals("enabled", StringComparison.InvariantCultureIgnoreCase))
         {
             _logger.LogInformation("Entering key vault production with Managed Identity");
@@ -109,10 +97,13 @@ public class KeyVaultCoreService : IKeyVaultService
         }
         else
         {
+            var tenantId = _portalConfiguration.AzureAd.TenantId;
+            var clientId = _portalConfiguration.AzureAd.ClientId;
+            var clientSecret = _portalConfiguration.AzureAd.ClientSecret;
+            
             _logger.LogInformation("Entering key vault production with default identity");
-            var azureServiceTokenProvider = new AzureServiceTokenProvider();
+            var azureServiceTokenProvider = new AzureServiceTokenProvider($"RunAs=App;AppId={clientId};TenantId={tenantId};AppKey={clientSecret}");
             _keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
-
         }
     }
 


### PR DESCRIPTION
Service now uses portal configuration credentials by default. No more hosting environment clauses, only managed identity.

Proper config binding will need to be added later.