### PR TITLE
using new queue for healthcheck results

### DIFF
--- a/Portal/src/Datahub.Infrastructure/ConfigureServices.cs
+++ b/Portal/src/Datahub.Infrastructure/ConfigureServices.cs
@@ -62,6 +62,7 @@ public static class ConfigureServices
         if (isDevelopment)
         {
             services.AddScoped<IHealthCheckConsumer, HealthCheckConsumer>();
+            services.AddScoped<IHealthCheckResultConsumer, HealthCheckResultConsumer>();
             services.AddHostedService<LocalMessageReaderService>();
         }
 
@@ -75,6 +76,10 @@ public static class ConfigureServices
                     cfg.ReceiveEndpoint("infrastructure-health-check", endpoint =>
                     {
                         endpoint.Consumer<HealthCheckConsumer>();
+                    });
+                    cfg.ReceiveEndpoint("infrastructure-health-check-results", endpoint =>
+                    {
+                        endpoint.Consumer<HealthCheckResultConsumer>();
                     });
                 });
             }

--- a/Portal/src/Datahub.Infrastructure/Queues/Messages/InfrastructureHealthCheckResultMessage.cs
+++ b/Portal/src/Datahub.Infrastructure/Queues/Messages/InfrastructureHealthCheckResultMessage.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+using Datahub.Core.Model.Health;
+
+namespace Datahub.Infrastructure.Queues.Messages
+{
+    public record InfrastructureHealthCheckResultMessage(
+        string Group,
+        string Name,
+        InfrastructureHealthResourceType ResourceType,
+        InfrastructureHealthStatus Status,
+        DateTime HealthCheckTimeUtc,
+        string Details
+    ) : IRequest;
+}

--- a/Portal/src/Datahub.Infrastructure/Services/HealthCheckResultsConsumer.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/HealthCheckResultsConsumer.cs
@@ -1,0 +1,36 @@
+﻿using Datahub.Infrastructure.Queues.Messages;
+using MassTransit;
+using System.Text.Json;
+
+namespace Datahub.Infrastructure.Services
+{
+    public interface IHealthCheckResultConsumer
+    {
+        Task Consume(ConsumeContext<InfrastructureHealthCheckResultMessage> context);
+    }
+    /// <summary>
+    /// Local consumer of InfrastructureHealthCheckResultMessage for debugging and troubleshooting
+    /// Saves message to local folder
+    /// Service \datahub-portal\Portal\src\Datahub.Infrastructure\Services\Loopback\FileWatcherService.cs consumes the message
+    /// and processes it using code copied from \datahub-portal\ServerlessOperations\src\Datahub.Functions\RecordInfrastructureStatus.cs
+    /// </summary>
+    public class HealthCheckResultConsumer : IConsumer<InfrastructureHealthCheckResultMessage>, IHealthCheckResultConsumer
+    {
+        public HealthCheckResultConsumer() { }
+
+        public async Task Consume(ConsumeContext<InfrastructureHealthCheckResultMessage> context)
+        {
+            var healthCheckResultMessage = context.Message; // Get the order details from the message
+
+            // Persist the message to a folder
+            var folderPath = Path.Combine(Directory.GetCurrentDirectory(), "MessageFolder");
+            var randomName= Guid.NewGuid().ToString();
+            Directory.CreateDirectory(folderPath);
+            var filePath = Path.Combine(folderPath, $"{randomName}.txt");
+            var message = JsonSerializer.Serialize(healthCheckResultMessage);
+            await File.WriteAllTextAsync(filePath, message);
+
+            Console.WriteLine($"Got message = {healthCheckResultMessage}");
+        }
+    }
+} 

--- a/Portal/src/Datahub.Infrastructure/Services/Helpers/LocalMessageReaderService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Helpers/LocalMessageReaderService.cs
@@ -10,6 +10,7 @@ using Datahub.Infrastructure.Queues.Messages;
 using Datahub.Infrastructure.Services.Storage;
 using Datahub.Shared.Clients;
 using Datahub.Shared.Configuration;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -88,18 +89,24 @@ public class LocalMessageReaderService : BackgroundService
 
             // Deserialize the file contents into an InfrastructureHealthCheckMessage object
             InfrastructureHealthCheckMessage message = JsonSerializer.Deserialize<InfrastructureHealthCheckMessage>(fileContents);
-            var request = new InfrastructureHealthCheckRequest(message.Type, message.Group, message.Name);
-            if (message.Group == "all")
+            InfrastructureHealthCheckResultMessage checkResult = JsonSerializer.Deserialize<InfrastructureHealthCheckResultMessage>(fileContents);
+            if (message != null )
             {
-                RunAllChecks(e.Name).SyncResult();
+                var request = new InfrastructureHealthCheckRequest(message.Type, message.Group, message.Name);
+                if (message.Group == "all")
+                {
+                    RunAllChecks(e.Name).SyncResult();
+                }
+                else
+                {
+                    RunHealthCheck(request, e.Name).SyncResult();
+                }
             }
