### PR TITLE
💻 Make topbar appear in one line on small screens

### DIFF
--- a/Portal/src/Datahub.Portal/Components/LanguageToggle.razor
+++ b/Portal/src/Datahub.Portal/Components/LanguageToggle.razor
@@ -7,11 +7,13 @@
 @inject NavigationManager NavManager
 @inject IJSRuntime _jsRuntime
 
-<DHButton OnClick="() => ChangeLanguage(Language)">
+<DHButton OnClick="() => ChangeLanguage(Language)" Size="@Size">
     @LanguageDisplay
 </DHButton>
 
 @code {
+    [Parameter]
+    public Size Size { get; set; } = Size.Medium;
 
     private static string Language => Thread.CurrentThread.CurrentCulture.Name.ToLower().Contains("fr") ? "en-CA" : "fr-CA";
     private static string LanguageDisplay => Thread.CurrentThread.CurrentCulture.Name.ToLower().Contains("fr") ? "English" : "Français";

--- a/Portal/src/Datahub.Portal/Layout/Topbar/TopBarProfileButton.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/TopBarProfileButton.razor
@@ -43,8 +43,8 @@
             </MudMenuItem>
         </ChildContent>
     </MudMenu> *@
-    <LanguageToggle @ref="_languageToggle" />
-    <DHButton OnClick="@HandleLogOut">
+    <LanguageToggle @ref="_languageToggle" Size="Size.Small" />
+    <DHButton OnClick="@HandleLogOut" Size="Size.Small">
         @Localizer["Sign Out"]
     </DHButton>
 </DatahubAuthView>

--- a/Portal/src/Datahub.Portal/Layout/Topbar/TopBarProfileButton.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/TopBarProfileButton.razor
@@ -43,10 +43,18 @@
             </MudMenuItem>
         </ChildContent>
     </MudMenu> *@
-    <LanguageToggle @ref="_languageToggle" Size="Size.Small" />
-    <DHButton OnClick="@HandleLogOut" Size="Size.Small">
-        @Localizer["Sign Out"]
-    </DHButton>
+    <MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
+        <LanguageToggle @ref="_languageToggle" Size="Size.Small" />
+        <DHButton OnClick="@HandleLogOut" Size="Size.Small">
+            @Localizer["Sign Out"]
+        </DHButton>
+    </MudHidden>
+    <MudHidden Breakpoint="Breakpoint.XlAndUp" Invert="true">
+        <LanguageToggle @ref="_languageToggle" Size="Size.Medium" />
+        <DHButton OnClick="@HandleLogOut" Size="Size.Medium">
+            @Localizer["Sign Out"]
+        </DHButton>
+    </MudHidden>
 </DatahubAuthView>
 
 @code {

--- a/Portal/src/Datahub.Portal/Layout/Topbar/Topbar.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/Topbar.razor
@@ -23,31 +23,60 @@
     <h2 class="sr-only">@Localizer["Navigation menu"]</h2>
     <nav role="navigation">
         <ul style="list-style-type: none">
-            <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Home] Size="Size.Small">
-                    @Localizer["Home"]
-                </DHButton>
-            </li>
-            <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.News] Size="Size.Small">
-                    @Localizer["News"]
-                </DHButton>
-            </li>
-            <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Explore] Size="Size.Small">
-                    @Localizer["Explore"]
-                </DHButton>
-            </li>
-            <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.ResourceDefault] Size="Size.Small">
-                    @Localizer["Learn"]
-                </DHButton>
-            </li>
-            <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.Help] Size="Size.Small">
-                    @Localizer["Support"]
-                </DHButton>
-            </li>
+            <MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Home] Size="Size.Small">
+                        @Localizer["Home"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.News] Size="Size.Small">
+                        @Localizer["News"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Explore] Size="Size.Small">
+                        @Localizer["Explore"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.ResourceDefault] Size="Size.Small">
+                        @Localizer["Learn"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.Help] Size="Size.Small">
+                        @Localizer["Support"]
+                    </DHButton>
+                </li>
+            </MudHidden>
+            <MudHidden Breakpoint="Breakpoint.XlAndUp" Invert="true">
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Home] Size="Size.Medium">
+                        @Localizer["Home"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.News] Size="Size.Medium">
+                        @Localizer["News"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Explore] Size="Size.Medium">
+                        @Localizer["Explore"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.ResourceDefault] Size="Size.Medium">
+                        @Localizer["Learn"]
+                    </DHButton>
+                </li>
+                <li style="display: inline-block; margin-inline: 5px">
+                    <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.Help] Size="Size.Medium">
+                        @Localizer["Support"]
+                    </DHButton>
+                </li>
+            </MudHidden>
         </ul>
     </nav>
 </MudStack>

--- a/Portal/src/Datahub.Portal/Layout/Topbar/Topbar.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/Topbar.razor
@@ -24,27 +24,27 @@
     <nav role="navigation">
         <ul style="list-style-type: none">
             <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Home]>
+                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Home] Size="Size.Small">
                     @Localizer["Home"]
                 </DHButton>
             </li>
             <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.News]>
+                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.News] Size="Size.Small">
                     @Localizer["News"]
                 </DHButton>
             </li>
             <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Explore]>
+                <DHButton Variant="Variant.Text" Href=@Localizer[PageRoutes.Explore] Size="Size.Small">
                     @Localizer["Explore"]
                 </DHButton>
             </li>
             <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.ResourceDefault]>
+                <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.ResourceDefault] Size="Size.Small">
                     @Localizer["Learn"]
                 </DHButton>
             </li>
             <li style="display: inline-block; margin-inline: 5px">
-                <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.Help]>
+                <DHButton Variant="Variant.Text" Href=@Localizer[@PageRoutes.Help] Size="Size.Small">
                     @Localizer["Support"]
                 </DHButton>
             </li>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->

In French, the current contents of the topbar are wider, making it expand into a second line:

![image](https://github.com/user-attachments/assets/af925392-d534-4935-9eda-5b6522b71943)

This PR uses breakpoints and shrinks the button size on smaller size screens:

![image](https://github.com/user-attachments/assets/7febb42f-3f2a-46e5-9181-92cc404c06a2)


## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Visual locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [x] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
