### PR TITLE
Refactor Service Bus trigger and message parameters

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner_PyFunctions/function_app.py
+++ b/ResourceProvisioner/src/ResourceProvisioner_PyFunctions/function_app.py
@@ -38,10 +38,9 @@ def http_sync_workspace_users_function(req: func.HttpRequest) -> func.HttpRespon
     return func.HttpResponse("Successfully synchronized workspace users.")
 
 @app.function_name(name="SynchronizeWorkspaceUsersQueueTrigger")
-@app.service_bus_queue_trigger(arg_name="msg", queue_name="user-run-request", 
-                   connection="DatahubServiceBus__ConnectionString") # Queue Trigger
+@app.service_bus_queue_trigger(arg_name="msg", queue_name="user-run-request", connection="DatahubServiceBus") # Queue Trigger
 
-def queue_sync_workspace_users_function(msg: func.QueueMessage) -> None:
+def queue_sync_workspace_users_function(msg: func.ServiceBusMessage):
     """
     Synchronizes the users in the Databricks workspace with the users in the definition file.
 


### PR DESCRIPTION
The refactor aligns the function signature and trigger decorator for the `queue_sync_workspace_users_function`. It replaces the `func.QueueMessage` parameter with `func.ServiceBusMessage` and modifies the connection from `DatahubServiceBus__ConnectionString` to `DatahubServiceBus`. These changes allow for clearer code and better consistency with Azure service bus specifications.

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] PR is submitted to the correct branch `develop`.
- [ ] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [ ] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
