### PR TITLE
:gem: Updating the announcement carousel to properly display images

### DIFF
--- a/Portal/src/Datahub.Core/Components/DHMarkdown.razor
+++ b/Portal/src/Datahub.Core/Components/DHMarkdown.razor
@@ -106,7 +106,6 @@
         var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import",
             "./_content/Datahub.Core/Components/DHMarkdown.razor.js");
         await module.InvokeVoidAsync("styleCodeblocks", _elementReference);
-        await module.InvokeVoidAsync("addStyleSheetRule", ".markdown-content .mud-typography { margin-bottom: 1em!important; margin-top: 1em!important; }");
     }
 
 }

--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -18,12 +18,22 @@
             @foreach (var preview in Previews)
             {
                 <MudCarouselItem Transition="Transition.Fade">
-                    <MudStack Class="px-12 py-4" Style="height: 100%">
-                        <DHMarkdown Content="@preview.Preview"/>
+                    @if (!preview.Preview.StartsWith("!["))
+                    {
+                        <MudStack Class="px-12 py-4" Style="height: 100%">
+                            <DHMarkdown Content="@preview.Preview"/>
+                            <MudButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
+                                @Localizer["Read more"]
+                            </MudButton>
+                        </MudStack>
+                    }
+					else
+					{
+						<DHMarkdown Content="@preview.Preview"/>
                         <MudButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
                             @Localizer["Read more"]
                         </MudButton>
-                    </MudStack>
+					}
                 </MudCarouselItem>
             }
         </MudCarousel>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorerPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorerPage.razor
@@ -30,7 +30,7 @@
 
 @if (!containersLoaded)
 {
-    <DHLoadingInitializer />
+    <DHLoadingInitializer/>
     return;
 }
 
@@ -44,14 +44,14 @@
                 @if (ShouldShowContainerDropdown)
                 {
                     <MudStack Style="border-bottom: 1px solid var(--mud-palette-lines-default);" Class="my-6">
-                        <MudStack Row Justify=@Justify.FlexStart AlignItems=@AlignItems.Center >
+                        <MudStack Row Justify=@Justify.FlexStart AlignItems=@AlignItems.Center>
                             <MudText Typo="Typo.h2">@Localizer["Current Container"]</MudText>
-                            <StorageContainerSelector 
-                                @bind-SelectedContainer=@SelectedContainer 
-                                CloudContainers=_cloudContainers 
-                                OnAddProviderClicked=@AddCloudStorageAccount 
+                            <StorageContainerSelector
+                                @bind-SelectedContainer=@SelectedContainer
+                                CloudContainers=_cloudContainers
+                                OnAddProviderClicked=@AddCloudStorageAccount
                                 OnEditProviderClicked=@EditCloudStorageAccount
-                                OnRemoveProviderClicked=@RemoveCloudStorageAccount />
+                                OnRemoveProviderClicked=@RemoveCloudStorageAccount/>
                         </MudStack>
                     </MudStack>
                 }
@@ -60,25 +60,31 @@
                     {
                         <MudTabs Elevation="0" @key="@SelectedContainer.Name">
                             <MudTabPanel Text="@(!MultiContainer ? SelectedContainer.Name : Localizer["File Explorer"])" Icon="fas fa-hdd">
-                                <FileExplorer ProjectId=@_projectId Container="@_selectedContainer" />
+                                <FileExplorer ProjectId=@_projectId Container="@_selectedContainer"/>
                             </MudTabPanel>
                             <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym">
                                 @if (SelectedContainer.StorageManager.AzCopyEnabled)
                                 {
                                     <MudTabPanel Text="@Localizer["AzCopy"]" Icon="fas fa-info-circle">
-                                        <AzCopy Container=@SelectedContainer />
+                                        <MudStack Class="py-6 px-2">
+                                            <AzCopy Container=@SelectedContainer/>
+                                        </MudStack>
                                     </MudTabPanel>
                                 }
                                 @if (SelectedContainer.StorageManager.DatabrickEnabled)
                                 {
                                     <MudTabPanel Text="@Localizer["Databricks Access"]" Icon="fas fa-info-circle">
-                                        <Databricks Container="@SelectedContainer" />
+                                        <MudStack Class="py-6 px-2">
+                                            <Databricks Container="@SelectedContainer"/>
+                                        </MudStack>
                                     </MudTabPanel>
                                 }
                                 @if (SelectedContainer.StorageManager.AzCopyEnabled)
                                 {
                                     <MudTabPanel Text="@Localizer["DataHub Uploader"]" Icon="fas fa-info-circle">
-                                        <UploaderCode Container=@SelectedContainer />
+                                        <MudStack Class="py-6 px-2">
+                                            <UploaderCode Container=@SelectedContainer/>
+                                        </MudStack>
                                     </MudTabPanel>
                                 }
                             </DatahubAuthView>
@@ -92,8 +98,7 @@
 
 @code {
 
-    [Parameter]
-    public string WorkspaceAcronym { get; set; }
+    [Parameter] public string WorkspaceAcronym { get; set; }
 
     private Datahub_Project _project;
     private int? _projectId;
@@ -111,7 +116,7 @@
 
         _user = await _userInformationService.GetCurrentGraphUserAsync();
         _isUserProjectAdmin = await _userInformationService.IsUserProjectAdmin(WorkspaceAcronym) ||
-            await _userInformationService.IsUserProjectWorkspaceLead(WorkspaceAcronym);
+                              await _userInformationService.IsUserProjectWorkspaceLead(WorkspaceAcronym);
 
         _project = await projectContext.Projects
             .Include(p => p.Users)
@@ -122,14 +127,19 @@
         _projectName = _project?.ProjectName;
         _projectId = _project?.Project_ID;
         containersLoaded = false;
-        try {
+        try
+        {
             await keyVaultUserService.Authenticate();
             await LoadContainersAsync();
             containersLoaded = true;
             StateHasChanged();
-        } catch (MicrosoftIdentityWebChallengeUserException e) {
+        }
+        catch (MicrosoftIdentityWebChallengeUserException e)
+        {
             _consentHandler.HandleException(e);
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             _logger.LogError(e, "Error loading cloud storage connection");
         }
     }
@@ -145,11 +155,11 @@
         var projectStorageManager = new AzureCloudStorageManager(accountName, accountKey);
         var containerNames = await projectStorageManager.GetContainersAsync();
 
-        _cloudContainers.AddRange(containerNames.Select(c => new CloudStorageContainer(accountName, c, CloudStorageProviderType.Azure, projectStorageManager)));        
+        _cloudContainers.AddRange(containerNames.Select(c => new CloudStorageContainer(accountName, c, CloudStorageProviderType.Azure, projectStorageManager)));
         var dbStorage = await GetCloudStorages();
         foreach (var stg in dbStorage.Where(s => s.Enabled || _isUserProjectAdmin))
         {
-            try 
+            try
             {
                 var storageManager = await _cloudStorageManagerFactory.CreateCloudStorageManager(WorkspaceAcronym, stg);
                 if (storageManager is null)
@@ -169,12 +179,11 @@
                     ctx.Attach(stg);
                     stg.Enabled = false;
                     await ctx.SaveChangesAsync();
-                } 
+                }
                 catch (Exception ex2)
                 {
-                    _logger.LogCritical(ex2, $"error disabling containers from {stg.Name} (ID:{stg.Id})");                    
+                    _logger.LogCritical(ex2, $"error disabling containers from {stg.Name} (ID:{stg.Id})");
                 }
-
             }
         }
 
