### PR TITLE
health check page UI fixes

### DIFF
--- a/Portal/src/Datahub.Core/Model/Health/InfrastructureHealthCheck.cs
+++ b/Portal/src/Datahub.Core/Model/Health/InfrastructureHealthCheck.cs
@@ -54,7 +54,9 @@ public enum InfrastructureHealthStatus
     Expired,
     Healthy,
     Degraded,
-    Unhealthy
+    Unhealthy,
+    Undefined,
+    NeedHealthCheckRun
 }
 
 /// <summary>

--- a/Portal/src/Datahub.Portal/Pages/Tools/Health/InfrastructureHealthPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Health/InfrastructureHealthPage.razor
@@ -9,6 +9,12 @@
 @inject IDialogService DialogService
 @inject ISendEndpointProvider _sendEndpointProvider;
 
+@if (isLoading)
+    {
+        <Spinner />
+    }
+else
+{
 <MudStack Spacing="6">
     <MudStack>
         <MudText Typo="Typo.h2">@Localizer["Infrastructure Health"]</MudText>
@@ -66,13 +72,13 @@
             <RowTemplate>
                 <MudTd>@context.Name</MudTd>
                 <MudTd>
-                    <MudChip Color="@GetColor(context.Status)" Size="Size.Small">
-                        @Localizer[context.Status.ToString()]
+                    <MudChip Color="@GetColor(context)" Size="Size.Small">
+                        @Localizer[GetStatusText(context)]
                     </MudChip>
                 </MudTd>
                 <MudTd>
-                    <MudChip Color="@GetColor(GetPoison(context).Status)" Size="Size.Small">
-                        @Localizer[GetPoison(context).Status.ToString()]
+                    <MudChip Color="@GetColor(GetPoison(context))" Size="Size.Small">
+                        @Localizer[GetStatusText(GetPoison(context))]
 					</MudChip>
                 </MudTd>
                 <MudTd>@context.HealthCheckTimeUtc</MudTd>
@@ -106,17 +112,21 @@
                     if (health == null)
                     {
                         <MudTd>
-							<MudChip Color="@GetColor(InfrastructureHealthStatus.Create)" Size="Size.Small" OnClick="@(() => CallFunction((InfrastructureHealthResourceType)resourceType, context.Key, "workspace"))">
-								@Localizer["Create"]
+							<MudChip Color="@GetColor(InfrastructureHealthStatus.Undefined)" Size="Size.Small" OnClick="@(() => CallFunction((InfrastructureHealthResourceType)resourceType, context.Key, "workspace"))">
+								@Localizer[InfrastructureHealthStatus.Undefined.ToString()]
 							</MudChip/>
                         </MudTd>
                     }
                     else
                     {
+                        var realStatus = GetRealStatus(health);
                         <MudTd>
-							<MudChip Color="@GetColor(health.Status)" Size="Size.Small" OnClick="@(() => CallFunction((InfrastructureHealthResourceType)resourceType, context.Key, "workspace"))">
-								@Localizer[health.Status.ToString()]
+                            <MudTooltip Delay="600" Text="@health.HealthCheckTimeUtc.ToString()">
+							<MudChip Color="@GetColor(realStatus)" 
+                                Size="Size.Small" OnClick="@(() => CallFunction((InfrastructureHealthResourceType)resourceType, context.Key, "workspace"))">
+								@Localizer[realStatus.ToString()]
 							</MudChip>
+                            </MudTooltip>
 						</MudTd>
                     }
                 }
@@ -124,6 +134,7 @@
         </MudTable>
     </MudStack>
 </MudStack>
+}
 
 @code {
 
@@ -148,10 +159,16 @@
         InfrastructureHealthResourceType.AzureWebApp,
     };
 
+    public bool isLoading { get; set; } = false;
 
-    protected override void OnInitialized()
+
+    protected override async Task OnInitializedAsync()
     {
         base.OnInitialized();
+
+        isLoading = true;
+
+        await Task.Delay(1);
 
         _projectDbContext = DbFactory.CreateDbContext();
 
@@ -207,6 +224,8 @@
                 .GroupBy(h => h.Name)
                 .Select(g => g.OrderByDescending(h => h.HealthCheckTimeUtc).FirstOrDefault())
                 .ToList();
+
+        isLoading = false;
     }
 
     private async Task CallFunction(InfrastructureHealthResourceType type, string name, string group)
