### PR TITLE
Bugs 2003 and 2002: Missing App Service config was throwing. Removed

### DIFF
--- a/Portal/src/Datahub.Core/Utils/TerraformVariableExtraction.cs
+++ b/Portal/src/Datahub.Core/Utils/TerraformVariableExtraction.cs
@@ -60,15 +60,15 @@ public static class TerraformVariableExtraction
     /// </summary>
     /// <param name="project">The Datahub Project to find the app service config from</param>
     /// <returns>The AppServiceConfiguration object containing the configuration info of the app service</returns>
-    public static AppServiceConfiguration ExtractAppServiceConfiguration(Datahub_Project? project)
+    public static AppServiceConfiguration? ExtractAppServiceConfiguration(Datahub_Project? project)
     {
         var appServiceTemplateName = TerraformTemplate.GetTerraformServiceType(TerraformTemplate.AzureAppService);
         var appServiceResource = project?.Resources?.FirstOrDefault(r =>
             r.ResourceType == appServiceTemplateName);
         
-        if (appServiceResource == null)
-        {
-            throw new Exception("App service resource not found in the project");
+        if (appServiceResource == null) {
+            // TODO: Might be worth logging but this class seems to have all static functions and no logger.
+            return null;
         }
         
         return ExtractAppServiceConfiguration(appServiceResource);


### PR DESCRIPTION
App Service configuration was missing. But it need not have thown an error. Just returns null now.

## Description
Update made in ExtractAppServiceConfiguration

## How Has This Been Tested?
Verified locally in 2 scenarios - Sudo page and Create Workspace dialog. Both work now

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

## Checklist:
- [x ] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.
