### PR TITLE
Updating the sample database R code to fix the quotations

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Database/WorkspaceDatabasePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Database/WorkspaceDatabasePage.razor
@@ -213,15 +213,15 @@ library(DBI)
 
 db <- '<database_name>'  #provide the name of your db
 
-host_db <- ‘<database_host>’ #i.e. # i.e. 'ec2-54-83-201-96.compute-1.amazonaws.com'  
+host_db <- '<database_host>' #i.e. # i.e. 'ec2-54-83-201-96.compute-1.amazonaws.com'
 
 db_port <- '<port>'  # or any other port specified by the DBA
 
-db_user <- ‘<username>’  
+db_user <- '<username>'
 
-db_password <- ‘<password>'
+db_password <- '<password>'
 
-con <- dbConnect(RPostgres::Postgres(), dbname = db, host=host_db, port=db_port, user=db_user, password=db_password)  
+con <- dbConnect(RPostgres::Postgres(), dbname = db, host=host_db, port=db_port, user=db_user, password=db_password)
 ```";
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->

The R sample code for the workspace database page randomly uses different types of quotation symbols (ex `‘’` instead of `''` - just trust me i promise they are different). This causes errors when trying to run the sample code.

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/3c5416f2-475d-48e1-a11b-d40642cbab37)

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visually validated on the workspace database page

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
