### PR TITLE
🔧 Update workspace validation to always use latest version

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/RepositoryService.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/RepositoryService.cs
@@ -373,12 +373,18 @@ public class RepositoryService : IRepositoryService
 
     public async Task ValidateWorkspaceVersion(TerraformWorkspace terraformWorkspace)
     {
-        if (terraformWorkspace.Version == TerraformWorkspace.DefaultVersion)
-        {
-            var versions = await GetModuleVersions();
-            var latestVersion = versions.Max();
-            terraformWorkspace.Version = $"v{latestVersion!.ToString()}";
-        }
+        // Old behavior, to maintain existing versions
+        // if (terraformWorkspace.Version == TerraformWorkspace.DefaultVersion)
+        // {
+        //     var versions = await GetModuleVersions();
+        //     var latestVersion = versions.Max();
+        //     terraformWorkspace.Version = $"v{latestVersion!.ToString()}";
+        // }
+        
+        // new behavior to always update the version
+        var versions = await GetModuleVersions();
+        var latestVersion = versions.Max();
+        terraformWorkspace.Version = $"v{latestVersion!.ToString()}";
     }
 
     public async Task<RepositoryUpdateEvent> ExecuteResourceRun(TerraformTemplate template, TerraformWorkspace terraformWorkspace,


### PR DESCRIPTION
The previous behavior of the ValidateWorkspaceVersion method was to maintain the existing version if it was set to DefaultVersion. This has been modified so that it now always updates the Terraform workspace version to the latest version, regardless of the incoming version. This ensures that we're always using the most recent version.