### PR TITLE
Per-workspace keyvault check

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Datahub.Infrastructure.csproj
+++ b/Portal/src/Datahub.Infrastructure/Datahub.Infrastructure.csproj
@@ -12,6 +12,7 @@
       <PackageReference Include="Azure.ResourceManager.CostManagement" Version="1.0.*" />
       <PackageReference Include="Azure.ResourceManager.Monitor" Version="1.3.*" />
       <PackageReference Include="Azure.ResourceManager.Storage" Version="1.2.*" />
+      <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
       <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
       <PackageReference Include="MassTransit" Version="8.2.*" />
       <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.2.*" />

--- a/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
@@ -676,7 +676,6 @@ namespace Datahub.Infrastructure.Services.Helpers
             {
                 new(InfrastructureHealthResourceType.AzureSqlDatabase, InfrastructureHealthCheckConstants.CoreRequestGroup, InfrastructureHealthCheckConstants.CoreRequestGroup),
                 new(InfrastructureHealthResourceType.AzureKeyVault, InfrastructureHealthCheckConstants.CoreRequestGroup, InfrastructureHealthCheckConstants.CoreRequestGroup),
-                new(InfrastructureHealthResourceType.AzureKeyVault, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, InfrastructureHealthCheckConstants.WorkspacesRequestGroup),
                 new(InfrastructureHealthResourceType.AzureFunction, InfrastructureHealthCheckConstants.CoreRequestGroup, functionAppAddress)
             };
 

--- a/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
@@ -2,6 +2,7 @@
 using Azure.Messaging.ServiceBus;
 using Azure.ResourceManager;
 using Azure.ResourceManager.AppService;
+using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Storage.Queues;
 using Datahub.Application.Configuration;
@@ -33,8 +34,8 @@ namespace Datahub.Infrastructure.Services.Helpers
 
         public const string FSDHFunctionPrefix = "fsdh-func-dotnet";
 
-        public const string WorkspaceKeyCheck = "project-cmk";
-        public const string CoreKeyCheck = "datahubportal-client-id";
+        public const string WorkspaceKeyVaultCheckKeyName = "project-cmk";
+        public const string CoreKeyVaultCheckSecretName = "datahubportal-client-id";
 
         public const string TerraformAzureDatabricksResourceType = "terraform:azure-databricks";
 
@@ -130,24 +131,25 @@ namespace Datahub.Infrastructure.Services.Helpers
                 Environment.SetEnvironmentVariable(InfrastructureHealthCheckConstants.AzureClientIdEnvKey, DevopsClientId);
                 Environment.SetEnvironmentVariable(InfrastructureHealthCheckConstants.AzureClientSecretEnvKey, DevopsClientSecret);
 
-                var client =
-                    new SecretClient(GetAzureKeyVaultUrl(request),
-                        new DefaultAzureCredential()); // Authenticates with Azure AD and creates a SecretClient object for the specified key vault
+                var kvUrl = GetAzureKeyVaultUrl(request);
+                var credential = new DefaultAzureCredential();
 
-                KeyVaultSecret secret;
+                var secretClient = new SecretClient(kvUrl, credential);
+                var keyClient = new KeyClient(kvUrl, credential);
+
                 if (request.Group == InfrastructureHealthCheckConstants.CoreRequestGroup) // Key check for core
                 {
-                    secret = await client.GetSecretAsync(InfrastructureHealthCheckConstants.CoreKeyCheck);
+                    var _ = await secretClient.GetSecretAsync(InfrastructureHealthCheckConstants.CoreKeyVaultCheckSecretName);
                 }
                 else // Key check for workspaces (to verify)
                 {
-                    secret = await client.GetSecretAsync(InfrastructureHealthCheckConstants.WorkspaceKeyCheck);
+                    var _ = await keyClient.GetKeyAsync(InfrastructureHealthCheckConstants.WorkspaceKeyVaultCheckKeyName);
                 }
 
                 try
                 {
-                    // Iterate through the keys in the key vault and check if they are expired
-                    await foreach (var secretProperties in client.GetPropertiesOfSecretsAsync())
+                    // Iterate through the secrets in the key vault and check if they are expired
+                    await foreach (var secretProperties in secretClient.GetPropertiesOfSecretsAsync())
                     {
                         if (secretProperties.ExpiresOn < DateTime.UtcNow)
                         {
@@ -160,10 +162,27 @@ namespace Datahub.Infrastructure.Services.Helpers
                     errors.Add("Unable to retrieve the secrets from the key vault." + ex.GetType().ToString());
                     errors.Add($"Details: {ex.Message}");
                 }
+
+                try
+                {
+                    // Iterate through the keys in the key vault and check if they are expired
+                    await foreach (var keyProperties in keyClient.GetPropertiesOfKeysAsync())
+                    {
+                        if (keyProperties.ExpiresOn < DateTime.UtcNow)
+                        {
+                            errors.Add($"The key {keyProperties.Name} has expired.");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add("Unable to retrieve the keys from the key vault." + ex.GetType().ToString());
+                    errors.Add($"Details: {ex.Message}");
+                }
             }
             catch (Exception ex)
             {
-                errors.Add("Unable to connect and retrieve a secret. " + ex.GetType().ToString());
+                errors.Add("Unable to connect and retrieve a key or secret. " + ex.GetType().ToString());
                 errors.Add($"Details: {ex.Message}");
             }
 
@@ -672,7 +691,8 @@ namespace Datahub.Infrastructure.Services.Helpers
                 new(InfrastructureHealthResourceType.AzureSqlDatabase, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, p.Project_Acronym_CD),
                 new(InfrastructureHealthResourceType.AzureStorageAccount, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, p.Project_Acronym_CD),
                 new(InfrastructureHealthResourceType.AzureDatabricks, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, p.Project_Acronym_CD),
-                new(InfrastructureHealthResourceType.AzureWebApp, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, p.Project_Acronym_CD)
+                new(InfrastructureHealthResourceType.AzureWebApp, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, p.Project_Acronym_CD),
+                new(InfrastructureHealthResourceType.AzureKeyVault, InfrastructureHealthCheckConstants.WorkspacesRequestGroup, p.Project_Acronym_CD)
             });
 
             string[] queuesToCheck =

--- a/Portal/src/Datahub.Portal/Pages/Tools/Health/InfrastructureHealthPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Health/InfrastructureHealthPage.razor
@@ -221,6 +221,7 @@ else
         InfrastructureHealthResourceType.AzureStorageAccount,
         InfrastructureHealthResourceType.AzureWebApp,
         InfrastructureHealthResourceType.WorkspaceSync,
+        InfrastructureHealthResourceType.AzureKeyVault
     };
 
     public bool isLoading { get; set; } = false;


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Fixes per-workspace keyvault check and adds it to the infrastructure health page.

## Related Issues

Task # 6631: Verify per-workspace Keyvault check and add to All Checks for each workspace

## Changes
<!-- List the key changes in this PR -->

- Fix per-workspace keyvault check. Previously, it was trying to fetch a key in the workspace kv using SecretClient, which failed. Now it uses KeyClient which successfully fetches the key.
- Iterates through not only secrets in core and workspace keyvaults, but keys as well, checking if any have expired.
- Add the keyvault check to workspace checks section in the infrastructure health page.

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Manually ran the AzureKeyVault health checks on local deployment

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [ ] Documentation updated (if necessary)
- [ ] Tests added/updated (if necessary)