-            else
+            if (checkResult != null)
             {
-                RunHealthCheck(request, e.Name).SyncResult();
+               RecordHealthCheckResults(checkResult);
             }
-
         }
-        // Process the file here
     }
 
     private bool IsFileLocked(string filePath)
@@ -957,6 +964,98 @@ public class LocalMessageReaderService : BackgroundService
 
         return new InfrastructureHealthCheckResponse(check, errors);
     }
+    #region Handling Health Check  Results 
+    // copied and modified from \datahub-portal\ServerlessOperations\src\Datahub.Functions\RecordInfrastructureStatus.cs
+    /// <summary>
+    /// Persists in DB the result of an infrastructure health check. 
+    /// </summary>
+    /// <param name="request">the request containing the resource type, group, name, heathcheck status and details</param>
+    /// <returns>An OkResult containing the request is formatted properly. A BadRequestObjectResult is returned for poorly formatted requests.</returns>
+    private IActionResult RecordHealthCheckResults(InfrastructureHealthCheckResultMessage request)
+    {
+        try
+        {
+            StoreResult(request).GetAwaiter().GetResult();          // operational data
+            StoreHealthCheckRun(request).GetAwaiter().GetResult();  // historical data
+
+            return new OkResult();
+        }
+        catch (Exception ex)
+        {
+            return new BadRequestObjectResult(ex);
+        }
+    }
+
+    /// <summary>
+    /// Function that stores the result of an infrastructure health check in the database.
+    /// </summary>
+    /// <param name="result">the result of the health check result to upload</param>
+    /// <returns></returns>
+    private async Task StoreResult(InfrastructureHealthCheckResultMessage check)
+    {
+        if (check.Group == null || check.Name == null) { return; }
+        var existingChecks = _projectDBContext.InfrastructureHealthChecks.Where(c =>
+            c.Group == check.Group && c.Name == check.Name && c.ResourceType == check.ResourceType);
+
+        if (existingChecks != null)
+        {
+            foreach (var item in existingChecks)
+            {
+                _projectDBContext.InfrastructureHealthChecks.Remove(item);
+            }
+        }
+
+        // Add the check without specifying the ID to allow the database to generate it
+        _projectDBContext.InfrastructureHealthChecks.Add(new InfrastructureHealthCheck
+        {
+            Group = check.Group,
+            Name = check.Name,
+            ResourceType = check.ResourceType,
+            Status = check.Status,
+            HealthCheckTimeUtc = check.HealthCheckTimeUtc,
+            Details = check.Details,
+        });
+        try
+        {
+            await _projectDBContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex.Message, check);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Function that stores the result of an infrastructure health check in the database.
+    /// </summary>
+    /// <param name="result">the result of the health check result to upload</param>
+    /// <returns></returns>
+    private async Task StoreHealthCheckRun(InfrastructureHealthCheckResultMessage check)
+    {
+        if (check.Group == null || check.Name == null) { return; }
+
+        // Add the check run without specifying the ID to allow the database to generate it
+        _projectDBContext.InfrastructureHealthCheckRuns.Add(new InfrastructureHealthCheck
+        {
+            Group = check.Group,
+            Name = check.Name,
+            ResourceType = check.ResourceType,
+            Status = check.Status,
+            HealthCheckTimeUtc = check.HealthCheckTimeUtc,
+            Details = check.Details,
+        });
+        try
+        {
+            await _projectDBContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex.Message, check);
+        }
+    }
+
+    #endregion
 
     public record InfrastructureHealthCheckRequest(InfrastructureHealthResourceType Type, string Group, string Name);
 

