### PR TITLE
Updating icon accessibility

### DIFF
--- a/Portal/src/Datahub.Core/Components/DHSteps.razor
+++ b/Portal/src/Datahub.Core/Components/DHSteps.razor
@@ -20,7 +20,7 @@
                 }
                 else
                 {
-                    <MudIcon Icon=@dotAppearance.Icon Size=@Size.Large />
+                    <MudIcon aria-hidden="true" focusable="false" Icon=@dotAppearance.Icon Size=@Size.Large />
                 }
             </ItemDot>
 

--- a/Portal/src/Datahub.Core/Components/FACard.razor
+++ b/Portal/src/Datahub.Core/Components/FACard.razor
@@ -3,7 +3,7 @@
 <AeCard class="facard1">
     <ChildContent>
         <AeFlex>
-            <MudIcon Icon="@GetIconClass()" />
+            <MudIcon aria-hidden="true" focusable="false" Icon="@GetIconClass()" />
             <AeFlex Vertical>
 @if (NavLink is null)
 {
@@ -16,7 +16,7 @@ else
 @if (!(InfoLink is null))
 {
                 <AeTypography Variant="a" class="top-right" @onclick="@(() => NavigationManager.NavigateTo(InfoLink))">
-                    <MudIcon Icon="@Icon" />
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icon" />
                 </AeTypography>
 }
                 <AeTypography>@Text</AeTypography>

--- a/Portal/src/Datahub.Core/Components/Form/FormDataTable.razor
+++ b/Portal/src/Datahub.Core/Components/Form/FormDataTable.razor
@@ -49,7 +49,9 @@
         }
         @if (Metadata.AllowDelete)
         {
-            <MudTd @onclick="async () => await DeleteRow(RowContext)"><MudIcon Icon="@Icons.Material.Filled.DeleteOutline" Size="Size.Small" Style="cursor:pointer" /></MudTd>
+            <MudTd @onclick="async () => await DeleteRow(RowContext)">
+                <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.DeleteOutline" Size="Size.Small" Style="cursor:pointer" />
+            </MudTd>
         }
 
     </RowTemplate>

--- a/Portal/src/Datahub.Portal/Components/Dialogs/TrackerComments.razor
+++ b/Portal/src/Datahub.Portal/Components/Dialogs/TrackerComments.razor
@@ -8,7 +8,7 @@
 <MudDialog Style="overflow-y: scroll">
     <TitleContent>
         <MudText Typo="Typo.h6">
-            <MudIcon Icon="@Icons.Material.Filled.CommentBank" Class="mr-3 mb-n1" />
+            <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.CommentBank" Class="mr-3 mb-n1" />
            @Project.ProjectName - @Project.Project_Acronym_CD
         </MudText>
     </TitleContent>

--- a/Portal/src/Datahub.Portal/Components/PageAlerts/DHPageAlertDialog.razor
+++ b/Portal/src/Datahub.Portal/Components/PageAlerts/DHPageAlertDialog.razor
@@ -2,7 +2,7 @@
 <MudDialog Style="min-height: 80vh; max-height: 90vh" ContentStyle="height: 100%" aria-label="@Localizer["Welcome dialog"]">
     <TitleContent>
         <div class="d-flex gap-4">
-            <MudIcon Icon="@Icons.Material.Filled.Info" Color="Color.Primary"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Info" Color="Color.Primary"/>
             <MudText Typo="Typo.h4">@Localizer[Title]</MudText>
         </div>
     </TitleContent>

--- a/Portal/src/Datahub.Portal/Components/PageAlerts/NewUserAlert.razor
+++ b/Portal/src/Datahub.Portal/Components/PageAlerts/NewUserAlert.razor
@@ -2,7 +2,7 @@
     <BulletTemplate Context="selected">
         <div Class="mud-button-root mud-icon-button mud-icon-button-color-inherit mud-ripple mud-ripple-icon">
             <span class="mud-icon-button-label">
-                <MudIcon Icon="@(selected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Circle)" Color="@Color.Inherit"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@(selected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Circle)" Color="@Color.Inherit"/>
             </span>
         </div>
     </BulletTemplate>

--- a/Portal/src/Datahub.Portal/Components/PageAlerts/WorkspaceAlert.razor
+++ b/Portal/src/Datahub.Portal/Components/PageAlerts/WorkspaceAlert.razor
@@ -2,7 +2,7 @@
     <BulletTemplate Context="selected">
         <div Class="mud-button-root mud-icon-button mud-icon-button-color-inherit mud-ripple mud-ripple-icon">
             <span class="mud-icon-button-label">
-                <MudIcon Icon="@(selected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Circle)" Color="@Color.Inherit"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@(selected ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Circle)" Color="@Color.Inherit"/>
             </span>
         </div>
     </BulletTemplate>

--- a/Portal/src/Datahub.Portal/Components/Resources/ResourcesAdminView.razor
+++ b/Portal/src/Datahub.Portal/Components/Resources/ResourcesAdminView.razor
@@ -8,7 +8,7 @@
         <MudCard>
             <MudCardHeader>
                 <CardHeaderAvatar>
-                    <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.AdminPanelSettings"/>
                 </CardHeaderAvatar>
                 <CardHeaderContent>
                     @Localizer["Administration"]

--- a/Portal/src/Datahub.Portal/Components/Resources/ResourcesPreviewCard.razor
+++ b/Portal/src/Datahub.Portal/Components/Resources/ResourcesPreviewCard.razor
@@ -7,7 +7,21 @@
      <MudStack Justify="Justify.SpaceBetween" Style="height: 100%;">
          <MudStack>
              <MudStack Row AlignItems="AlignItems.Center">
-                 <MudIcon Icon="@(DocumentItem.GetSidebarIcon())" />
+                <MudIcon role="img" aria-labelledby="decimg01" Icon="@(DocumentItem.GetSidebarIcon())" />
+                <div class="sr-only" id="decimg01">
+                    @if (DocumentItem.DocType == DocItemType.External)
+                    {
+                        @Localizer["External"]
+                    }
+                    else if (DocumentItem.DocType == DocItemType.Tutorial)
+                    {
+                        @Localizer["Video"]
+                    }
+                    else
+                    {
+                        @Localizer["Document"]
+                    }
+                </div>
                  <MudText Typo="Typo.body1" Style="@_titleTextStyle">                     
                          @DocumentItem?.Title                    
                 </MudText>

