### PR TITLE
🐛 Add regex-based module version matching

### DIFF
--- a/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Testing.cs
+++ b/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Testing.cs
@@ -51,8 +51,8 @@ public class Testing
         _resourceProvisionerConfiguration = new ResourceProvisionerConfiguration();
         _configuration.Bind(_resourceProvisionerConfiguration);
         
-        // Set the resource module branch to the latest branch
-        _resourceProvisionerConfiguration.ModuleRepository.Branch = "v3.5.0";
+        // Set the resource module branch to the latest dev branch
+        _resourceProvisionerConfiguration.ModuleRepository.Branch = "dev";
         
         var httpClientFactory = new Mock<IHttpClientFactory>();
         httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(Mock.Of<HttpClient>());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Enhanced `RepositoryService` to use regular expressions for matching module versions in the repository. Updated comments and added relevant summaries to methods for better clarity. Adjusted unit test configuration to point to the latest development branch.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Unit tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Unit test (new or update to tests)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (change that would cause documentation to be updated)
- [ ] Configuration change (change that would affect the configuration of the application)

<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] PR is submitted to the correct branch `develop`.
- [x] Code follows the code style of this project.
- [x] Changes are covered by Specflow tests and all new or existing tests are passing.
- [x] Any new or updated translatable strings have been added to the localization files.
- [x] Necessary and relevant documentation has been created or updated.
- [x] There are either no changes to the application's configuration or the necessary changes in the infrastructure repository are included in a separate PR.

<!-- Link to the "infrastructure" repository PR here -->
