### PR TITLE
added try/catch around sending messages to Azure Service Bus

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner_PyFunctions/function_app.py
+++ b/ResourceProvisioner/src/ResourceProvisioner_PyFunctions/function_app.py
@@ -82,12 +82,16 @@ def send_exception_to_service_bus(exception_message):
             print(f"Sent message to queue: {queue_name}")
 
 def send_healthcheck_to_service_bus(message):
-    asb_connection_str, check_results_queue_name = get_config()
-    with servicebus.ServiceBusClient.from_connection_string(asb_connection_str, transport_type="AmqpWebSockets") as client:
-        with client.get_queue_sender(check_results_queue_name) as sender:
-            message = servicebus.ServiceBusMessage(message.to_json())
-            sender.send_messages(message)
-            print(f"Sent message to queue: {check_results_queue_name}")
+    try:
+        asb_connection_str, check_results_queue_name = get_config()
+        with servicebus.ServiceBusClient.from_connection_string(asb_connection_str, transport_type="AmqpWebSockets") as client:
+            with client.get_queue_sender(check_results_queue_name) as sender:
+                message = servicebus.ServiceBusMessage(message.to_json())
+                sender.send_messages(message)
+                print(f"Sent message to queue: {check_results_queue_name}")
+        pass
+    except Exception as e:
+        logging.error(f"An error occurred while sending health check to service bus: {e}")
 
 def keys_upper(dictionary):
     """


### PR DESCRIPTION
## Description
Calls to `send_healthcheck_to_service_bus` were failing due to missing config value. To avoid similar issue in future, try/catch is added to let function to proceed 

## How Has This Been Tested?
manually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [ ] Changes are covered by Specflow tests and all new or existing tests are passing.
- [ ] Any new or updated translatable strings have been added to the localization files.
- [ ] Necessary and relevant documentation has been created or updated.
- [ ] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