--- a/Portal/src/Datahub.Portal/Layout/DHBreadcrumbs.razor
+++ b/Portal/src/Datahub.Portal/Layout/DHBreadcrumbs.razor
@@ -20,7 +20,7 @@
             <MudLink Href="@item.Href" Typo="Typo.body1">
                 @if (item.Icon != null)
                 {
-                    <MudIcon Icon="@item.Icon" Class="mr-2"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@item.Icon" Class="mr-2"/>
                 }
                 @item.Text
             </MudLink>
@@ -30,7 +30,7 @@
             <MudText Typo="Typo.body1">
                 @if (item.Icon != null)
                 {
-                    <MudIcon Icon="@item.Icon" Class="mr-2"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@item.Icon" Class="mr-2" />
                 }
                 @item.Text
             </MudText>

--- a/Portal/src/Datahub.Portal/Layout/LearnSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/LearnSidebar.razor
@@ -32,7 +32,7 @@
                                                  ToggledChanged="@ToggleNotificationsList"
                                                  Toggled="IsNotificationsListOpen"
                                                  Icon="@Icons.Material.Outlined.Notifications" /> *@
-                            <MudNavLink Match="NavLinkMatch.All" Href=@BuildResourceLink(cat) Icon="@(cat.GetSidebarIconFilled())">
+                            <MudNavLink Match="NavLinkMatch.All" Href=@BuildResourceLink(cat) Icon="@(cat.GetSidebarIcon())">
                                 @cat.Title
                             </MudNavLink>
                         }

--- a/Portal/src/Datahub.Portal/Layout/LearnSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/LearnSidebar.razor
@@ -2,13 +2,14 @@
 @using Datahub.Portal.Components.Resources
 
 @inject NavigationManager _navManager