--- a/ServerlessOperations/src/Datahub.Functions/RecordInfrastructureStatus.cs
+++ b/ServerlessOperations/src/Datahub.Functions/RecordInfrastructureStatus.cs
@@ -1,0 +1,153 @@
+using Azure.Messaging.ServiceBus;
+using Datahub.Core.Model.Datahub;
+using Datahub.Core.Model.Health;
+using Datahub.Functions.Extensions;
+using Datahub.Infrastructure.Queues.Messages;
+using Datahub.Shared.Configuration;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Datahub.Functions;
+
+public class RecordInfrastructureStatus(
+    ILoggerFactory loggerFactory,
+    DatahubProjectDBContext dbProjectContext)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<RecordInfrastructureStatus>();
+
+    /// <summary>
+    /// Azure Function that can be called to record in DB results of heathcheck of a specific infrastructure resource with a POST request.
+    /// </summary>
+    /// <param name="req"></param>
+    /// <returns>An OkResult that means that the heathcheck result was recorded.</returns>
+    [Function("RecordInfrastructureStatusHttp")]
+    public async Task<IActionResult> RecordHealthCheckHttp(
+        [HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
+    {
+        _logger.LogInformation("C# HTTP trigger function processed a request.");
+        var requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+        var request = System.Text.Json.JsonSerializer.Deserialize<InfrastructureHealthCheckResultMessage>(requestBody);
+        if (request == null)
+        {
+            return new BadRequestObjectResult(req.Body);
+        }
+        return await RecordHealthCheckResults(request);
+    }
+
+    /// <summary>
+    /// Azure Function that consumes messages from the infrastructure health check results queue and persists it into DB.
+    /// </summary>
+    /// <param name="message">The ServiceBusReceivedMessage containing the infrastructure health check results.</param>
+    /// <returns>
+    /// An IActionResult containing the results of the database SaveChanges operation. 
+    /// </returns>
+    /// <remarks>
+    /// The method retrieves the InfrastructureHealthCheckResultMessage object from the message body and persists in DB.
+    /// </remarks>
+    [Function("RecordInfrastructureStatusQueue")]
+    public async Task<IActionResult> RecordHealthCheckQueue(
+        [ServiceBusTrigger(QueueConstants.InfrastructureHealthCheckResultsQueueName,
+            Connection = "DatahubServiceBus:ConnectionString")]
+        ServiceBusReceivedMessage message)
+    {
+        _logger.LogInformation($"C# Queue trigger function processed: {message.Body}");
+        
+        var request = await message.DeserializeAndUnwrapMessageAsync<InfrastructureHealthCheckResultMessage>();
+        if (request == null)
+        {
+            return new BadRequestObjectResult(message);
+        }
+        return await RecordHealthCheckResults(request);
+    }
+
+    /// <summary>
+    /// Persists in DB the result of an infrastructure health check. 
+    /// </summary>
+    /// <param name="request">the request containing the resource type, group, name, heathcheck status and details</param>
+    /// <returns>An OkResult if operation was successful. A BadResult is returned otherwise.</returns>
+    private async Task<IActionResult> RecordHealthCheckResults(InfrastructureHealthCheckResultMessage request)
+    {
+        try
+        {
+            await StoreResult(request);          // operational data
+            await StoreHealthCheckRun(request);  // historical data
+
+            return new OkResult();
+        }
+        catch(Exception ex)
+        {
+            return new BadRequestObjectResult(ex);
+        }
+    }
+
+    /// <summary>
+    /// Function that stores the result of an infrastructure health check in the database.
+    /// </summary>
+    /// <param name="result">the result of the database SaveChanges operation.</param>
+    /// <returns></returns>
+    private async Task StoreResult(InfrastructureHealthCheckResultMessage check)
+    {
+        if (check.Group == null || check.Name == null) { return; }
+        var existingChecks = dbProjectContext.InfrastructureHealthChecks.Where(c =>
+            c.Group == check.Group && c.Name == check.Name && c.ResourceType == check.ResourceType);
+
+        if (existingChecks != null)
+        {
+            foreach(var item in existingChecks)
+            {
+                dbProjectContext.InfrastructureHealthChecks.Remove(item);
+            }
+        }
+
+        // Add the check without specifying the ID to allow the database to generate it
+        dbProjectContext.InfrastructureHealthChecks.Add(new InfrastructureHealthCheck
+        {
+            Group = check.Group,
+            Name = check.Name,
+            ResourceType = check.ResourceType,
+            Status = check.Status,
+            HealthCheckTimeUtc = check.HealthCheckTimeUtc,
+            Details = check.Details,
+        });
+        try
+        {
+            await dbProjectContext.SaveChangesAsync();
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError(ex.Message, check);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Function that stores the result of an infrastructure health check in the database.
+    /// </summary>
+    /// <param name="result">the result of the database SaveChanges operation</param>
+    /// <returns></returns>
+    private async Task StoreHealthCheckRun(InfrastructureHealthCheckResultMessage check)
+    {
+        if (check.Group == null || check.Name == null) { return; }
+
+        // Add the check run without specifying the ID to allow the database to generate it
+        dbProjectContext.InfrastructureHealthCheckRuns.Add(new InfrastructureHealthCheck
+        {
+            Group = check.Group,
+            Name = check.Name,
+            ResourceType = check.ResourceType,
+            Status = check.Status,
+            HealthCheckTimeUtc = check.HealthCheckTimeUtc,
+            Details = check.Details,
+        });
+        try
+        {
+            await dbProjectContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex.Message, check);
+        }
+    }
+}

--- a/Shared/src/Datahub.Shared/Configuration/QueueConstants.cs
+++ b/Shared/src/Datahub.Shared/Configuration/QueueConstants.cs
@@ -8,6 +8,7 @@ public static class QueueConstants
     public const string BugReportQueueName = "bug-report";
     public const string EmailNotificationQueueName = "email-notification";
     public const string InfrastructureHealthCheckQueueName = "infrastructure-health-check";
+    public const string InfrastructureHealthCheckResultsQueueName = "infrastructure-health-check-results";
     public const string ProjectCapacityUpdateQueueName = "project-capacity-update";
     public const string ProjectInactivityNotificationQueueName = "project-inactivity-notification";
     public const string ProjectUsageNotificationQueueName = "project-usage-notification";


### PR DESCRIPTION
## Description
- added new Azure Service Bus queue message handler to process healthcheck results (coming from Python sync)

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
- manually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

[<!-- Link to the "infrastructure" repository PR here -->](https://github.com/ssc-sp/datahub-infra/pull/125)
