### PR TITLE
Hide automatically generated bug reports from the support page

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,21 @@
 # MIT License
 
-Copyright (c) Her Majesty the Queen in Right of Canada, as represented by the Minister of NRCan, 2020.
+Copyright (c) His Majesty the King in Right of Canada, as represented by Shared Services Canada, 2024.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+# Licence MIT
+
+Droit d’auteur (c) Sa Majesté le Roi du chef du Canada, représentée par Services partagés Canada, 2024.
+
+L'autorisation est par les présentes accordée, à titre gratuit, à toute personne obtenant une copie de ce logiciel et des fichiers de documentation associés (le "Logiciel"), d'utiliser le Logiciel sans restriction, y compris, sans limitation, les droits d'utilisation, de copie, de modification, de fusion, de publication, de distribution, de sous-licence et/ou de vente de copies du Logiciel, et d'autoriser les personnes à qui le Logiciel est fourni à le faire, sous réserve des conditions suivantes :
+
+L'avis de droit d'auteur ci-dessus et le présent avis d'autorisation doivent être inclus dans toutes les copies ou parties substantielles du Logiciel.
+
+LE LOGICIEL EST FOURNI "TEL QUEL", SANS GARANTIE D'AUCUNE SORTE, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS S'Y LIMITER, LES GARANTIES DE QUALITÉ MARCHANDE, D'ADÉQUATION À UN USAGE PARTICULIER ET DE NON-CONTREFAÇON. EN AUCUN CAS, LES AUTEURS OU LES DÉTENTEURS DE DROITS D'AUTEUR SA MAJESTÉ LA ROI DU CHEF DU CANADA, REPRÉSENTÉE PAR L'AGENCE SPATIALE CANADIENNE, NE PEUVENT ÊTRE TENUS RESPONSABLES DE TOUTE RÉCLAMATION, DOMMAGE OU AUTRE RESPONSABILITÉ, QUE CE SOIT DANS LE CADRE D'UNE ACTION CONTRACTUELLE, DÉLICTUELLE OU AUTRE, DÉCOULANT DU LOGICIEL OU DE L'UTILISATION OU D'AUTRES TRANSACTIONS DU LOGICIEL, OU EN RELATION AVEC CEUX-CI.

--- a/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
@@ -454,7 +454,12 @@
                 var workItemDetails = JObject.Parse(workItemJsonResponse);
 
                 // Add the issue to the list
-                _issuesList.Add(new IssueForDisplaying(workItemDetails, true));
+                var issue = new IssueForDisplaying(workItemDetails, true);
+
+                if (!issue.Title.Contains("Exception")) // No point in showing automated exceptions to the user
+                {
+                    _issuesList.Add(issue);
+                }
             }
         }
         _loading = false; // Stop showing the loading bar in the table.

--- a/Portal/src/Datahub.Portal/Pages/Tools/SupportRequests/SupportRequestPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/SupportRequests/SupportRequestPage.razor
@@ -124,11 +124,14 @@
                 var workItemDetails = JObject.Parse(workItemJsonResponse);
                 var issue = new IssueForDisplaying(workItemDetails, false);
 
-                if (issue.State == "Closed"){
-                    _closedIssues.Add(issue);
-                }
-                else {
-                    _openIssues.Add(issue);
+                if (!issue.Title.Contains("Exception")) // Filter out exceptions
+                {
+                    if (issue.State == "Closed"){
+                        _closedIssues.Add(issue);
+                    }
+                    else {
+                        _openIssues.Add(issue);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->

Currently, the support request and help pages display automatic reports since they are tied to a user. These pages should be focused on the manually user submitted issues.

![image](https://github.com/ssc-sp/datahub-portal/assets/55161042/3eee9bea-97a4-4aa4-a117-48c3988cb42c)

I also updated the license.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visual testing to confirm the issues are removed

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [x] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
