### PR TITLE
🔧 Remove usage of deprecated model

### DIFF
--- a/Portal/src/Datahub.Functions/ProjectUsageNotifier.cs
+++ b/Portal/src/Datahub.Functions/ProjectUsageNotifier.cs
@@ -65,7 +65,7 @@ namespace Datahub.Functions
         {
             using var ctx = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-            // load from details from db
+            // load details from db
             var details = await GetProjectDetails(ctx, projectId, cancellationToken);
 
             if (details?.Credits is null)
@@ -99,7 +99,7 @@ namespace Datahub.Functions
 
                 await ctx.SaveChangesAsync(cancellationToken);
 
-                _logger.LogWarning("Notifiying {0}% comsumed for workspace {1}", notificationPerc, details.ProjectAcro);
+                _logger.LogWarning("Notifiying {0}% consumed for workspace {1}", notificationPerc, details.ProjectAcro);
             }
             catch (Exception ex)
             {
@@ -115,6 +115,7 @@ namespace Datahub.Functions
                 .Where(e => e.Project_ID == projectId)
                 .Include(e => e.Credits)
                 .Include(e => e.Users)
+                .ThenInclude(e => e.PortalUser)
                 .AsSingleQuery()
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -122,7 +123,7 @@ namespace Datahub.Functions
                 return default;
 
             var contacts = project.Users
-                .Select(u => u.User_Name)
+                .Select(u => u.PortalUser.Email)
                 .Where(_emailValidator.IsValidEmail)
                 .ToList();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Received 100% -> 75% -> 100% -> 75% cost usage notifs for DW1 on POC during daylight saving time, investigated the function logs and code and could not discern why. I would bet it's that theres a mismatch of timezones between two datetimes in the process and it caused something somewhere to calculate the budget differently (or incorrectly) 

Found a deprecated value used, which caused some emails to not be sent. Switched that over.


## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Not tested, minor fix

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
