### PR TITLE
:bug: Updating the announcement service to order previews from newest to oldest

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/Announcements/AnnouncementService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Announcements/AnnouncementService.cs
@@ -84,6 +84,7 @@ public class AnnouncementService : IAnnouncementService
 
         var articles = await ctx.Announcements
             .Where(e => !e.ForceHidden && today > e.StartDateTime && (!e.EndDateTime.HasValue || today < e.EndDateTime.Value))
+            .OrderByDescending(e => e.StartDateTime)
             .Select(e => new AnnouncementPreview(e.Id, isFrench ? e.PreviewFr : e.PreviewEn))
             .ToListAsync();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->

Currently, there is no ordering for the announcement previews, causing them to appear oldest-newest.

This minor PR changes that behaviour to ensure newer announcements have better visibility than older ones.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Tested on the portal and validated with several announcements.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
