### PR TITLE
🐛 Handle null projectUser in ProjectUserManagementService

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/ProjectUserManagementService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/ProjectUserManagementService.cs
@@ -193,7 +193,7 @@ public class ProjectUserManagementService : IProjectUserManagementService
             }
            
             // If current user is not the user being added to the project
-            if (projectUser.PortalUserId != currentUser.Id)
+            if (projectUser?.PortalUserId != currentUser.Id)
             {
                 context.Attach(currentUser);
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Description
<!-- Please provide a brief description of the changes made in this pull request -->
A null exception was thrown whenever creating a new `Datahub_Project_User` role for a workspace, as opposed to modifying the state of an existing one.

To fix, in `ProjectUserManagementService`, the code has been modified to handle a scenario where `projectUser` might be null. This change prevents potential null reference exceptions when comparing the `PortalUserId` of a null `projectUser` with the Id of the current user.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Added existing removed user role, added brand new user role, modified a role.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [x] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
