### PR TITLE
new web app share link that embeds the web application inside an iframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Portal/src/Datahub.Core/Utils/Certs/gc1.pem
 /ServerlessOperations/src/Datahub.Functions/settings.dev.json
 Portal/src/Datahub.Portal/MessageFolder/
 ResourceProvisioner/test/ResourceProvisioner_PyFunctions_Tests/venv/*
+/Portal/utils/JsonTranslator/Properties/launchSettings.json

--- a/Datahub.sln
+++ b/Datahub.sln
@@ -341,9 +341,9 @@ Global
 		{53C2E55C-7BF1-477E-B12A-05A3CAD9B39A} = {12002871-163E-49CD-93DE-FBED9F5573E1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {9DC4B901-16FF-4FF2-9ED6-B286EA17048E}
-		RESX_AutoCreateNewLanguageFiles = True
 		RESX_ConfirmAddLanguageFile = True
+		RESX_AutoCreateNewLanguageFiles = True
+		SolutionGuid = {9DC4B901-16FF-4FF2-9ED6-B286EA17048E}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Shared\src\Datahub.Shared\Datahub.Shared.projitems*{57703cec-08b9-40b8-b5e2-064a196b1587}*SharedItemsImports = 5

--- a/Portal/src/Datahub.Portal/Pages/PageRoutes.cs
+++ b/Portal/src/Datahub.Portal/Pages/PageRoutes.cs
@@ -13,6 +13,8 @@ public static class PageRoutes
     public const string Workspace = $"/{WorkspacePrefix}/{{WorkspaceAcronymParam}}/{{Section}}";
     public const string WorkspaceSubSection = $"/{WorkspacePrefix}/{{WorkspaceAcronymParam}}/{{Section}}/{{SubSection}}";
 
+    public const string WorkspaceWebAppShare = $"/{WorkspacePrefix}/{{WorkspaceAcronymParam}}/webapp-ext";
+
     public const string AccountPrefix = "account";
     public const string AccountDefault = $"/{AccountPrefix}/";
     public const string Account = $"/{AccountPrefix}/{{Section}}";

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppInfoTable.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppInfoTable.razor
@@ -14,7 +14,15 @@
     <tbody>
     <tr>
         <td>
-            @Localizer["Proxy URL"]
+            @Localizer["Share link"]
+        </td>
+        <td>
+            <MudLink Href="@shareLink" Target="_blank">@shareLink</MudLink>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            @Localizer["Proxy URL for development"]
         </td>
         <td>
             <MudLink Href="@_url" Target="_blank" >@_url</MudLink>
@@ -52,14 +60,6 @@
             <code>@ComposePath</code>
         </td>
     </tr>
-        <tr>
-            <td>
-                @Localizer["Share link"]
-            </td>
-            <td>
-                <MudLink Href="@shareLink" Target="_blank">@shareLink</MudLink>
-            </td>
-        </tr>
     </tbody>
 </MudSimpleTable>
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppInfoTable.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppInfoTable.razor
@@ -52,11 +52,18 @@
             <code>@ComposePath</code>
         </td>
     </tr>
+        <tr>
+            <td>
+                @Localizer["Share link"]
+            </td>
+            <td>
+                <MudLink Href="@shareLink" Target="_blank">@shareLink</MudLink>
+            </td>
+        </tr>
     </tbody>
 </MudSimpleTable>
 
 @code {
-
     [Parameter] public string WebAppHost { get; set; }
 
     [Parameter] public string WebAppId { get; set; }
@@ -68,11 +75,14 @@
     [Parameter] public string ComposePath { get; set; }
     [Parameter] public string WorkspaceAcronym { get; set; }
 
+    private string shareLink = null!;
+
     private string _url;
 
     protected override void OnParametersSet()
     {
         RefreshUrl();
+        shareLink = PageRoutes.WorkspaceWebAppShare.Replace("{WorkspaceAcronymParam}", WorkspaceAcronym);
     }
 
     public void RefreshUrl()

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
@@ -20,8 +20,6 @@
     <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" />
 </SectionContent>
 
-@if (DisclaimerAccepted)
-{
 <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronymParam">
     <Authorized>
         <MudGrid>
@@ -32,6 +30,12 @@
                 {
                     <MudText>
                         @Localizer["This web application is not provisioned yet. Please come back soon."]
+                    </MudText>
+                }
+                else
+                {
+                    <MudText Typo="Typo.h3">
+                        @Localizer["Web Application hosted by FSDH"]
                     </MudText>
                 }
             </MudItem>
@@ -47,18 +51,7 @@
     <NotAuthorized>
         <NotAuthorizedMessage />
     </NotAuthorized>
-    </DatahubAuthView>
-}
-else
-{
-
-    <MudText Typo="Typo.h3">
-        @Localizer["Web Application hosted by FSDH. The owners of the workspace are responsible for the web application content."]
-    </MudText>
-    <DHButton Variant="Variant.Filled" Size="Size.Small" OnClick="@(async () => { await ExecuteAsyncWithStateChangeDelay(_webAppMgmtService.Start, _webAppId, 2000); })">
-        @Localizer["Accept web application terms"]
-    </DHButton>
-}
+</DatahubAuthView>
 
 
 
@@ -67,15 +60,7 @@ else
     [Parameter]
     public string WorkspaceAcronymParam { get; set; }
 
-    [Parameter]
-    public bool DisclaimerAccepted { get; set; }
-
     private bool isAvailable = false;
-
-    private async Task ApproveWebAppTerms()
-    {
-        
-    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
@@ -1,0 +1,76 @@
+﻿@using Datahub.Application.Services.ReverseProxy
+@using Datahub.Application.Services.Security
+@using Datahub.Portal.Views.Dialogs
+@using Datahub.Shared.Entities
+@using Microsoft.Identity.Web
+@using Datahub.Core.Model.Projects
+@using System.Text.Json
+@using Datahub.Application.Services.WebApp
+
+@inject IDbContextFactory<DatahubProjectDBContext> dbContextFactory
+@inject ILogger<WorkspaceWebAppSharePage> _logger
+
+@attribute [Route(PageRoutes.WorkspaceWebAppShare)]
+
+<PageTitle>
+    @Localizer["SSC Datahub - Workspace - {0}", WorkspaceAcronymParam ?? ""]
+</PageTitle>
+
+<SectionContent SectionName="side-bar">
+    <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" />
+</SectionContent>
+
+<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronymParam">
+    <Authorized>
+        <MudGrid>
+            <MudItem xs="12" sm="8">
+
+                <WorkspaceInfo WorkspaceAcronym="@WorkspaceAcronymParam" />
+                @if (!isAvailable)
+                {
+                    <MudText>
+                        @Localizer["This web application is not provisioned yet. Please come back soon."]
+                    </MudText>
+                }
+                else
+                {
+                    <MudText Typo="Typo.h3">
+                        @Localizer["Web Application hosted by FSDH"]
+                    </MudText>
+                }
+            </MudItem>
+            @if (isAvailable)
+            {
+                <MudItem xs="12">
+                    <iframe src="/webapp-@(WorkspaceAcronymParam)/" style="height: 70vh;" title="Web Application" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"> </iframe>
+                </MudItem>
+            }
+
+        </MudGrid>
+    </Authorized>
+    <NotAuthorized>
+        <NotAuthorizedMessage />
+    </NotAuthorized>
+</DatahubAuthView>
+
+
+
+@code {
+
+    [Parameter]
+    public string WorkspaceAcronymParam { get; set; }
+
+    private bool isAvailable = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        using var ctx = await dbContextFactory.CreateDbContextAsync();
+        var workspace = await ctx.Projects
+            .Include(x => x.Resources)
+            .FirstOrDefaultAsync(x => x.Project_Acronym_CD == WorkspaceAcronymParam);
+        var appConfiguration = TerraformVariableExtraction.ExtractAppServiceConfiguration(workspace);
+        isAvailable = workspace is not null && !(string.IsNullOrWhiteSpace(appConfiguration.Framework) && string.IsNullOrWhiteSpace(appConfiguration.GitRepo) && string.IsNullOrWhiteSpace(appConfiguration.ComposePath));
+        StateHasChanged();
+    }
+
+}

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
@@ -20,6 +20,8 @@
     <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" />
 </SectionContent>
 
+@if (DisclaimerAccepted)
+{
 <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronymParam">
     <Authorized>
         <MudGrid>
@@ -30,12 +32,6 @@
                 {
                     <MudText>
                         @Localizer["This web application is not provisioned yet. Please come back soon."]
-                    </MudText>
-                }
-                else
-                {
-                    <MudText Typo="Typo.h3">
-                        @Localizer["Web Application hosted by FSDH"]
                     </MudText>
                 }
             </MudItem>
@@ -51,7 +47,18 @@
     <NotAuthorized>
         <NotAuthorizedMessage />
     </NotAuthorized>
-</DatahubAuthView>
+    </DatahubAuthView>
+}
+else
+{
+
+    <MudText Typo="Typo.h3">
+        @Localizer["Web Application hosted by FSDH. The owners of the workspace are responsible for the web application content."]
+    </MudText>
+    <DHButton Variant="Variant.Filled" Size="Size.Small" OnClick="@(async () => { await ExecuteAsyncWithStateChangeDelay(_webAppMgmtService.Start, _webAppId, 2000); })">
+        @Localizer["Accept web application terms"]
+    </DHButton>
+}
 
 
 
@@ -60,7 +67,15 @@
     [Parameter]
     public string WorkspaceAcronymParam { get; set; }
 
+    [Parameter]
+    public bool DisclaimerAccepted { get; set; }
+
     private bool isAvailable = false;
+
+    private async Task ApproveWebAppTerms()
+    {
+        
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppSharePage.razor
@@ -9,6 +9,7 @@
 
 @inject IDbContextFactory<DatahubProjectDBContext> dbContextFactory
 @inject ILogger<WorkspaceWebAppSharePage> _logger
+@inject NavigationManager NavigationManager
 
 @attribute [Route(PageRoutes.WorkspaceWebAppShare)]
 
@@ -20,39 +21,71 @@
     <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" />
 </SectionContent>
 
-<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronymParam">
-    <Authorized>
-        <MudGrid>
-            <MudItem xs="12" sm="8">
+<MudItem xs="12" sm="12">
 
-                <WorkspaceInfo WorkspaceAcronym="@WorkspaceAcronymParam" />
-                @if (!isAvailable)
-                {
-                    <MudText>
-                        @Localizer["This web application is not provisioned yet. Please come back soon."]
-                    </MudText>
-                }
-                else
-                {
-                    <MudText Typo="Typo.h3">
-                        @Localizer["Web Application hosted by FSDH"]
-                    </MudText>
-                }
-            </MudItem>
-            @if (isAvailable)
+    <WorkspaceInfo WorkspaceAcronym="@WorkspaceAcronymParam" />
+    @if (!isAvailable)
+    {
+        <MudText>
+            @Localizer["This web application is not provisioned yet. Please come back soon."]
+        </MudText>
+    }
+    else
+    {
+        <MudStack Row="true">
+            <MudText Typo="Typo.h3">
+                @Localizer["Web Application hosted by FSDH"]
+            </MudText>
+            @if (isDisclaimerAccepted)
             {
-                <MudItem xs="12">
-                    <iframe src="/webapp-@(WorkspaceAcronymParam)/" style="height: 70vh;" title="Web Application" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"> </iframe>
-                </MudItem>
+            <MudButton Href="@($"/webapp-{WorkspaceAcronymParam}/")" Target="_blank" EndIcon="@Icons.Material.Filled.Launch" Variant="Variant.Outlined" Style="text-transform:none">@Localizer["Open in new window"]</MudButton>
             }
+        </MudStack>
+    }
+</MudItem>
+@if (isDisclaimerAccepted)
+{
+    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronymParam">
+        <Authorized>
+            <MudGrid Class="mt-4">
 
-        </MudGrid>
-    </Authorized>
-    <NotAuthorized>
-        <NotAuthorizedMessage />
-    </NotAuthorized>
-</DatahubAuthView>
+                @if (isAvailable)
+                {
+                    <MudItem xs="12">
+                        <iframe src="/webapp-@(WorkspaceAcronymParam)/" style="height: 70vh;" title="@Localizer["Web Application hosted by FSDH"]" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"> </iframe>
+                    </MudItem>
+                }
 
+            </MudGrid>
+        </Authorized>
+        <NotAuthorized>
+            <NotAuthorizedMessage />
+        </NotAuthorized>
+    </DatahubAuthView>
+}
+else
+{
+    <MudStack Class="mt-8">
+        <MudText>
+            @Localizer["The following web application has been uploaded by a user onto this data platform using their own code. Please be aware that the content and functionality of this application are entirely controlled by the user who uploaded it, and the platform provider takes no responsibility for its content, accuracy, or performance."]
+        </MudText>
+        <MudText>
+            @Localizer["It is the sole responsibility of the user and the content creator to ensure that any material or information included in the web application complies with applicable laws, regulations, and ethical standards. The platform provider does not endorse, guarantee, or warrant the suitability, completeness, or security of the uploaded application."]
+        </MudText>
+        <MudText>
+            @Localizer["By accessing and using this web application, you acknowledge that the platform provider assumes no liability for any damages, losses, or injuries incurred as a result of its use or reliance on the content provided by the user. Users are advised to exercise caution and perform due diligence when interacting with the application and its content."]
+        </MudText>
+        <MudText>
+            @Localizer["Please note that any questions or concerns regarding the content or functionality of the web application should be directed to the user who uploaded it, as the platform provider does not assume responsibility for its maintenance or support."]
+        </MudText>
+        <MudText>
+            @Localizer["By continuing to utilize this web application, you are indicating your understanding and acceptance of this disclaimer."]
+        </MudText>
+        <DHButton Class="mt-8" OnClick="ApproveWebAppTC" Variant="Variant.Filled">
+            @Localizer["Accept Web Application Terms"]
+        </DHButton>
+    </MudStack>
+}
 
 
 @code {
@@ -62,6 +95,11 @@
 
     private bool isAvailable = false;
 
+    private bool isDisclaimerAccepted = false;
+
+    [SupplyParameterFromQuery(Name = "d")]
+    public string DisclaimerAccepted { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         using var ctx = await dbContextFactory.CreateDbContextAsync();
@@ -70,7 +108,21 @@
             .FirstOrDefaultAsync(x => x.Project_Acronym_CD == WorkspaceAcronymParam);
         var appConfiguration = TerraformVariableExtraction.ExtractAppServiceConfiguration(workspace);
         isAvailable = workspace is not null && !(string.IsNullOrWhiteSpace(appConfiguration.Framework) && string.IsNullOrWhiteSpace(appConfiguration.GitRepo) && string.IsNullOrWhiteSpace(appConfiguration.ComposePath));
+        if (DisclaimerAccepted == "1")
+        {
+            isDisclaimerAccepted = true;
+        }
         StateHasChanged();
     }
 
+    private async Task ApproveWebAppTC()
+    {
+        // Construct the new URL with the d=1 query parameter
+        var newUrl = $"{NavigationManager.Uri.Split('?')[0]}?d=1";
+
+        // Redirect the user to the same page with d=1
+        NavigationManager.NavigateTo(newUrl);
+        isDisclaimerAccepted = true;
+        StateHasChanged();
+    }
 }

--- a/Portal/src/Datahub.Portal/Program.cs
+++ b/Portal/src/Datahub.Portal/Program.cs
@@ -8,10 +8,6 @@ public class Program
     public static void Main(string[] args)
     {
         var host = CreateHostBuilder(args)
-            //.ConfigureServices(serviceCollection =>
-            //{
-            //    serviceCollection.AddSingleton(new ResourceManager("Datahub.Portal.Resources", typeof(Startup).GetTypeInfo().Assembly));
-            //})  
             .Build();
            
         host.Run();
@@ -24,12 +20,6 @@ public class Program
             {
                 logBuilder.ClearProviders();
                 logBuilder.AddConsole();
-
-                //var appInsightsConfig = hostingContext.Configuration.GetSection("ApplicationInsights");
-                //logBuilder.AddApplicationInsights(config => 
-                //{ 
-                //    config.ConnectionString = appInsightsConfig.GetValue<string>("ConnectionString"); 
-                //}, options => {});
 
                 logBuilder.AddAzureWebAppDiagnostics();
 

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -1,6 +1,5 @@
 ﻿{
   " is the default role and has only read access to all resources within your project.": " est le rôle par défaut et n'a qu'un accès en lecture à toutes les ressources de votre projet.",
-  " is the default role and has only read access to all resources within your project.": " est le rôle par défaut et n'a qu'un accès en lecture à toutes les ressources de votre projet.",
   " is the role that you will want to give to most of your colleagues. It gives them read/write access to most of your resources.": " est le rôle que vous voudrez donner à la plupart de vos collègues. Il leur donne un accès en lecture/écriture à la plupart de vos ressources.",
   " must always be the first YAML statement in the file.": " doit toujours être la première déclaration YAML dans le fichier.",
   " of use for the FSDH Proof-of-Concept Phase 2": " d'utilisation pour la phase 2 de la démonstration de concept du DHSF",
@@ -2903,5 +2902,6 @@
   "{0} credits consumed on average (daily)": "{0} crédits consommés en moyenne (quotidiennement)",
   "{0} credits consumed yesterday": "{0} crédits consommés hier",
   "{0} successfully added to your workspace": "{0} ajouté avec succès à votre espace de travail",
-  "© Natural Resources Canada, 2020.  All rights reserved.": "© Ressources naturelles Canada, 2020.  Tous droits réservés."
+  "© Natural Resources Canada, 2020.  All rights reserved.": "© Ressources naturelles Canada, 2020.  Tous droits réservés.",
+  "Web Application hosted by FSDH": "Application web hébergée par le DHSF"
 }

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -2879,7 +2879,6 @@
   "of {0}": "de {0}",
   "on setting up your account.": "sur la configuration de votre compte.",
   "please contact us to set-up volumes as they require more configuration.": "veuillez nous contacter pour configurer les volumes.",
-  "please contact us to set-up volumes as they require more configuration.": "veuillez nous contacter pour configurer les volumes.",
   "please refer to the resources page on it.": "veuillez vous référer à la page de ressources à ce sujet.",
   "ports section in the YAML must use quoted numbers.": "la section des ports dans le YAML doit utiliser des nombres entre guillemets.",
   "remaining credits": "crédits restants",
@@ -2895,7 +2894,6 @@
   "xxxx moved xxxx to xxxx": "xxxx a déplacé xxxx à xxxx",
   "yes": "oui",
   "{0}": "{0}",
-  "{0}": "{0}",
   "{0} Storage Explorer": "Explorateur de stockage de {0}",
   "{0} copied {1} to {2}": "xxxx a copié xxxx dans xxxx ",
   "{0} created {1} in {2}": "{0} a créé {1} dans {2}",
@@ -2903,5 +2901,14 @@
   "{0} credits consumed yesterday": "{0} crédits consommés hier",
   "{0} successfully added to your workspace": "{0} ajouté avec succès à votre espace de travail",
   "© Natural Resources Canada, 2020.  All rights reserved.": "© Ressources naturelles Canada, 2020.  Tous droits réservés.",
-  "Web Application hosted by FSDH": "Application web hébergée par le DHSF"
+  "Web Application hosted by FSDH": "Application web hébergée par le DHSF",
+  "The following web application has been uploaded by a user onto this data platform using their own code. Please be aware that the content and functionality of this application are entirely controlled by the user who uploaded it, and the platform provider takes no responsibility for its content, accuracy, or performance.": "L'application web suivante a été téléchargée par un utilisateur sur cette plateforme de données à l'aide de son propre code. Le contenu et les fonctionnalités de cette application sont entièrement contrôlés par l'utilisateur qui l'a téléchargée, et le fournisseur de la plateforme n'est pas responsable de son contenu, de son exactitude ou de ses performances.",
+  "It is the sole responsibility of the user and the content creator to ensure that any material or information included in the web application complies with applicable laws, regulations, and ethical standards. The platform provider does not endorse, guarantee, or warrant the suitability, completeness, or security of the uploaded application.": "Il est de la seule responsabilité de l'utilisateur et du créateur de contenu de s'assurer que tout matériel ou information inclus dans l'application web est conforme aux lois, réglementations et normes éthiques applicables. Le fournisseur de la plateforme n'approuve pas, ne garantit pas l'adéquation, l'exhaustivité ou la sécurité de l'application téléchargée.",
+  "By accessing and using this web application, you acknowledge that the platform provider assumes no liability for any damages, losses, or injuries incurred as a result of its use or reliance on the content provided by the user. Users are advised to exercise caution and perform due diligence when interacting with the application and its content.": "En accédant à cette application web et en l'utilisant, vous reconnaissez que le fournisseur de la plateforme n'assume aucune responsabilité pour les dommages, pertes ou blessures résultant de l'utilisation ou de la confiance accordée au contenu fourni par l'utilisateur. Il est conseillé aux utilisateurs de faire preuve de prudence et de diligence raisonnable lorsqu'ils interagissent avec l'application et son contenu.",
+  "Please note that any questions or concerns regarding the content or functionality of the web application should be directed to the user who uploaded it, as the platform provider does not assume responsibility for its maintenance or support.": "Veuillez noter que toute question ou préoccupation concernant le contenu ou la fonctionnalité de l'application web doit être adressée à l'utilisateur qui l'a téléchargée, étant donné que le fournisseur de la plateforme n'assume pas la responsabilité de sa maintenance ou de son soutien.",
+  "By continuing to utilize this web application, you are indicating your understanding and acceptance of this disclaimer.": "En continuant à utiliser cette application web, vous indiquez que vous comprenez et acceptez cette clause de non-responsabilité.",
+  "Accept Web Application Terms": "Accepter les conditions d'utilisation de l'application Web",
+  "Open in new window": "Ouvrir dans une nouvelle fenêtre",
+  "Share link": "Lien pour partager",
+  "Proxy URL for development": "URL proxy pour le développement"
 }

--- a/Portal/utils/JsonTranslator/Program.cs
+++ b/Portal/utils/JsonTranslator/Program.cs
@@ -11,7 +11,7 @@ if (!File.Exists(fPath))
 }
 var tgt = Path.Combine(Path.GetDirectoryName(fPath)!, "output-fr.json");
 using var sourceFile = File.OpenRead(src);
-var data = (await JsonSerializer.DeserializeAsync<Dictionary<string,string>>(sourceFile)) ?? new();
+var data = (await JsonSerializer.DeserializeAsync<RootObject>(sourceFile)) ?? new();
 var cfgPath = Path.GetFullPath(@"../../../../../src/Datahub.Portal");
 var config = new ConfigurationBuilder()
     //.SetBasePath(AppContext.BaseDirectory)
@@ -27,7 +27,7 @@ if (authKey is null)
 }
 var translator = new TranslationService(config);
 var newDic = new Dictionary<string, string>();
-foreach (var item in data.Where(d => !String.IsNullOrWhiteSpace(d.Key)))
+foreach (var item in data.@default.Where(d => !String.IsNullOrWhiteSpace(d.Key)))
 {
     if (!string.IsNullOrWhiteSpace(item.Value))
     {
@@ -50,3 +50,8 @@ var options = new JsonSerializerOptions
     WriteIndented = true
 };
 await JsonSerializer.SerializeAsync(outFile, newDic, options);
+
+public class RootObject
+{
+    public Dictionary<string, string> @default { get; set; } = new();
+}


### PR DESCRIPTION
## Description

- This is to support the flow required by SWAPIT team
- This adds a _share_ link that should simplify sharing a web application to new members
- The new share link opens a new page that embeds the web app inside an iframe and gives context to the shared link including FSDH menu

## How Has This Been Tested?

Visually tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

## Checklist:
- [X] PR is submitted to the correct branch `develop`.
- [X] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [X] Any new or updated translatable strings have been added to the localization files.
- [X] Necessary and relevant documentation has been created or updated.
- [X] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

## New Share Link in Web App info

![image](https://github.com/user-attachments/assets/ee49946f-48e0-4f44-9059-3452e4d97cc6)

## New Web App page for guests

![image](https://github.com/user-attachments/assets/7e67618b-b0e9-4f03-89d3-f5090df8b906)


