### PR TITLE
Add timestamps for storage and cost reports

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
@@ -31,6 +31,20 @@
     @if (_currentServiceCosts?.Count > 0)
     {
         <MudText Typo="Typo.h3">@Localizer["Cost Analysis"]</MudText>
+        @if (_lastUpdateValid)
+        {
+            <MudText Style="font-style: italic">
+                @Localizer["Last updated {0} {1}",$"{ConvertToLocalTime(_projectCredits.LastUpdate!.Value):yyyy-MM-dd HH:mm}", TimeZone.CurrentTimeZone.StandardName]
+            </MudText>
+        }
+
+        @if (!_validData)
+        {
+            <MudAlert Variant="Variant.Outlined" Severity="Severity.Error" Style="color: #000">
+                @Localizer["Costing data is older than 7 days and may be incorrect, please check back later."]
+            </MudAlert>
+        }
+
         <MudStack Row>
             <MudChip Label="true"
                      Icon="@Icons.Material.Filled.AttachMoney"
@@ -64,7 +78,7 @@
 
     @if (_currentDailyCosts?.Count > 1 && _currentDailyCosts.Any(c => c.Amount > 0))
     {
-        <MudDivider Class="my-6" />
+        <MudDivider Class="my-6"/>
         <MudText Typo="Typo.h3">@Localizer["Daily cost (over last 30 days)"]</MudText>
         <div>
             <MudChart ChartType="ChartType.Bar"
@@ -77,7 +91,7 @@
 
     @if (_remainingBudget > 0 && _spendingEstimation != null)
     {
-        <MudDivider Class="my-6" />
+        <MudDivider Class="my-6"/>
         <MudStack>
             <MudText Typo="Typo.h3">@Localizer["Daily cost (over last 30 days)"]</MudText>
             <MudStack>
@@ -115,8 +129,7 @@
 
 @code {
 
-    [Parameter]
-    public string WorkspaceAcronym { get; set; }
+    [Parameter] public string WorkspaceAcronym { get; set; }
 
     public decimal _projectBudget { get; set; }
     private Project_Credits _projectCredits { get; set; }
@@ -129,6 +142,8 @@
     private decimal YesterdayCost => Convert.ToDecimal(_projectCredits.YesterdayCredits);
 
     private bool _showingTotal = true;
+    private bool _lastUpdateValid => _projectCredits is not null && _projectCredits.LastUpdate is not null;
+    private bool _validData => _lastUpdateValid && _projectCredits.LastUpdate >= DateTime.UtcNow.AddDays(-7);
     private string SelectedTotalLabel => _showingTotal ? Localizer["Total"] : Localizer["Yesterday"];
     private decimal SelectedTotalCost => _showingTotal ? CurrentCost : YesterdayCost;
     private MudBlazor.Color MonthChipColor => _showingTotal ? MudBlazor.Color.Primary : MudBlazor.Color.Default;
@@ -189,14 +204,14 @@
 
     private async Task<SpendingEstimation> GetSpendingEstimations(decimal amount)
     {
-    // storage
+        // storage
         var storageCostGrid = await _azurePriceListService.GetAzureStoragePriceLists();
 
         var searchKey = IAzurePriceListService.GenerateAzureStoragePriceListKey(AccessTierType.Hot, DataRedundancyType.LRS);
         var priceList = storageCostGrid.PriceLists[searchKey];
         var storage = decimal.ToDouble(amount / priceList.Capacity.BasePrice);
 
-    // compute
+        // compute
         var compCostGrid = await _azurePriceListService.GetAzureComputeCostPrices();
 
         var smPerHour = CalculateComputeCost(5, compCostGrid.Ds3VmPrice, compCostGrid.DbuPrice, 0.75M, 1);
@@ -291,9 +306,16 @@
         return true;
     }
 
+    private DateTime ConvertToLocalTime(DateTime UTCTime)
+    {
+        TimeZone localZone = TimeZone.CurrentTimeZone;
+        return localZone.ToLocalTime(UTCTime);
+    }
+
     private void HandleShowMonth() => _showingTotal = true;
     private void HandleShowYesterday() => _showingTotal = false;
 
     record SpendingEstimation(double Storage, double ComputeSmall, double ComputeMedium, double ComputeLarge);
 
 }
+

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
@@ -40,8 +40,8 @@
 
         @if (!_validData)
         {
-            <MudAlert Variant="Variant.Outlined" Severity="Severity.Error" Style="color: #000">
-                @Localizer["Costing data is older than 7 days and may be incorrect, please check back later."]
+            <MudAlert Variant="Variant.Outlined" Severity="Severity.Warning" Style="color: #000">
+                @Localizer["Costing data has not been updated in the last 7 days, please check back later for updated costs."]
             </MudAlert>
         }
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceReports.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceReports.razor
@@ -1,12 +1,12 @@
 <MudStack>
     <MudText Typo="Typo.h2">@Localizer["Workspace Reports"]</MudText>
-    
-    <WorkspaceCostingReport WorkspaceAcronym="@WorkspaceAcronym" />
-    <WorkspaceStorageReport WorkspaceAcronym="@WorkspaceAcronym" />
+
+    <WorkspaceCostingReport WorkspaceAcronym="@WorkspaceAcronym"/>
+    <MudDivider Class="my-6"/>
+    <WorkspaceStorageReport WorkspaceAcronym="@WorkspaceAcronym"/>
 </MudStack>
 
 @code {
-    [Parameter]
-    public string WorkspaceAcronym { get; set; }
-    
+    [Parameter] public string WorkspaceAcronym { get; set; }
+
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceStorageReport.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceStorageReport.razor
@@ -6,21 +6,32 @@
 
 @if (_averages != null)
 {
-    <MudDivider Class="my-6" />
     <MudText Typo="Typo.h3">@Localizer["Storage daily average (over last 30 days)"]</MudText>
+    @if (_lastUpdate != default)
+    {
+        <MudText Style="font-style: italic">@Localizer["Last updated {0} {1}", $"{_lastUpdate:yyyy-MM-dd HH:mm}", TimeZone.CurrentTimeZone.StandardName]</MudText>
+        @if (_lastUpdate < DateTime.UtcNow.AddDays(-7))
+        {
+            <MudAlert Variant="Variant.Outlined" Severity="Severity.Error" Style="color: #000">
+                @Localizer["Storage data is older than 7 days and may be incorrect, please check back later."]
+            </MudAlert>
+        }
+    }
+
     <div>
         <MudChart ChartType="ChartType.Bar"
                   ChartSeries="@DailySeries"
                   XAxisLabels="@XAxisDailyLabels"
                   Width="100%"
-                  Height="350px" />
+                  Height="350px"/>
     </div>
 }
 
 @code {
 
-    [Parameter]
-    public string WorkspaceAcronym { get; set; }
+    [Parameter] public string WorkspaceAcronym { get; set; }
+
+    private DateTime _lastUpdate { get; set; }
 
     private List<DayAverage> _averages = default;
 
@@ -34,7 +45,7 @@
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        _averages = await GetLast30DaysAverages();        
+        _averages = await GetLast30DaysAverages();
     }
 
     private async Task<List<DayAverage>> GetLast30DaysAverages()
@@ -42,17 +53,24 @@
         var minDate = DateTime.Now.AddDays(-30).Date;
 
         await using var ctx = await dbContextFactory.CreateDbContextAsync();
-        var averages = await ctx.Projects
+        var project_averages = await ctx.Projects
             .Where(e => e.Project_Acronym_CD == WorkspaceAcronym)
-            .Join(ctx.Project_Storage_Avgs, p => p.Project_ID, s => s.ProjectId, (p, s) => s)
-            .Where(e => e.Date >= minDate)
-            .Select(e => new DayAverage(e.Date.Day, e.AverageCapacity))
-            .ToListAsync();
+            .Join(ctx.Project_Storage_Avgs, p => p.Project_ID, s => s.ProjectId, (p, s) => s).ToListAsync();
+        var averages = project_averages.Where(e => e.Date >= minDate)
+            .Select(e => new DayAverage(e.Date.Day, e.AverageCapacity)).ToList();
 
+        _lastUpdate = project_averages.Max(e => e.Date);
         return averages;
+    }
+
+    private DateTime ConvertToLocalTime(DateTime UTCTime)
+    {
+        TimeZone localZone = TimeZone.CurrentTimeZone;
+        return localZone.ToLocalTime(UTCTime);
     }
 
     static string FormatDay(int day) => $"{day.ToString("D2")}";
 
     record DayAverage(int Day, double Average);
+
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceStorageReport.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceStorageReport.razor
@@ -12,8 +12,8 @@
         <MudText Style="font-style: italic">@Localizer["Last updated {0} {1}", $"{_lastUpdate:yyyy-MM-dd HH:mm}", TimeZone.CurrentTimeZone.StandardName]</MudText>
         @if (_lastUpdate < DateTime.UtcNow.AddDays(-7))
         {
-            <MudAlert Variant="Variant.Outlined" Severity="Severity.Error" Style="color: #000">
-                @Localizer["Storage data is older than 7 days and may be incorrect, please check back later."]
+            <MudAlert Variant="Variant.Outlined" Severity="Severity.Warning" Style="color: #000">
+                @Localizer["Storage data has not been updated in the last 7 days, please check back later for updated storage data."]
             </MudAlert>
         }
     }

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -2897,5 +2897,9 @@
   "{0} credits consumed on average (daily)": "{0} crédits consommés en moyenne (quotidiennement)",
   "{0} credits consumed yesterday": "{0} crédits consommés hier",
   "{0} successfully added to your workspace": "{0} ajouté avec succès à votre espace de travail",
-  "© Natural Resources Canada, 2020.  All rights reserved.": "© Ressources naturelles Canada, 2020.  Tous droits réservés."
+  "© Natural Resources Canada, 2020.  All rights reserved.": "© Ressources naturelles Canada, 2020.  Tous droits réservés.",
+  "Last updated {0} {1}": "Dernière mise à jour le {0} {1}",
+  "Costing data has not been updated in the last 7 days, please check back later for updated costs.": "Les données de coût n'ont pas été mises à jour au cours des 7 derniers jours, veuillez vérifier plus tard pour obtenir des coûts mis à jour.",
+  "Storage data has not been updated in the last 7 days, please check back later for updated storage data.": "Les données de stockage n'ont pas été mises à jour au cours des 7 derniers jours, veuillez vérifier plus tard pour obtenir des données de stockage mises à jour.",
+  "This web application is not configured yet. Please configure it by clicking the \u0027Configure\u0027 button at the top right of the page.": "Cette application web n'est pas encore configurée. Veuillez la configurer en cliquant sur le bouton \u0027Configurer\u0027 en haut à droite de la page."
 }

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1954,5 +1954,9 @@
   "{0} Storage Explorer": "{0} Storage Explorer",
   "{0} credits consumed on average (daily)": "{0} credits consumed on average (daily)",
   "{0} credits consumed yesterday": "{0} credits consumed yesterday",
-  "{0} successfully added to your workspace": "{0} successfully added to your workspace"
+  "{0} successfully added to your workspace": "{0} successfully added to your workspace",
+  "Last updated {0} {1}": "Last updated {0} {1}",
+  "Costing data has not been updated in the last 7 days, please check back later for updated costs.": "Costing data has not been updated in the last 7 days, please check back later for updated costs.",
+  "Storage data has not been updated in the last 7 days, please check back later for updated storage data.": "Storage data has not been updated in the last 7 days, please check back later for updated storage data.",
+  "This web application is not configured yet. Please configure it by clicking the \u0027Configure\u0027 button at the top right of the page.": "This web application is not configured yet. Please configure it by clicking the \u0027Configure\u0027 button at the top right of the page."
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Added timestamps for storage and cost reports, with some alerts to indicate when the data is old

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
![image](https://github.com/ssc-sp/datahub-portal/assets/56747050/9faa8cfe-d315-4672-bfc6-ffca5d52f764)
![image](https://github.com/ssc-sp/datahub-portal/assets/56747050/5dc792c7-61e1-4e29-89d7-cadad77d4704)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [x] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