-
+@* "@currentCategory.GetMudblazorMaterialIcon("Outlined")" *@
+@* @DocItemHelper.GetMudblazorMaterialIcon("Outlined", "LibraryBooks") *@
 @if (!PageIsLoading)
 {
     <MudStack Class="px-4 mt-6">
         <MudStack Class="ml-2">
             <MudStack Row="true" Spacing="3">
-                <MudIcon Icon="@currentCategory.GetMudblazorMaterialIcon("Outlined")"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@currentCategory.GetMudblazorMaterialIcon("Outlined")" />
                 <MudText Typo="Typo.h6">
                     @Localizer[currentCategory.Title.ToUpper()]
                 </MudText>
@@ -26,7 +27,12 @@
 
                         if (isDoc)
                         {
-                            <MudNavLink Match="NavLinkMatch.All" Href=@BuildResourceLink(cat) Icon="@(cat.GetSidebarIcon())">
+@*                             <MudToggleIconButton aria-label="Notifications toggle"
+                                                 ToggledIcon="@Icons.Material.Filled.Notifications"
+                                                 ToggledChanged="@ToggleNotificationsList"
+                                                 Toggled="IsNotificationsListOpen"
+                                                 Icon="@Icons.Material.Outlined.Notifications" /> *@
+                            <MudNavLink Match="NavLinkMatch.All" Href=@BuildResourceLink(cat) Icon="@(cat.GetSidebarIconFilled())">
                                 @cat.Title
                             </MudNavLink>
                         }
@@ -35,16 +41,30 @@
                             <MudNavGroup Title="@cat.Title" ExpandedChanged=@(isExpanding => UpdateCategory(cat, isExpanding)) Icon="@(cat.GetSidebarIcon())">
                                 @foreach (var article in cat.Children)
                                 {
-                                    if (article.DocType == DocItemType.External)
+                                    if(article.DocType == DocItemType.External)
                                     {
-                                        <MudNavLink Match="NavLinkMatch.All" Target="_blank" Href=@BuildResourceLink(article) Icon="@(article.GetSidebarIcon())">
-                                            @article.Title
+                                        <MudNavLink Match="NavLinkMatch.All" Target="_blank" Href=@BuildResourceLink(article)>
+                                            <MudStack Row AlignItems="AlignItems.Center">
+                                                <MudIcon role="img" aria-labelledby="decimg01" Icon="@(article.GetSidebarIcon())" Size="Size.Small" Color="Color.Dark" Class="mr-2 ml-n2" Style="font-size: 1.25rem;" />
+                                                <div class="sr-only" id="decimg01">@Localizer["External"]</div>
+                                                <MudText>
+                                                    @article.Title
+                                                </MudText>
+                                            </MudStack>
                                         </MudNavLink>
                                     }
                                     else
                                     {
-                                        <MudNavLink Match="NavLinkMatch.All" Href=@BuildResourceLink(article) Icon="@(article.GetSidebarIcon())">
-                                            @article.Title
+                                        <MudNavLink Match="NavLinkMatch.All" Href=@BuildResourceLink(article)>
+                                            <MudStack Row AlignItems="AlignItems.Center">
+                                                <MudIcon role="img" aria-labelledby="decimg01" Icon="@(article.GetSidebarIcon())" Size="Size.Small" Color="Color.Dark" Class="mr-2 ml-n2" Style="font-size: 1.25rem;" />
+                                                <div class="sr-only" id="decimg01">
+                                                    @((article.DocType == DocItemType.Tutorial) ? @Localizer["Video"] : @Localizer["Document"])
+                                                </div>
+                                                <MudText>
+                                                    @article.Title
+                                                </MudText>
+                                            </MudStack>
                                         </MudNavLink>
                                     }
                                 }

--- a/Portal/src/Datahub.Portal/Layout/PersonalSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/PersonalSidebar.razor
@@ -36,7 +36,7 @@
             @if (userRoles.Any())
             {
                 <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" OnClick="@ShowProjectDialog" Disabled="@_canNotCreateWorkspace">
-                    <MudIcon Icon="@SidebarIcons.CreateNew" Size="Size.Small" Class="mr-2" Style="font-size: 0.75rem;"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.CreateNew" Size="Size.Small" Class="mr-2" Style="font-size: 0.75rem;"/>
                     @Localizer["New"]
                 </MudButton>
             }
@@ -49,7 +49,7 @@
                 {
                     <MudNavLink Href="@($"/w/{userRole.Project.Project_Acronym_CD}")">
                         <MudStack Row AlignItems="AlignItems.Center">
-                            <MudIcon Icon="@SidebarIcons.Workspace" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" Color="Color.Dark"/>
+                            <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.Workspace" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" Color="Color.Dark"/>
                             <MudText Style="@_workspaceLinkStyle">
                                 @userRole.Project.ProjectName
                             </MudText>
@@ -67,7 +67,7 @@
         else
         {
             <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" Class="ml-2 mt-2 mb-4" OnClick="@ShowProjectDialog">
-                <MudIcon Icon="@SidebarIcons.CreateNew" Size="Size.Small" Color="Color.Dark" Class="mr-5" Style="font-size: 0.85rem;"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.CreateNew" Size="Size.Small" Color="Color.Dark" Class="mr-5" Style="font-size: 0.85rem;" />
                 @Localizer["Create new"]
                 <MudSpacer/>
             </MudButton>
@@ -85,7 +85,7 @@
             {
                 <MudNavLink Href="@GetSectionViewUrl(recentActivity)">
                     <MudStack Row AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@GetIcon(recentActivity)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" Color="Color.Dark"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@GetIcon(recentActivity)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" Color="Color.Dark"/>
                         <MudText Style="@_workspaceLinkStyle">
                             @GetLabel(recentActivity)
                         </MudText>
@@ -106,7 +106,7 @@
             {
                 <MudNavLink Href="@GetSectionViewUrl(PageRoutes.AccountPrefix, sectionView)" Match="NavLinkMatch.All">
                     <MudStack Row AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@GetIcon(sectionView)" Size="Size.Small" Color="Color.Dark" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@GetIcon(sectionView)" Size="Size.Small" Color="Color.Dark" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
                         <MudText Style="@_workspaceLinkStyle">
                             @GetLabel(sectionView)
                         </MudText>
@@ -127,7 +127,7 @@
                 {
                     <MudNavLink Href="@GetSectionViewUrl(PageRoutes.ToolPrefix, sectionView)" Match="NavLinkMatch.All">
                         <MudStack Row AlignItems="AlignItems.Center">
-                            <MudIcon Icon="@GetIcon(sectionView)" Size="Size.Small" Color="Color.Dark" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
+                            <MudIcon aria-hidden="true" focusable="false" Icon="@GetIcon(sectionView)" Size="Size.Small" Color="Color.Dark" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
                             <MudText Style="@_workspaceLinkStyle">
                                 @GetLabel(sectionView)
                             </MudText>

--- a/Portal/src/Datahub.Portal/Layout/Sidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/Sidebar.razor
@@ -23,7 +23,7 @@
             <NavLink class="mud-nav-link mud-ripple px-0 py-4 justify-center" style="@GetNavStyle(icon)" href="@href" Match="NavLinkMatch.Prefix" ActiveClass="active">
                 <MudBadge Dot=true Color="@Color.Primary" Visible="@(showDotBadge())">
                     <MudStack AlignItems="AlignItems.Center" Spacing="1">
-                        <MudIcon Icon="@icon.Name"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@icon.Name" />
                         <MudText Typo="Typo.body2" Style="@_navTextStyle">
                             @Localizer[label]
                         </MudText>
@@ -38,7 +38,7 @@
             <div class="mud-nav-item">
                 <NavLink class="mud-nav-link mud-ripple px-0 py-4 justify-center" href="@href" Match="NavLinkMatch.Prefix" ActiveClass="active">
                     <MudStack AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@icon.Name"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@icon.Name"/>
                         <MudText Typo="Typo.body2" Style="@_navTextStyle">
                             @Localizer[label]
                         </MudText>

--- a/Portal/src/Datahub.Portal/Layout/Topbar/SearchResultTab.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/SearchResultTab.razor
@@ -5,7 +5,7 @@
 @foreach (var result in Results)
 {
      <MudStack Row Class="mb-2">
-         <MudIcon Icon=@GetIcon(result)></MudIcon>
+         <MudIcon aria-hidden="true" focusable="false" Icon=@GetIcon(result)></MudIcon>
          <MudStack Spacing="0">
              <MudText Typo="Typo.h6" Color="Color.Success">
                 <MudLink Href=@GetLink(result) Underline="Underline.None" Target=@GetTarget(result) OnClick=@OnClickLink>

--- a/Portal/src/Datahub.Portal/Layout/Topbar/TopBarProfileButton.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/TopBarProfileButton.razor
@@ -18,7 +18,7 @@
         <ActivatorContent>
             <MudButton Class="ml-2">
                 <UserCard ViewedUserGraphId="@_viewedUser.GraphGuid" Size="@Size.Medium"/>
-                <MudIcon Icon="@Icons.Material.Filled.ArrowDropDown" Size="@Size.Medium"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.ArrowDropDown" Size="@Size.Medium"/>
             </MudButton>
         </ActivatorContent>
         <ChildContent>

--- a/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
@@ -41,7 +41,7 @@
                     <MudNavLink Href="@GetSectionViewUrl(toolSection)" Target="@GetTarget(toolSection)" Disabled="@IsDisabled(toolSection)">
                         <span @onclick="@(async () => await RegisterClickTelemetry(toolSection))">
                             <MudStack Row AlignItems="@AlignItems.Center">
-                                <MudIcon Icon="@GetIcon(toolSection)" Size="@Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
+                                <MudIcon aria-hidden="true" focusable="false" Icon="@GetIcon(toolSection)" Size="@Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
                                 <MudText Style="@_workspaceTitleStyle">
                                     @GetLabel(toolSection)
                                 </MudText>
@@ -69,7 +69,7 @@
                     <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym">
                         <MudNavLink Href="@GetSectionViewUrl(toolSection)" Target="@GetTarget(toolSection)" Match="NavLinkMatch.All">
                             <MudStack Row AlignItems="AlignItems.Center">
-                                <MudIcon Icon="@GetIcon(toolSection)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
+                                <MudIcon aria-hidden="true" focusable="false" Icon="@GetIcon(toolSection)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
                                 <MudText Style="@_workspaceTitleStyle">
                                     @GetLabel(toolSection)
                                 </MudText>

--- a/Portal/src/Datahub.Portal/Pages/Account/Achievements/AchievementToast.razor
+++ b/Portal/src/Datahub.Portal/Pages/Account/Achievements/AchievementToast.razor
@@ -2,7 +2,7 @@
 
 <MudStack>
     <MudStack Row>
-        <MudIcon Icon="@Icons.Material.Outlined.Celebration" Title="@Localizer["Achievement Unlocked"]" />
+        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.Celebration" Title="@Localizer["Achievement Unlocked"]" />
         <MudText Typo="Typo.body1">@Localizer["New Achievement Unlocked!"]</MudText>
     </MudStack>
     <AchievementCard Achievement="@Achievement"/>

--- a/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementEditor.razor
+++ b/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementEditor.razor
@@ -34,7 +34,7 @@
         <MudItem xs="4">
             <MudPaper Elevation="0" Outlined Class="px-6 py-4 sticky">
                 <MudStack Row AlignItems="AlignItems.Center" Class="mb-6">
-                    <MudIcon Icon="@Icons.Material.Outlined.CalendarMonth" Color="Color.Default"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.CalendarMonth" Color="Color.Default"/>
                     <MudText Typo="Typo.h2">@Localizer["Schedule"]</MudText>
                 </MudStack>
                 <MudDivider Class="my-4"/>
@@ -77,7 +77,7 @@
         <MudItem xs="8">
             <MudPaper Elevation="0" Outlined Class="px-6 py-4">
                 <MudStack Row AlignItems="AlignItems.Center" Class="mb-6">
-                    <MudIcon Icon="@Icons.Material.Outlined.Newspaper" Color="Color.Default"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.Newspaper" Color="Color.Default"/>
                     <MudText Typo="Typo.h2">@Localizer[_announcement.IsNew() ? "Create a new Announcement" : "Edit Announcement"]</MudText>
                 </MudStack>
 

--- a/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementsPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementsPage.razor
@@ -39,7 +39,7 @@
         else
         {
             <MudStack Justify="Justify.Center" AlignItems="AlignItems.Center">
-                <MudIcon Size="Size.Large" Class="mt-16 mb-4" Icon="@Icons.Material.Outlined.Deck"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.Deck" Size="Size.Large" Class="mt-16 mb-4"/>
                 <MudText Typo="Typo.h3">@Localizer["No announcements yet!"]</MudText>
             </MudStack>
         }

--- a/Portal/src/Datahub.Portal/Pages/Catalog/DiscoverySearchLanding.razor
+++ b/Portal/src/Datahub.Portal/Pages/Catalog/DiscoverySearchLanding.razor
@@ -23,7 +23,7 @@
 						<MudCard Class="d-flex align-center justify-center mud-width-full pa-8" style="height: 100%">
 							<MudGrid>
 								<MudItem sm="2">
-									<MudIcon Icon="@Icons.Material.Outlined.InsertDriveFile" Size="Size.Large" />
+									<MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.InsertDriveFile" Size="Size.Large" />
 								</MudItem>
 								<MudItem sm="8">
 									<MudText Typo="Typo.h6">@Localizer["Files"]</MudText>
@@ -35,7 +35,7 @@
 						<MudCard Class="d-flex align-center justify-center mud-width-full pa-8" style="height: 100%">
 							<MudGrid>
 								<MudItem sm="2">
-									<MudIcon Icon="@Icons.Material.Outlined.BarChart" Size="Size.Large" />
+									<MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.BarChart" Size="Size.Large" />
 								</MudItem>
 								<MudItem sm="8">
 									<MudText Typo="Typo.h6">@Localizer["Power BI Reports"]</MudText>
@@ -55,7 +55,7 @@
 							<MudCard Class="d-flex align-center justify-center mud-width-full pa-8" style="height: 100%">
 								<MudGrid>
 									<MudItem sm="2">
-										<MudIcon Icon=@GetSectorIconClass(sector.Id) Size="Size.Large" />
+										<MudIcon aria-hidden="true" focusable="false" Icon=@GetSectorIconClass(sector.Id) Size="Size.Large" />
 									</MudItem>
 									<MudItem sm="8">
 										<MudText Typo="Typo.h6">@(IsFrench ? sector.FrenchLabel : sector.EnglishLabel)</MudText>

--- a/Portal/src/Datahub.Portal/Pages/Explore/ProjectPreviewCardIconDetails.razor
+++ b/Portal/src/Datahub.Portal/Pages/Explore/ProjectPreviewCardIconDetails.razor
@@ -4,7 +4,7 @@
         <MudTooltip Text="@Localizer["Number of workspaces remaining"]" Arrow Placement="Placement.Top">
             <MudChip Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <MudIcon Icon="fa-light fa-layer-plus" Style="font-size: 0.75rem;" Color="Color.Dark"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-layer-plus" Style="font-size: 0.75rem;" Color="Color.Dark"/>
                     <div class="sr-only"><p>@Localizer["Number of workspaces remaining"]</p></div>
                     @NumberOfWorkspacesRemaining
                 </MudStack>
@@ -16,7 +16,7 @@
         <MudTooltip Text="@Localizer["Number of users in the workspace"]" Arrow Placement="Placement.Top">
             <MudChip Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <MudIcon Icon="fa-light fa-users" Style="font-size: 0.75rem;" Color="Color.Dark" />
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-users" Style="font-size: 0.75rem;" Color="Color.Dark" />
                     <div class="sr-only"><p>@Localizer["Number of users in the workspace"]</p></div>
                     @NumberOfUsers
                 </MudStack>
@@ -28,7 +28,7 @@
         <MudTooltip Text="@Localizer["Number of shared repositories"]" Arrow Placement="Placement.Top">
             <MudChip Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <MudIcon Icon="fa-light fa-code-branch" Style="font-size: 0.75rem;" Color="Color.Dark"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-code-branch" Style="font-size: 0.75rem;" Color="Color.Dark"/>
                     <div class="sr-only"><p>@Localizer["Number of shared repositories"]</p></div>
                     @NumberOfRepositories
                 </MudStack>
@@ -40,7 +40,7 @@
         <MudTooltip Text="@Localizer["Number of shared files"]" Arrow Placement="Placement.Top">
             <MudChip Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <MudIcon Icon="fa-light fa-files" Style="font-size: 0.75rem;" Color="Color.Dark"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-files" Style="font-size: 0.75rem;" Color="Color.Dark"/>
                     <div class="sr-only"><p>@Localizer["Number of shared files"]</p></div>
                     @NumberOfFiles
                 </MudStack>

--- a/Portal/src/Datahub.Portal/Pages/FormBuilder/ViewForm.razor
+++ b/Portal/src/Datahub.Portal/Pages/FormBuilder/ViewForm.razor
@@ -110,7 +110,7 @@
     {
         null,
         (f => @<a href=@($"/w/{f.WebForm.Project.Project_Acronym_CD}/forms/fields/{f.FieldID}")>@f.Field_DESC</a>),
-        (f => f.Mandatory_FLAG? @<MudIcon Icon="fas fa-asterisk" /> : @<span></span>
+        (f => f.Mandatory_FLAG? @<MudIcon aria-hidden="true" focusable="false" Icon="fas fa-asterisk" /> : @<span></span>
     ),
         null,
         null

--- a/Portal/src/Datahub.Portal/Pages/Project/DataProject/AzureWebAppCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Project/DataProject/AzureWebAppCard.razor
@@ -8,7 +8,7 @@
         <MudStack Justify="Justify.SpaceBetween">
             <MudStack>
                 <MudStack Row>
-                    <MudIcon Icon="fa-light fa-display-code" Color="Color.Secondary"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-display-code" Color="Color.Secondary"/>
                     <MudText Class="mb-3" Typo="Typo.h5">@Localizer["Web App Service"]</MudText>
                     <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.DatahubAdmin" ProjectAcronym="@ProjectAcronym">
                         <MudSpacer/>

--- a/Portal/src/Datahub.Portal/Pages/Project/DataProject/ProjectInfo.razor
+++ b/Portal/src/Datahub.Portal/Pages/Project/DataProject/ProjectInfo.razor
@@ -86,7 +86,7 @@
 
 <MudStack>
     <MudText Typo="Typo.h2">
-        <MudIcon Icon="@_projectIcon" Title="@Localizer["Project Icon"]"/>
+        <MudIcon aria-hidden="true" focusable="false" Icon="@_projectIcon" Title="@Localizer["Project Icon"]"/>
         @_project.ProjectName
     </MudText>
 

--- a/Portal/src/Datahub.Portal/Pages/Project/DataProject/ProjectTools/FormBuilder.razor
+++ b/Portal/src/Datahub.Portal/Pages/Project/DataProject/ProjectTools/FormBuilder.razor
@@ -8,7 +8,7 @@ else
         Title=@Localizer["Form Builder"]
         Description="@Localizer["Design custom data entry forms"]">
         <Logo>
-                <MudIcon Icon="fad fa-file-alt card-icon fa-xs"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="fad fa-file-alt card-icon fa-xs"/>
         </Logo>
         <ToolActionsList>
              <ul>

--- a/Portal/src/Datahub.Portal/Pages/Tools/Email/ComposeEmailPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Email/ComposeEmailPage.razor
@@ -23,21 +23,21 @@
             <MudSelect T="RecipientType" @bind-Value="_recipientType" Label="To:" Variant="Variant.Outlined">
                 <MudSelectItem Value="RecipientType.All">
                     <MudStack Row Spacing="3">
-                        <MudIcon Icon="@Icons.Material.Filled.People"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.People"/>
                         <MudText>@Localizer["Everybody"]</MudText>
                     </MudStack>
                 </MudSelectItem>
 
                 <MudSelectItem Value="RecipientType.Projects">
                     <MudStack Row Spacing="3">
-                        <MudIcon Icon="@Icons.Material.Filled.Groups"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Groups"/>
                         <MudText>@Localizer["Workspaces"]</MudText>
                     </MudStack>
                 </MudSelectItem>
 
                 <MudSelectItem Value="RecipientType.Addresses">
                     <MudStack Row Spacing="3">
-                        <MudIcon Icon="@Icons.Material.Filled.AlternateEmail"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.AlternateEmail"/>
                         <MudText>@Localizer["Emails"]</MudText>
                     </MudStack>
                 </MudSelectItem>

--- a/Portal/src/Datahub.Portal/Pages/Tools/Statistics/StatisticsPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Statistics/StatisticsPage.razor
@@ -81,21 +81,21 @@
             <MudTd DataLabel="Metadata">
                 @if (context.MetadataComplete)
                 {
-                    <MudIcon Icon="@Icons.Material.Filled.Check" Color="Color.Success"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Check" Color="Color.Success"/>
                 }
                 else
                 {
-                    <MudIcon Icon="@Icons.Material.Filled.WatchLater" Color="Color.Warning"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.WatchLater" Color="Color.Warning"/>
                 }
             </MudTd>
             <MudTd DataLabel="Storage">
                 @switch (context.StorageStatus)
                 {
                     case DatahubProjectStatsRow.ResourceStatus.Complete:
-                        <MudIcon Icon="@Icons.Material.Filled.Check" Color="@Color.Success"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Check" Color="@Color.Success"/>
                         break;
                     case DatahubProjectStatsRow.ResourceStatus.Requested:
-                        <MudIcon Icon="@Icons.Material.Filled.WatchLater" Color="@Color.Warning"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.WatchLater" Color="@Color.Warning"/>
                         break;
                     case DatahubProjectStatsRow.ResourceStatus.None:
                         break;
@@ -107,10 +107,10 @@
                 @switch (context.DatabricksStatus)
                 {
                     case DatahubProjectStatsRow.ResourceStatus.Complete:
-                        <MudIcon Icon="@Icons.Material.Filled.Check" Color="@Color.Success"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Check" Color="@Color.Success"/>
                         break;
                     case DatahubProjectStatsRow.ResourceStatus.Requested:
-                        <MudIcon Icon="@Icons.Material.Filled.WatchLater" Color="@Color.Warning"/>
+                        <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.WatchLater" Color="@Color.Warning"/>
                         break;
                     case DatahubProjectStatsRow.ResourceStatus.None:
                         break;

--- a/Portal/src/Datahub.Portal/Pages/Tools/Users/UsersTable.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Users/UsersTable.razor
@@ -41,10 +41,10 @@
             @switch(GetUserStatus(@context.User.Email))
             {
                 case "locked":
-                    <MudIcon Icon="@Icons.Material.Filled.Lock" Title=@Localizer["Account locked"]/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Lock" Title=@Localizer["Account locked"]/>
                     break;
                 case "missing":
-                    <MudIcon Icon="@Icons.Material.Filled.QuestionMark" Title=@Localizer["Account missing from MSGraph"]/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.QuestionMark" Title=@Localizer["Account missing from MSGraph"]/>
                     break;
                 case "":
                     break;                        

--- a/Portal/src/Datahub.Portal/Pages/Wiki.razor
+++ b/Portal/src/Datahub.Portal/Pages/Wiki.razor
@@ -50,7 +50,7 @@ else
                             <MudCard>
                                 <MudCardHeader>
                                     <CardHeaderAvatar>
-                                        <MudIcon Icon=@Icons.Material.Filled.MenuBook />
+                                        <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.MenuBook />
                                     </CardHeaderAvatar>
                                     <CardHeaderContent>
                                         <MudText Typo=@Typo.h5>@card.Title</MudText>
@@ -106,7 +106,7 @@ else
             <MudCard>
                 <MudCardHeader>
                     <CardHeaderAvatar>
-                        <MudIcon Icon=@Icons.Material.Filled.AdminPanelSettings />
+                        <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.AdminPanelSettings />
                     </CardHeaderAvatar>
                     <CardHeaderContent>
                         @Localizer["Administration"]

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/AppServiceCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/AppServiceCard.razor
@@ -3,7 +3,7 @@
 <MudPaper Outlined Class="pa-4">
     <MudStack>
         <MudStack Row AlignItems="AlignItems.Center">
-            <MudIcon Icon="@SidebarIcons.WebApp" Size="Size.Medium"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.WebApp" Size="Size.Medium"/>
             <MudText Typo="Typo.h3">@Localizer["Web Application"]</MudText>
             <MudSpacer/>
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/DatabricksCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/DatabricksCard.razor
@@ -3,7 +3,7 @@
 <MudPaper Outlined Class="pa-4">
     <MudStack>
         <MudStack Row AlignItems="AlignItems.Center">
-            <MudIcon Icon="@SvgIcons.Databricks" Size="Size.Medium"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@SvgIcons.Databricks" Size="Size.Medium"/>
             <MudText Typo="Typo.h3">@Localizer["Databricks Analytics"]</MudText>
             <MudSpacer/>
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/PostgreSQLCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/PostgreSQLCard.razor
@@ -4,7 +4,7 @@
 <MudPaper Outlined Class="pa-4">
     <MudStack>
         <MudStack Row AlignItems="AlignItems.Center">
-            <MudIcon Icon="@SidebarIcons.SqlDatabase" Size="Size.Medium"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.SqlDatabase" Size="Size.Medium"/>
             <MudText Typo="Typo.h3">@Localizer["Azure PostgreSQL Database"]</MudText>
         </MudStack>
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/StorageCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/StorageCard.razor
@@ -4,7 +4,7 @@
 <MudPaper Outlined Class="pa-4">
     <MudStack>
         <MudStack Row AlignItems="AlignItems.Center">
-            <MudIcon Icon="fa-light fa-hard-drive" Size="Size.Medium"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-hard-drive" Size="Size.Medium"/>
             <MudText Typo="Typo.h3">@Localizer["Workspace Storage"]</MudText>
         </MudStack>
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Publishing/PublishingFileControl.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Publishing/PublishingFileControl.razor
@@ -23,14 +23,14 @@
     else if (File.UploadStatus == OpenDataPublishFileUploadStatus.Completed)
     {
         <MudStack Row AlignItems=@AlignItems.Center>
-            <MudIcon Icon=@Icons.Material.Filled.Check Color=@Color.Success Size=@Size.Medium />
+            <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.Check Color=@Color.Success Size=@Size.Medium />
             <MudText>@Localizer["Upload complete"]</MudText>
         </MudStack>
     }
     else if (File.UploadStatus == OpenDataPublishFileUploadStatus.Failed)
     {
         <MudStack Row AlignItems=@AlignItems.Center>
-            <MudIcon Icon=@Icons.Material.Filled.Cancel Color=@Color.Error Size=@Size.Medium />
+            <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.Cancel Color=@Color.Error Size=@Size.Medium />
             <MudText>@Localizer["Upload failed"]</MudText>
             @* TODO: expand/popup to show error *@
         </MudStack>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Repositories/RepositoryCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Repositories/RepositoryCard.razor
@@ -13,13 +13,13 @@
                 <MudText Typo="Typo.caption">@RepositoryInfoDto.Path</MudText>
             }
             <MudStack Row AlignItems="AlignItems.Center">
-                <MudIcon Icon="@GetRepositoryIcon()" Size="Size.Small"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@GetRepositoryIcon()" Size="Size.Small"/>
                 <MudStack Row AlignItems="AlignItems.Center">
-                    <MudIcon Icon="fa-regular fa-code-branch" Style="@_smallIconStyle"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-regular fa-code-branch" Style="@_smallIconStyle"/>
                     <MudText Style="@_codeBlockStyle" Typo="Typo.caption">@RepositoryInfoDto.Branch</MudText>
                 </MudStack>
                 <MudStack Row AlignItems="AlignItems.Center">
-                    <MudIcon Icon="fa-regular fa-code-commit" Style="@_smallIconStyle"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="fa-regular fa-code-commit" Style="@_smallIconStyle"/>
                     <MudText Style="@_codeBlockStyle" Typo="Typo.caption">@RepositoryInfoDto.HeadCommitId[..8]</MudText>
                 </MudStack>
             </MudStack>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Repositories/RepositoryManagementPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Repositories/RepositoryManagementPage.razor
@@ -45,7 +45,7 @@
                     <MudItem xs="12" sm="8">
                         <MudPaper Elevation="0" Class="border-dashed py-12 px-4" Outlined>
                             <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center">
-                                <MudIcon Icon="@Icons.Material.Outlined.Cloud" Size="Size.Large"/>
+                                <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.Cloud" Size="Size.Large"/>
                                 <MudText Align="Align.Center">@Localizer["No linked repositories found in Databricks workspace"]</MudText>
                             </MudStack>
                         </MudPaper>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/Container/StorageContainerSelector.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/Container/StorageContainerSelector.razor
@@ -7,11 +7,11 @@
         <ActivatorContent>
             <MudButton>
                 <MudStack Row>
-                    <MudIcon Icon=@GetCloudProviderIcon(SelectedContainer) 
+                    <MudIcon aria-hidden="true" focusable="false" Icon=@GetCloudProviderIcon(SelectedContainer) 
                         ViewBox=@GetCloudProviderIconViewBox(SelectedContainer) 
                         Size=@Size.Large />
                     <MudText Typo=@Typo.h2>@Localizer[SelectedContainer.CloudStorageProvider.ToString()] - @SelectedContainer.AccountName - @SelectedContainer.ContainerName</MudText>
-                    <MudIcon Icon=@Icons.Material.Filled.ArrowDropDown Size=@Size.Large />
+                    <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.ArrowDropDown Size=@Size.Large />
                 </MudStack>
             </MudButton>
         </ActivatorContent>
@@ -22,10 +22,10 @@
                     <MudMenu ActivationEvent=@MouseEvent.MouseOver AnchorOrigin=@Origin.TopRight TransformOrigin=@Origin.TopLeft Style="display:block;" >
                         <ActivatorContent>
                             <MudStack Row>
-                                <MudIcon Icon=@GetCloudProviderIcon(accountContainer) ViewBox=@GetCloudProviderIconViewBox(accountContainer) />
+                                <MudIcon aria-hidden="true" focusable="false" Icon=@GetCloudProviderIcon(accountContainer) ViewBox=@GetCloudProviderIconViewBox(accountContainer) />
                                 <MudText>@Localizer[accountContainer.CloudStorageProvider.ToString()] - @accountContainer.AccountName</MudText>
                                 <MudSpacer />
-                                <MudIcon Icon=@Icons.Material.Filled.ChevronRight />
+                                <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.ChevronRight />
                             </MudStack>
                         </ActivatorContent>
                         <ChildContent>
@@ -52,13 +52,13 @@
                                     <MudDivider />
                                     <MudMenuItem OnClick=@(() => EditProviderAccount(accountContainer))>
                                         <MudStack Row>
-                                            <MudIcon Icon=@Icons.Material.Filled.Edit />
+                                            <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.Edit />
                                             <MudText>@Localizer["Edit"]</MudText>
                                         </MudStack>
                                     </MudMenuItem>
                                     <MudMenuItem OnClick=@(() => RemoveProviderAccount(accountContainer))>
                                         <MudStack Row>
-                                            <MudIcon Icon=@Icons.Material.Filled.Delete Color=@Color.Error />
+                                            <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.Delete Color=@Color.Error />
                                             <MudText>@Localizer["Remove"]</MudText>
                                         </MudStack>
                                     </MudMenuItem>
@@ -76,7 +76,7 @@
                             <MudStack Row>
                                 <MudText>@Localizer["Add Account"]</MudText>
                                 <MudSpacer />
-                                <MudIcon Icon=@Icons.Material.Filled.ChevronRight />
+                                <MudIcon aria-hidden="true" focusable="false" Icon=@Icons.Material.Filled.ChevronRight />
                             </MudStack>
                         </ActivatorContent>
                         <ChildContent>
@@ -84,7 +84,7 @@
                             {
                                 <MudMenuItem OnClick=@(() => AddNewProviderAccount(cloudProviderType))>
                                     <MudStack Row>
-                                        <MudIcon Icon=@GetCloudProviderIconByType(cloudProviderType) ViewBox=@GetCloudProviderIconViewBox(cloudProviderType) />
+                                        <MudIcon aria-hidden="true" focusable="false" Icon=@GetCloudProviderIconByType(cloudProviderType) ViewBox=@GetCloudProviderIconViewBox(cloudProviderType) />
                                         <MudText>@Localizer[cloudProviderType.ToString()]</MudText>
                                     </MudStack>
                                 </MudMenuItem>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Sudo/WorkspaceSudoPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Sudo/WorkspaceSudoPage.razor
@@ -62,7 +62,7 @@
                         <MudPaper Outlined Class="pt-4 px-6 pb-6">
                             <MudStack Style="height: 150px;">
                                 <MudStack Row AlignItems="AlignItems.Center">
-                                    <MudIcon Icon="@SidebarIcons.Api" Class="mr-2" />
+                                    <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.Api" Class="mr-2" />
                                     <MudText Typo="Typo.h3">
                                         @Localizer["Databricks Admin"]
                                     </MudText>
@@ -75,7 +75,7 @@
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary"
                                                OnClick="@(async () => await AddToDatabricksAdmins())">
                                         @Localizer["Databricks Admin"]
-                                        <MudIcon Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;" />
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;" />
                                     </MudButton>
                                 </MudStack>
                             </MudStack>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
@@ -39,7 +39,7 @@
                 <MudPaper Outlined Class="pt-4 px-6 pb-6">
                     <MudStack Style="height: 280px;">
                         <MudStack Row AlignItems="AlignItems.Center">
-                            <MudIcon Icon="@GetIcon(tool)" Class="mr-2"/>
+                            <MudIcon aria-hidden="true" focusable="false" Icon="@GetIcon(tool)" Class="mr-2"/>
                             <MudText Typo="Typo.h3">
                                 @GetLabel(tool)
                             </MudText>
@@ -54,7 +54,7 @@
                                 case ToolStatus.Available:
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary" OnClick="@(async () => await AddToolToWorkspace(tool))">
                                         @Localizer["Add to Workspace"]
-                                        <MudIcon Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;"/>
                                     </MudButton>
                                     break;
                                 case ToolStatus.SendingRequest:
@@ -68,31 +68,31 @@
                                 case ToolStatus.Exists:
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary" Disabled>
                                         @Localizer["Tool has been created"]
-                                        <MudIcon Icon="fa-light fa-check-to-slot" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-check-to-slot" Class="ml-2" Style="font-size: 0.8rem;"/>
                                     </MudButton>
                                     break;
                                 case ToolStatus.Disabled:
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary" Disabled>
                                         @Localizer["Not Enabled"]
-                                        <MudIcon Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;"/>
                                     </MudButton>
                                     break;
                                 case ToolStatus.UnderDevelopment:
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary" Disabled>
                                         @Localizer["Under Development"]
-                                        <MudIcon Icon="fa-light fa-space-station-moon-construction" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-space-station-moon-construction" Class="ml-2" Style="font-size: 0.8rem;"/>
                                     </MudButton>
                                     break;
                                 case ToolStatus.MetadataRequired:
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary" Disabled>
                                         @Localizer["Metadata Required"]
-                                        <MudIcon Icon="@SidebarIcons.Metadata" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.Metadata" Class="ml-2" Style="font-size: 0.8rem;"/>
                                     </MudButton>
                                     break;
                                 default:
                                     <MudButton Variant="@Variant.Filled" Color="@Color.Primary" Disabled>
                                         @Localizer["Unknown"]
-                                        <MudIcon Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-layer-plus" Class="ml-2" Style="font-size: 0.8rem;"/>
                                     </MudButton>
                                     break;
                             }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/AddNewUsersToProjectDialog.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/AddNewUsersToProjectDialog.razor
@@ -35,7 +35,7 @@
                         <MudText Typo="Typo.h6">@user?.DisplayName</MudText>
                         <MudText Typo="Typo.h6">@user?.Mail</MudText>
                     </MudStack>
-                    <MudIcon Icon="@AddUserIcon" Color="Color.Primary" Class="px-2"/>
+                    <MudIcon aria-hidden="true" focusable="false" Icon="@AddUserIcon" Color="Color.Primary" Class="px-2"/>
                 </MudStack>
             </ItemTemplate>
         </MudAutocomplete>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/ProjectMembersRoleSelect.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/ProjectMembersRoleSelect.razor
@@ -8,7 +8,7 @@
     <ActivatorContent>
         <MudStack Row AlignItems="AlignItems.Center" Style="@_outlineStyle" Class="py-2 px-4">
             <MudText Typo="Typo.body1">@Localizer[_currentRole?.Name ?? string.Empty]</MudText>
-            <MudIcon Icon="@Icons.Material.Filled.ArrowDropDown"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.ArrowDropDown"/>
         </MudStack>
     </ActivatorContent>
     <ChildContent>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
@@ -54,7 +54,7 @@
                                         @if (userToBeAdded.GraphGuid == ProjectUserAddUserCommand.NEW_USER_GUID)
                                         {
                                             <MudAvatar>
-                                                <MudIcon Icon="@Icons.Material.Outlined.PersonAdd"/>
+                                                <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Outlined.PersonAdd"/>
                                             </MudAvatar>
                                         }
                                         else

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppPage.razor
@@ -27,7 +27,7 @@
         @if (_isConfigured)
         {
             <MudStack AlignItems="AlignItems.End" Justify="Justify.Center">
-                <MudIcon Icon="@SidebarIcons.Circle" Color="@(_webAppState ? Color.Success : Color.Error)" Title="@(_webAppState ? Localizer["Running"] : Localizer["Stopped"])"/>
+                <MudIcon aria-hidden="true" focusable="false" Icon="@SidebarIcons.Circle" Color="@(_webAppState ? Color.Success : Color.Error)" Title="@(_webAppState ? Localizer["Running"] : Localizer["Stopped"])"/>
             </MudStack>
         }
         <MudSpacer/>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WorkspaceInfo.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WorkspaceInfo.razor
@@ -8,7 +8,7 @@
 
 <MudStack>
     <MudText Typo="Typo.h2">
-        <MudIcon Icon="fa-light fa-flask-vial" Title="@Localizer["Workspace Icon"]" Size="Size.Large" Class="mr-2"/>
+        <MudIcon aria-hidden="true" focusable="false" Icon="fa-light fa-flask-vial" Title="@Localizer["Workspace Icon"]" Size="Size.Large" Class="mr-2"/>
         @_project?.ProjectName
     </MudText>
     <DHMarkdown class="description" Content="@_projectDescription"/>

--- a/Portal/src/Datahub.Portal/Views/Dialogs/AzureAppServiceConfigurationDialog.razor
+++ b/Portal/src/Datahub.Portal/Views/Dialogs/AzureAppServiceConfigurationDialog.razor
@@ -43,7 +43,7 @@
                 <MudExpansionPanel IsInitiallyExpanded="false">
                     <TitleContent>
                         <MudStack Row="true">
-                            <MudIcon Icon=@SidebarIcons.Brackets/>
+                            <MudIcon aria-hidden="true" focusable="false" Icon=@SidebarIcons.Brackets/>
                             <MudText>
                                 @Localizer["Environment variables"]
                             </MudText>

--- a/Portal/src/Datahub.Portal/Views/Dialogs/UserSelectLanguageDialog.razor
+++ b/Portal/src/Datahub.Portal/Views/Dialogs/UserSelectLanguageDialog.razor
@@ -1,7 +1,7 @@
 <MudDialog Class="pa-6" Style="min-width:600px;">
     <TitleContent>
         <MudText Typo="Typo.h6">
-            <MudIcon Icon="@Icons.Material.Filled.Language" Class="mr-3 mb-n1"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Language" Class="mr-3 mb-n1"/>
             Language Select / Sélection de la langue
         </MudText>
     </TitleContent>

--- a/Portal/src/Datahub.Portal/Views/Dialogs/UserTermsAndConditionsDialog.razor
+++ b/Portal/src/Datahub.Portal/Views/Dialogs/UserTermsAndConditionsDialog.razor
@@ -1,7 +1,7 @@
 <MudDialog Class="pa-6" Style="min-width:600px;">
     <TitleContent>
         <MudText Typo="Typo.h6">
-            <MudIcon Icon="@Icons.Material.Filled.Newspaper" Class="mr-3 mb-n1"/>
+            <MudIcon aria-hidden="true" focusable="false" Icon="@Icons.Material.Filled.Newspaper" Class="mr-3 mb-n1"/>
             @Localizer["Terms and Conditions"]
         </MudText>
     </TitleContent>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Adding <<aria-hidden="true" focusable="false">> to icons and << role="img" aria-labelledby="decimg01">> to the Learn Page icons that describe the article types (document vs. video vs. external link).

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Tested visually by removing styling and checking if text appears.

![image](https://github.com/ssc-sp/datahub-portal/assets/67435074/da4bf9e4-3820-4f6e-8011-e3761619065e)
![image](https://github.com/ssc-sp/datahub-portal/assets/67435074/75159106-f65b-45ab-89f4-55f412f135b0)
![image](https://github.com/ssc-sp/datahub-portal/assets/67435074/39a62bee-bfbe-47c5-8e9b-72d6aae8cbe9)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] PR is submitted to the correct branch `develop`.
- [X] Code follows the code style of this project.
- [X] Changes are covered by Specflow tests and all new or existing tests are passing.
- [X] Any new or updated translatable strings have been added to the localization files.
- [X] Necessary and relevant documentation has been created or updated.
- [X] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
