### PR TITLE
Fixing visiting a user profile via search

### DIFF
--- a/Portal/src/Datahub.Portal/Layout/Topbar/SearchResultTab.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/SearchResultTab.razor
@@ -66,7 +66,7 @@
     private string GetLink(CatalogObject obj) => obj.ObjectType switch
     {
         CatalogObjectType.Workspace => $"/w/{obj.ObjectId}",
-        CatalogObjectType.User => $"/profile?u={obj.ObjectId.Base64Encode()}",
+        CatalogObjectType.User => $"/account?u={obj.ObjectId.Base64Encode()}",
         CatalogObjectType.Repository => obj.Location ?? "#",
         _ => "#"
     };

--- a/Portal/src/Datahub.Portal/Layout/Topbar/SearchResultTab.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/SearchResultTab.razor
@@ -65,8 +65,8 @@
 
     private string GetLink(CatalogObject obj) => obj.ObjectType switch
     {
-        CatalogObjectType.Workspace => $"/w/{obj.ObjectId}",
-        CatalogObjectType.User => $"/account?u={obj.ObjectId.Base64Encode()}",
+        CatalogObjectType.Workspace => $"/{PageRoutes.WorkspacePrefix}/{obj.ObjectId}",
+        CatalogObjectType.User => $"{PageRoutes.AccountDefault}?u={obj.ObjectId.Base64Encode()}",
         CatalogObjectType.Repository => obj.Location ?? "#",
         _ => "#"
     };


### PR DESCRIPTION
Updates the search box in the topbar to use `/account?u=` instead of `/profile?u=`, avoiding a 404 error.