### PR TITLE
🔒 Hiding proxy info to non admins

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Tools/Diagnostics/YarpDetails.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Diagnostics/YarpDetails.razor
@@ -9,58 +9,60 @@
 @inject IReverseProxyConfigService _reverseProxyConfigService
 @inject IReverseProxyManagerService ReverseProxyManagerService
 
-@if (_loading)
-{
-    <DHLoadingInitializer Message="Loading Yarp Proxy information..."/>
-}
-else
-{
-    <MudGrid>
-        <MudItem xs="12">
-            <MudText Typo="Typo.h2" Class="mb-6">
-                Yarp Proxy Diagnostics
-            </MudText>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mb-6" OnClick="@(() => ReloadYarpConfig())">
-                Reload Yarp Config
-            </MudButton>
-            @if (_lastError is not null)
-            {
-                <MudText Typo="Typo.subtitle2" Class="mb-6">
-                    Last error: @(_lastError.Value.errorDescription) at @(_lastError.Value.Timestamp)
+<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.DatahubAdmin">
+    @if (_loading)
+    {
+        <DHLoadingInitializer Message="Loading Yarp Proxy information..."/>
+    }
+    else
+    {
+        <MudGrid>
+            <MudItem xs="12">
+                <MudText Typo="Typo.h2" Class="mb-6">
+                    Yarp Proxy Diagnostics
                 </MudText>
-            }
-            else
-            {
-                <MudText Typo="Typo.subtitle2" Class="mb-6">
-                    No errors in Yarp
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mb-6" OnClick="@(() => ReloadYarpConfig())">
+                    Reload Yarp Config
+                </MudButton>
+                @if (_lastError is not null)
+                {
+                    <MudText Typo="Typo.subtitle2" Class="mb-6">
+                        Last error: @(_lastError.Value.errorDescription) at @(_lastError.Value.Timestamp)
+                    </MudText>
+                }
+                else
+                {
+                    <MudText Typo="Typo.subtitle2" Class="mb-6">
+                        No errors in Yarp
+                    </MudText>
+                }
+                <MudText Typo="Typo.caption" Class="mb-6">
+                    Active Routes
                 </MudText>
-            }
-            <MudText Typo="Typo.caption" Class="mb-6">
-                Active Routes
-            </MudText>
-            <MudDataGrid Items="@_telemetryConsumer.GetLastInvokeStats()">
-                <Columns>
-                    <PropertyColumn Property="x => x.route" Title="Route" />
-                    <PropertyColumn Property="x => x.cluster" Title="Cluster" />
-                    <PropertyColumn Property="x => x.timeStamp" Title="Timestamp" />
-                </Columns>
-            </MudDataGrid>
-            <MudText Typo="Typo.caption" Class="mb-6">
-                Workspace routes
-            </MudText>
-            <MudDataGrid Items="@_yarpConfig">
-                <Columns>
-                    <PropertyColumn Property="x => x.Acronym" Title="Workspace" />
-                    <PropertyColumn Property="x => x.Cluster.ClusterId" Title="ClusterId" />
-                    <PropertyColumn Property="x => x.Cluster.Destinations.First().Value" Title="Cluster destination" />
-                    <PropertyColumn Property="x => x.Route.RouteId" Title="RouteId" />
-                    <PropertyColumn Property="x => x.Route.Match.Path" Title="Route Path" />
-                    <PropertyColumn Property="x => FindTransformRemovePrefix(x.Route)" Title="Prefix Removed" />
-                </Columns>
-            </MudDataGrid>
-        </MudItem>
-    </MudGrid>
-}
+                <MudDataGrid Items="@_telemetryConsumer.GetLastInvokeStats()">
+                    <Columns>
+                        <PropertyColumn Property="x => x.route" Title="Route" />
+                        <PropertyColumn Property="x => x.cluster" Title="Cluster" />
+                        <PropertyColumn Property="x => x.timeStamp" Title="Timestamp" />
+                    </Columns>
+                </MudDataGrid>
+                <MudText Typo="Typo.caption" Class="mb-6">
+                    Workspace routes
+                </MudText>
+                <MudDataGrid Items="@_yarpConfig">
+                    <Columns>
+                        <PropertyColumn Property="x => x.Acronym" Title="Workspace" />
+                        <PropertyColumn Property="x => x.Cluster.ClusterId" Title="ClusterId" />
+                        <PropertyColumn Property="x => x.Cluster.Destinations.First().Value" Title="Cluster destination" />
+                        <PropertyColumn Property="x => x.Route.RouteId" Title="RouteId" />
+                        <PropertyColumn Property="x => x.Route.Match.Path" Title="Route Path" />
+                        <PropertyColumn Property="x => FindTransformRemovePrefix(x.Route)" Title="Prefix Removed" />
+                    </Columns>
+                </MudDataGrid>
+            </MudItem>
+        </MudGrid>
+    }
+</DatahubAuthView>
 
 @code
 {


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

This PR hides the Yarp proxy details on the diagnostics page to non-admins

## Related Issues
<!-- List any related issues or tickets -->

[BUG 6954](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/6954)

## Changes
<!-- List the key changes in this PR -->

- Add a DataHubAuthView around the Yarp section.

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Local testing w/ and w/o admin access enabled.

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Documentation updated (if necessary)
- [x] Tests added/updated (if necessary)
