### PR TITLE
Validation on email text fields in metadata

### DIFF
--- a/Portal/src/Datahub.Metadata/Model/FieldDefinition.cs
+++ b/Portal/src/Datahub.Metadata/Model/FieldDefinition.cs
@@ -39,6 +39,7 @@ public class FieldDefinition
     public string Description => CultureUtils.SelectCulture(English_DESC, French_DESC);
     public bool HasChoices => Choices?.Count > 0;
     public bool IsDateField => (Validators_TXT ?? "").Split(' ').Contains("isodate");
+    public bool IsEmailField => (Validators_TXT ?? "").Split(' ').Contains("email");
         
     public string GetChoiceTextValue(string choiceValue, bool english)
     {

--- a/Portal/src/Datahub.Portal.Metadata/Components/MetadataFieldEditor.razor
+++ b/Portal/src/Datahub.Portal.Metadata/Components/MetadataFieldEditor.razor
@@ -1,6 +1,7 @@
 ﻿@*MetadataFieldEditor.razor*@
 @using Datahub.Metadata.Model
 @using Microsoft.AspNetCore.Components
+@using System.Text.RegularExpressions
 
 <MudStack>
     @if (Preview)
@@ -55,7 +56,8 @@
                                   OnAdornmentClick=@HandleTranslateField
                                   RequiredError=@(FieldDefinition.Description ?? Localizer["Required"])
                                   Variant="Variant.Outlined"
-                                  Margin="Margin.Dense" />
+                                  Validation="@Validate()"
+                                  Margin="Margin.Dense"/>
                 }
             }
         }
@@ -245,6 +247,16 @@
         catch (Exception)
         {
         }
+    }
+
+    private string Validate()
+    {
+        if (FieldDefinition.IsEmailField)
+        {
+            return Regex.IsMatch(FieldValue.Value_TXT, @"^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$") ? null : Localizer["Invalid email address"];
+        }
+
+        return null;
     }
 
     private List<ChoiceSelectItem> GetChoices()


### PR DESCRIPTION
Added validation on email text fields in metadata. @yjmrobert do we need to run migrations/update when adding an extension to a model?

We will only need to edit the metadata database to insert "email" in the Validators_TXT column of the FieldDefinition table for row with FieldDefinitionId == 13 (the workspace lead email field definition)