@@ -183,14 +192,8 @@
 
     public CloudStorageContainer SelectedContainer
     {
-        get 
-        { 
-            return _selectedContainer; 
-        }
-        set 
-        { 
-            _selectedContainer = value; 
-        }
+        get { return _selectedContainer; }
+        set { _selectedContainer = value; }
     }
 
     private bool MultiContainer => _cloudContainers?.Count > 1;
@@ -231,12 +234,12 @@
 
         if (!result.Canceled)
         {
-            if (result.Data is (ProjectCloudStorage storageSettings,IDictionary<string, string> ConnectionData))
+            if (result.Data is (ProjectCloudStorage storageSettings, IDictionary<string, string> ConnectionData))
             {
                 await using var ctx = await _dbFactoryProject.CreateDbContextAsync();
 
                 storageSettings.ProjectId = _projectId.Value;
-                storageSettings.Provider = cloudStorageProvider.ToString();                
+                storageSettings.Provider = cloudStorageProvider.ToString();
 
                 ctx.ProjectCloudStorages.Add(storageSettings);
 
@@ -261,14 +264,14 @@
         if (cloudProvider is null)
         {
             return;
-        }        
+        }
 
         var result = await ShowCloudStorageDialog(pageCloudProvider.CloudStorageProvider, cloudProvider);
 
         if (!result.Canceled)
         {
-            if (result.Data is (ProjectCloudStorage storageSettings,IDictionary<string, string> ConnectionData))
-            {               
+            if (result.Data is (ProjectCloudStorage storageSettings, IDictionary<string, string> ConnectionData))
+            {
                 await keyVaultUserService.StoreAllSecrets(storageSettings, WorkspaceAcronym, ConnectionData);
                 await ctx.SaveChangesAsync();
                 await LoadContainersAsync();
@@ -318,4 +321,5 @@
             }
         }
     }
+
 }

--- a/Portal/test/Datahub.SpecflowTests/Features/NewsCarousel.feature
+++ b/Portal/test/Datahub.SpecflowTests/Features/NewsCarousel.feature
@@ -1,0 +1,10 @@
+Feature: News Carousel
+	The news carousel should display the latest news items from the news feed.
+
+
+Scenario: Show padding on the carousel when it does not start with an image
+	Given the news carousel is not starting with an image
+	When the carousel is displayed
+	Then the carousel should have padding on the x-axis
+	And the carousel should have padding on the y-axis
+	


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Currently, there is padding around all announcement previews to format the text nicely. We'd like to use images for our announcement previews sometimes, but this padding causes issues.

This PR corrects this issue by detecting if an image is being used and does not use padding if an image is used.

There is a minor change to all uses of DHMarkdown. Removed a small extra top/bottom padding that was being applied. No impact in carousel, news, or learn.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visual testing to check carousel and all uses of the DHMarkdown object in FSDH.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

### Before

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/83d74932-bc24-4b29-9224-df25e2696d06)

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/2e174954-fae9-45be-804f-98140ab7b293)

### After

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/779eba84-3b0f-49a5-a36a-4fe7483ae443)

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/316ad024-f4a1-4efb-9e13-e8bc5fdc8099)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Relevant tests have been updated or added.
- [ ] All new and existing tests passed.
- [ ] I have added or updated necessary documentation (if appropriate)
- [ ] If this PR requires a change to any configuration, there is a corresponding PR in the "infrastructure" repository.

<!-- Link to the "infrastructure" repository PR here -->