@@ -257,6 +276,40 @@
 		return poison;
 	}
 
+    private static InfrastructureHealthStatus GetRealStatus(InfrastructureHealthCheck health)
+    {
+        var realStatus = health.Status; 
+        var timestamp = health.HealthCheckTimeUtc;
+        var now = DateTime.UtcNow;
+        if (health.Status == InfrastructureHealthStatus.Healthy)  
+        {
+            if (timestamp >= now.AddHours(-72)) 
+            {
+                realStatus = InfrastructureHealthStatus.Degraded; 
+            }
+            if (timestamp < now.AddHours(-72)) 
+            {
+                realStatus = InfrastructureHealthStatus.Unhealthy; 
+            }
+        }
+        if (health.Status == InfrastructureHealthStatus.Create)
+        {
+            realStatus = InfrastructureHealthStatus.NeedHealthCheckRun;
+        }
+        return realStatus;
+    }
+
+    private static string GetStatusText(InfrastructureHealthCheck health)
+    {
+        var realStatus = GetRealStatus(health);
+        return realStatus.ToString();
+    }
+
+    private static Color GetColor(InfrastructureHealthCheck health)
+    {
+        var realStatus = GetRealStatus(health);
+        return GetColor(realStatus);
+    }
     private static Color GetColor(InfrastructureHealthStatus status)
     {
         return status switch

--- a/Portal/src/Datahub.Portal/Pages/Tools/Health/InfrastructureHealthPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Health/InfrastructureHealthPage.razor
@@ -45,7 +45,7 @@ else
                         @Localizer[context.Status.ToString()]
                     </MudChip>
                 </MudTd>
-                <MudTd>@context.HealthCheckTimeUtc</MudTd>
+                <MudTd>@context.HealthCheckTimeUtc.ToLocalTime()</MudTd>
                 <MudTd>
                         <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" OnClick="@(() => CallFunction(context.ResourceType, context.Name, context.Group))">
 						@Localizer["Run"]
@@ -81,7 +81,7 @@ else
                         @Localizer[GetStatusText(GetPoison(context))]
 					</MudChip>
                 </MudTd>
-                <MudTd>@context.HealthCheckTimeUtc</MudTd>
+                <MudTd>@context.HealthCheckTimeUtc.ToLocalTime()</MudTd>
                     <MudTd>
                         <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" OnClick="@(() => CallFunction(context.ResourceType, context.Name, context.Group))">
                             @Localizer["Run"]
@@ -120,8 +120,9 @@ else
                     else
                     {
                         var realStatus = GetRealStatus(health);
+                        var realtTime = health.HealthCheckTimeUtc.ToLocalTime().ToString();
                         <MudTd>
-                            <MudTooltip Delay="600" Text="@health.HealthCheckTimeUtc.ToString()">
+                            <MudTooltip Delay="600" Text="@realtTime">
 							<MudChip Color="@GetColor(realStatus)" 
                                 Size="Size.Small" OnClick="@(() => CallFunction((InfrastructureHealthResourceType)resourceType, context.Key, "workspace"))">
 								@Localizer[realStatus.ToString()]

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -1549,6 +1549,7 @@
   "Navigating your workspace": "Naviguer dans votre espace de travail",
   "Navigation menu": "Menu de navigation",
   "Need a hand? We've got you covered.": "Besoin d'un coup de main? On s'occupe de vous.",
+  "NeedHealthCheckRun": "Démarrer l'évaluation",
   "Network": "Réseau",
   "New": "Nouveau",
   "New Achievement Unlocked!": "Nouveau trophée débloqué !",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -923,6 +923,7 @@
   "Navigating your workspace": "Navigating your workspace",
   "Navigation menu": "Navigation menu",
   "Need a hand? We\u0027ve got you covered.": "Need a hand? We\u0027ve got you covered.",
+  "NeedHealthCheckRun": "Run health check",
   "New": "New",
   "New Achievement Unlocked!": "New Achievement Unlocked!",
   "New Folder": "New Folder",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
- 2287: added health check label color-coded based on last health check date;
- 2288: updated language to "Run health check" button;
- 4532: date/time of last health check now displayed in local timezone.

Colors:
Green "Healthy": If latest health status is success and within last 24 hours
Yellow "Warning": If latest health status is older than 24 hours but within last 72 hours
Red "Unknown": If latest health status for resource does not exist and it should be there or latest health status is older than 72 hours

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [ ] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
