### PR TITLE
Replacing announcement carousel

### DIFF
--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -4,8 +4,66 @@
 @inject NavigationManager _navigationManager
 
 <div class="sr-only"><h2>@Localizer["Announcements"]</h2></div>
-<MudElement Class="rounded" HtmlTag="div" Style="@_backgroundImageStyle">
-    <MudElement  Class="rounded" HtmlTag="div" Style="@_glassStyle">
+
+<MudGrid>
+    @foreach (var preview in Previews)
+    {
+        @if (!preview.Preview.StartsWith("!["))
+        {
+            <MudItem xs="@_previewCount">
+                <MudPaper Elevation="0" Outlined Class="py-2 px-3">
+                    <MudStack Justify="Justify.SpaceBetween" Style="height: 100%;">
+                        <MudElement>
+                            @* <MudText Typo="Typo.body1">
+                                @preview.Preview
+                            </MudText> *@
+                            <DHMarkdown Content="@preview.Preview" />
+                            <DHButton Color="@Color.Primary" Variant="@Variant.Text">
+                                <span>
+                                    @Localizer["Read more"]
+                                    @* <span class="sr-only">@DocumentItem?.Title</span> *@
+                                </span>
+                            </DHButton>
+                        </MudElement>
+                    </MudStack>
+                </MudPaper>
+            
+            @* <AnnouncementPreviewCard DocumentItem="@preview" /> *@
+            </MudItem>
+        }
+    }
+</MudGrid>
+
+
+
+@* <MudElement Class="rounded" HtmlTag="div" Style="@_backgroundImageStyle">
+    <MudElement Class="rounded" HtmlTag="div" Style="@_glassStyle">
+        <MudGrid Class="px-4">
+            @foreach (var preview in Previews)
+            {
+                <MudItem xs="@_previewCount">
+                    @if (!preview.Preview.StartsWith("!["))
+                    {
+                        <MudStack Class="ma-6">
+                            <DHMarkdown Content="@preview.Preview" />
+                            <DHButton>@Localizer["Read More"]</DHButton>
+                            <DHButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
+                                @Localizer["Read more"]
+                            </DHButton>
+                        </MudStack>
+                    }
+                    else
+                    {
+                        <MudStack Class="ma-6">
+                            <DHMarkdown Content="@preview.Preview" />
+                            <DHButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
+                                @Localizer["Read more"]
+                            </DHButton>
+                        </MudStack>
+                    }
+                </MudItem>
+            }
+        </MudGrid>
         <MudCarousel Class="mud-width-full rounded"
                      Style="@_carouselStyle"
                      ShowArrows="true"
@@ -38,10 +96,10 @@
             }
         </MudCarousel>
     </MudElement>
-</MudElement>
+</MudElement> *@
 
 @code {
-        public const int CarouselHeight = 320;
+    public const int CarouselHeight = 320;
 
     [Parameter]
     public List<AnnouncementPreview> Previews { get; set; } = new();
@@ -54,6 +112,7 @@
     private string _glassStyle;
     private string _carouselStyle;
     private string _backgroundImageStyle;
+    private int _previewCount;
 
     // get the style so it's always at the bottom of the carousel
     private string _readMoreStyle => "position: absolute; bottom: 1rem; left: 2rem;";
@@ -63,7 +122,7 @@
         base.OnInitialized();
 
         var hasBackgroundUrl = !string.IsNullOrEmpty(BackgroundUrl);
-        
+
         _carouselStyle = new StyleBuilder()
             .AddStyle("height", $"{CarouselHeight}px")
             .Build();
@@ -83,6 +142,9 @@
             .AddStyle("--mud-palette-text-primary", "white", when: hasBackgroundUrl)
             .AddStyle("--mud-palette-primary", Colors.Purple.Accent2, when: hasBackgroundUrl)
             .Build();
+        
+        // There should really only be 2, 3, or 4 announcements at a time; if there are 3, they are displayed with 3 columns, otherwise it's 2 columns
+        _previewCount = (Previews.Count % 3 == 0) ? 4 : 6;
     }
 
     private void HandleReadMore(int newId)

