### PR TITLE
🔨 Changing the ProjectUsageNotifier to BCC us only at 75/100% usage

### DIFF
--- a/Portal/src/Datahub.Functions/ProjectUsageNotifier.cs
+++ b/Portal/src/Datahub.Functions/ProjectUsageNotifier.cs
@@ -142,7 +142,11 @@ namespace Datahub.Functions
                 { "{perc}", perc.ToString() }
             };
 
-            List<string> bcc = new() { GetNotificationCCAddress() };
+            List<string> bcc = new();
+            if (perc > 70) // Only sends the notification to us for the 75% and 100% notifications
+            {
+                bcc.Add(GetNotificationCCAddress());
+            }
 
             return _emailService.BuildEmail("cost_alert.html", contacts, bcc, bodyArgs, subjectArgs);
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Currently, the ProjectUsageNotifier attempts to BCC us for all usage notifications (including 25%/50% reminders). This PR restricts it to only BCC us for the 75%/100% emails.

`_config.Email?.NotificationsCCAddress` should be updated to the Data Solutions mailbox.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Existing unit tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [x] Necessary and relevant documentation has been created or updated.
- [ ] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
