### PR TITLE
Hotfix for creating workspaces with improper acronyms

### DIFF
--- a/Portal/src/Datahub.Portal/Views/Modals/CreateProjectDialog.razor
+++ b/Portal/src/Datahub.Portal/Views/Modals/CreateProjectDialog.razor
@@ -158,6 +158,8 @@
 
     private async Task CreateProject()
     {
+        _success = ValidateAcronym(_projectAcronym).Result is null; // Force validation - users can avoid otherwise by clicking the button while the field is selected.
+
         if (_success)
         {
             if (_isCreating)


### PR DESCRIPTION
Adds a forced validation if the create project button is clicked, avoiding the bypassing if a user has the "acronym" box selected with an invalid acronym.