--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -18,7 +18,10 @@
                                 @preview.Preview
                             </MudText> *@
                             <DHMarkdown Content="@preview.Preview" />
-                            <DHButton Color="@Color.Primary" Variant="@Variant.Text">
+                            <DHButton OnClick="() => HandleReadMore(preview.Id)"
+                                      Color="@Color.Primary"
+                                      Variant="@Variant.Text"
+                                      EndIcon="@Icons.Material.Filled.KeyboardDoubleArrowRight">
                                 <span>
                                     @Localizer["Read more"]
                                     @* <span class="sr-only">@DocumentItem?.Title</span> *@

--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -8,26 +8,25 @@
 <MudGrid>
     @foreach (var preview in Previews)
     {
+        // only allowing text-based announcements
         @if (!preview.Preview.StartsWith("!["))
         {
             <MudItem xs="@_previewCount">
                 <MudPaper Elevation="0" Outlined Class="py-2 px-3">
-                    <MudStack Justify="Justify.SpaceBetween" Style="height: 100%;">
-                        <MudElement>
-                            @* <MudText Typo="Typo.body1">
-                                @preview.Preview
-                            </MudText> *@
-                            <DHMarkdown Content="@preview.Preview" />
-                            <DHButton OnClick="() => HandleReadMore(preview.Id)"
-                                      Color="@Color.Primary"
-                                      Variant="@Variant.Text"
-                                      EndIcon="@Icons.Material.Filled.KeyboardDoubleArrowRight">
-                                <span>
-                                    @Localizer["Read more"]
-                                    @* <span class="sr-only">@DocumentItem?.Title</span> *@
-                                </span>
-                            </DHButton>
-                        </MudElement>
+                    <MudStack Justify="Justify.SpaceBetween" Style="height: 208px;">
+                        <MudStack>
+                            <DHMarkdown Content="@preview.Preview" Style="@_descriptionTextStyle" />
+                        </MudStack>
+                        <MudStack>
+                                <DHButton OnClick="() => HandleReadMore(preview.Id)"
+                                          Color="@Color.Primary"
+                                          Variant="@Variant.Text"
+                                          EndIcon="@Icons.Material.Filled.KeyboardDoubleArrowRight">
+                                    <span>
+                                        @Localizer["Read more"]
+                                    </span>
+                                </DHButton>
+                        </MudStack>
                     </MudStack>
                 </MudPaper>
             
@@ -115,6 +114,9 @@
     private string _glassStyle;
     private string _carouselStyle;
     private string _backgroundImageStyle;
+    private string _descriptionTextStyle;
+    private string _titleTextStyle;
+
     private int _previewCount;
 
     // get the style so it's always at the bottom of the carousel
@@ -145,9 +147,38 @@
             .AddStyle("--mud-palette-text-primary", "white", when: hasBackgroundUrl)
             .AddStyle("--mud-palette-primary", Colors.Purple.Accent2, when: hasBackgroundUrl)
             .Build();
-        
-        // There should really only be 2, 3, or 4 announcements at a time; if there are 3, they are displayed with 3 columns, otherwise it's 2 columns
-        _previewCount = (Previews.Count % 3 == 0) ? 4 : 6;
+
+        _descriptionTextStyle = new StyleBuilder()
+           .AddStyle("overflow", "hidden")
+           .AddStyle("-webkit-line-clamp", "6")
+           .AddStyle("-webkit-box-orient", "vertical")
+           .AddStyle("display", "-webkit-box")
+           .Build();
+
+        _titleTextStyle = new StyleBuilder()
+            .AddStyle("overflow", "hidden")
+            .AddStyle("-webkit-line-clamp", "2")
+            .AddStyle("-webkit-box-orient", "vertical")
+            .AddStyle("display", "-webkit-box")
+            .Build();
+
+        int count = 0;
+        foreach (var preview in Previews)
+        {
+            // only allowing text-based announcements
+            if (!preview.Preview.StartsWith("!["))
+            {
+                count++;
+            }
+        }
+
+        // There should really only be 1, 2, or 3 announcements at a time
+        // The # of columns for the announcements is displayed accordingly
+        _previewCount = (count % 3 == 0) ? 4 : 6;
+        if (count == 1)
+        {
+            _previewCount = 12;
+        }
     }
 
     private void HandleReadMore(int newId)

--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -8,97 +8,31 @@
 <MudGrid>
     @foreach (var preview in Previews)
     {
-        // only allowing text-based announcements
         @if (!preview.Preview.StartsWith("!["))
         {
             <MudItem xs="@_previewCount">
                 <MudPaper Elevation="0" Outlined Class="py-2 px-3">
-                    <MudStack Justify="Justify.SpaceBetween" Style="height: 208px;">
-                        <MudStack>
+                    <MudStack Justify="Justify.SpaceBetween" Style="height: 208px;" Spacing="1">
+                        <MudElement>
                             <DHMarkdown Content="@preview.Preview" Style="@_descriptionTextStyle" />
-                        </MudStack>
-                        <MudStack>
-                                <DHButton OnClick="() => HandleReadMore(preview.Id)"
-                                          Color="@Color.Primary"
-                                          Variant="@Variant.Text"
-                                          EndIcon="@Icons.Material.Filled.KeyboardDoubleArrowRight">
-                                    <span>
-                                        @Localizer["Read more"]
-                                    </span>
-                                </DHButton>
-                        </MudStack>
+                        </MudElement>
+                        <MudElement>
+                            <DHButton   OnClick="() => HandleReadMore(preview.Id)"
+                                        Color="@Color.Primary"
+                                        Variant="@Variant.Text"
+                                        EndIcon="@Icons.Material.Filled.KeyboardDoubleArrowRight">
+                                <span>
+                                    @Localizer["Read more"]
+                                    <span class="sr-only">@preview.Preview</span>
+                                </span>
+                            </DHButton>
+                        </MudElement>
                     </MudStack>
                 </MudPaper>
-            
-            @* <AnnouncementPreviewCard DocumentItem="@preview" /> *@
             </MudItem>
         }
     }
 </MudGrid>
-
-
-
-@* <MudElement Class="rounded" HtmlTag="div" Style="@_backgroundImageStyle">
-    <MudElement Class="rounded" HtmlTag="div" Style="@_glassStyle">
-        <MudGrid Class="px-4">
-            @foreach (var preview in Previews)
-            {
-                <MudItem xs="@_previewCount">
-                    @if (!preview.Preview.StartsWith("!["))
-                    {
-                        <MudStack Class="ma-6">
-                            <DHMarkdown Content="@preview.Preview" />
-                            <DHButton>@Localizer["Read More"]</DHButton>
-                            <DHButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
-                                @Localizer["Read more"]
-                            </DHButton>
-                        </MudStack>
-                    }
-                    else
-                    {
-                        <MudStack Class="ma-6">
-                            <DHMarkdown Content="@preview.Preview" />
-                            <DHButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
-                                @Localizer["Read more"]
-                            </DHButton>
-                        </MudStack>
-                    }
-                </MudItem>
-            }
-        </MudGrid>
-        <MudCarousel Class="mud-width-full rounded"
-                     Style="@_carouselStyle"
-                     ShowArrows="true"
-                     ShowBullets="false"
-                     EnableSwipeGesture="true"
-                     AutoCycle="true"
-                     AutoCycleTime="@TimeSpan.FromSeconds(10)"
-                     TData="object">
-
-            @foreach (var preview in Previews)
-            {
-                <MudCarouselItem Transition="Transition.Fade">
-                    @if (!preview.Preview.StartsWith("!["))
-                    {
-                        <MudStack Class="px-12 py-4" Style="height: 100%">
-                            <DHMarkdown Content="@preview.Preview"/>
-                            <DHButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
-                                @Localizer["Read more"]
-                            </DHButton>
-                        </MudStack>
-                    }
-					else
-					{
-						<DHMarkdown Content="@preview.Preview"/>
-                        <DHButton Style="@_readMoreStyle" Variant="Variant.Text" OnClick="() => HandleReadMore(preview.Id)">
-                            @Localizer["Read more"]
-                        </DHButton>
-					}
-                </MudCarouselItem>
-            }
-        </MudCarousel>
-    </MudElement>
-</MudElement> *@
 
 @code {
     public const int CarouselHeight = 320;
@@ -110,17 +44,15 @@
     public string BackgroundUrl { get; set; }
 
 
-
-    private string _glassStyle;
-    private string _carouselStyle;
-    private string _backgroundImageStyle;
+    // private string _glassStyle;
+    // private string _carouselStyle;
+    // private string _backgroundImageStyle;
     private string _descriptionTextStyle;
-    private string _titleTextStyle;
 
     private int _previewCount;
 
     // get the style so it's always at the bottom of the carousel
-    private string _readMoreStyle => "position: absolute; bottom: 1rem; left: 2rem;";
+    // private string _readMoreStyle => "position: absolute; bottom: 1rem; left: 2rem;";
 
     protected override void OnInitialized()
     {
@@ -128,25 +60,25 @@
 
         var hasBackgroundUrl = !string.IsNullOrEmpty(BackgroundUrl);
 
-        _carouselStyle = new StyleBuilder()
-            .AddStyle("height", $"{CarouselHeight}px")
-            .Build();
+        // _carouselStyle = new StyleBuilder()
+        //     .AddStyle("height", $"{CarouselHeight}px")
+        //     .Build();
 
-        _backgroundImageStyle = new StyleBuilder()
-            .AddStyle("height", $"{CarouselHeight}px")
-            .AddStyle("background", $"linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, black 100%), url('{BackgroundUrl}') no-repeat", when: hasBackgroundUrl)
-            .AddStyle("background-size", "cover", when: hasBackgroundUrl)
-            .AddStyle("margin-bottom", "1rem")
-            .Build();
+        // _backgroundImageStyle = new StyleBuilder()
+        //     .AddStyle("height", $"{CarouselHeight}px")
+        //     .AddStyle("background", $"linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, black 100%), url('{BackgroundUrl}') no-repeat", when: hasBackgroundUrl)
+        //     .AddStyle("background-size", "cover", when: hasBackgroundUrl)
+        //     .AddStyle("margin-bottom", "1rem")
+        //     .Build();
 
-        _glassStyle = new StyleBuilder()
-            .AddStyle("height", $"{CarouselHeight}px")
-            .AddStyle("background", "rgba(0, 0, 0, 0.5)", when: hasBackgroundUrl)
-            .AddStyle("color", "white", when: hasBackgroundUrl)
-            .AddStyle("backdrop-filter", "blur(5px)", when: hasBackgroundUrl)
-            .AddStyle("--mud-palette-text-primary", "white", when: hasBackgroundUrl)
-            .AddStyle("--mud-palette-primary", Colors.Purple.Accent2, when: hasBackgroundUrl)
-            .Build();
+        // _glassStyle = new StyleBuilder()
+        //     .AddStyle("height", $"{CarouselHeight}px")
+        //     .AddStyle("background", "rgba(0, 0, 0, 0.5)", when: hasBackgroundUrl)
+        //     .AddStyle("color", "white", when: hasBackgroundUrl)
+        //     .AddStyle("backdrop-filter", "blur(5px)", when: hasBackgroundUrl)
+        //     .AddStyle("--mud-palette-text-primary", "white", when: hasBackgroundUrl)
+        //     .AddStyle("--mud-palette-primary", Colors.Purple.Accent2, when: hasBackgroundUrl)
+        //     .Build();
 
         _descriptionTextStyle = new StyleBuilder()
            .AddStyle("overflow", "hidden")
@@ -154,13 +86,6 @@
            .AddStyle("-webkit-box-orient", "vertical")
            .AddStyle("display", "-webkit-box")
            .Build();
-
-        _titleTextStyle = new StyleBuilder()
-            .AddStyle("overflow", "hidden")
-            .AddStyle("-webkit-line-clamp", "2")
-            .AddStyle("-webkit-box-orient", "vertical")
-            .AddStyle("display", "-webkit-box")
-            .Build();
 
         int count = 0;
         foreach (var preview in Previews)

--- a/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
@@ -25,6 +25,18 @@
     @if (_viewedPortalUser.GraphGuid == _currentUser.GraphGuid)
     {
         <WelcomeBanner/>
+       @*  <MudGrid Class="px-4">
+            <MudItem>
+                <MudStack Class="ma-6">
+                    <MudText Typo="Typo.h2">@Localizer["Most Popular Resources"]</MudText>
+                    <MudText Typo="Typo.body1">
+                        @Localizer["Below you will find a comprehensive list of the most popular resources on the Datahub. If you are looking for something specific, you can also browse the full list of resources on the navigation sidebar."]
+                    </MudText>
+                </MudStack>
+                <ResourcesListView DocumentItems="@_mostPopularDocs" />
+            </MudItem>
+        </MudGrid> *@
+                
     }
     else
     {

--- a/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
@@ -24,19 +24,7 @@
 <MudStack>
     @if (_viewedPortalUser.GraphGuid == _currentUser.GraphGuid)
     {
-        <WelcomeBanner/>
-       @*  <MudGrid Class="px-4">
-            <MudItem>
-                <MudStack Class="ma-6">
-                    <MudText Typo="Typo.h2">@Localizer["Most Popular Resources"]</MudText>
-                    <MudText Typo="Typo.body1">
-                        @Localizer["Below you will find a comprehensive list of the most popular resources on the Datahub. If you are looking for something specific, you can also browse the full list of resources on the navigation sidebar."]
-                    </MudText>
-                </MudStack>
-                <ResourcesListView DocumentItems="@_mostPopularDocs" />
-            </MudItem>
-        </MudGrid> *@
-                
+        <WelcomeBanner/>        
     }
     else
     {

--- a/Portal/src/Datahub.Portal/Pages/Home/WelcomeBanner.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/WelcomeBanner.razor
@@ -26,7 +26,7 @@ else if (_previews.Count == 0)
 }
 else
 {
-    <AnnouncementCarousel Previews="_previews" BackgroundUrl="@_userBackgroundUrl" />
+   <AnnouncementCarousel Previews="_previews" BackgroundUrl="@_userBackgroundUrl" />
 }
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Removing the announcement carousel feature and replacing it with "read more" cards. Formatting changes depending on if there is one card, two, or three:
![image](https://github.com/user-attachments/assets/16cd62e9-621b-4a4a-b4a2-0fa037e18e10)
![image](https://github.com/user-attachments/assets/99d1fe67-e80d-4ba0-92c1-8c6dcd70bb6a)
![image](https://github.com/user-attachments/assets/7f3ae673-06d7-4f97-b1fc-774daf2e4475)


## How Has This Been Tested?
Visually (including removing styling to check screen reader functionality).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [X] PR is submitted to the correct branch `develop`.
- [X] Code follows the code style of this project.
- [X] Changes are covered by Specflow tests and all new or existing tests are passing.
- [X] Any new or updated translatable strings have been added to the localization files.
- [X] Necessary and relevant documentation has been created or updated.
- [X] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
