### PR TITLE
:accessibility:  Putting numbers in project details into p tags

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Explore/ProjectPreviewCardIconDetails.razor
+++ b/Portal/src/Datahub.Portal/Pages/Explore/ProjectPreviewCardIconDetails.razor
@@ -4,11 +4,11 @@
         <MudTooltip Text="@Localizer["Number of workspaces remaining"]" Arrow Placement="Placement.Top">
             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <span>
+                    <p>
                         <DHIcon Icon="fa-light fa-layer-plus" Style="font-size: 0.75rem;" Color="Color.Dark"/>
-                        <p class="sr-only">@Localizer["Number of workspaces remaining: "]</p>
+                        <span class="sr-only">@Localizer["Number of workspaces remaining: "]</span>
                         @NumberOfWorkspacesRemaining
-                    </span>
+                    </p>
                 </MudStack>
             </MudChip>
         </MudTooltip>
@@ -18,11 +18,11 @@
         <MudTooltip Text="@Localizer["Number of users in the workspace"]" Arrow Placement="Placement.Top">
             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <span>
-                        <DHIcon Icon="fa-light fa-users" Style="font-size: 0.75rem;" Color="Color.Dark"/>
-                        <p class="sr-only">@Localizer["Number of users in the workspace: "]</p>
+                    <p>
+                        <DHIcon Icon="fa-light fa-users" Style="font-size: 0.75rem;" Color="Color.Dark" Class="mr-1" />
+                        <span class="sr-only">@Localizer["Number of users in the workspace: "]</span>
                         @NumberOfUsers
-                    </span>
+                    </p>
                 </MudStack>
             </MudChip>
         </MudTooltip>
@@ -32,11 +32,11 @@
         <MudTooltip Text="@Localizer["Number of shared repositories"]" Arrow Placement="Placement.Top">
             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <span>
+                    <p>
                         <DHIcon Icon="fa-light fa-code-branch" Style="font-size: 0.75rem;" Color="Color.Dark"/>
-                        <p class="sr-only">@Localizer["Number of shared repositories: "]</p>
+                        <span class="sr-only">@Localizer["Number of shared repositories: "]</span>
                         @NumberOfRepositories
-                    </span>
+                    </p>
                 </MudStack>
             </MudChip>
         </MudTooltip>
@@ -46,11 +46,11 @@
         <MudTooltip Text="@Localizer["Number of shared files"]" Arrow Placement="Placement.Top">
             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Label="true" Color="Color.Dark">
                 <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                    <span>
+                    <p>
                         <DHIcon Icon="fa-light fa-files" Style="font-size: 0.75rem;" Color="Color.Dark"/>
-                        <p class="sr-only">@Localizer["Number of shared files: "]</p>
+                        <span class="sr-only">@Localizer["Number of shared files: "]</span>
                         @NumberOfFiles
-                    </span>
+                    </p>
                 </MudStack>
             </MudChip>
         </MudTooltip>


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

This PR puts the numbers shown in workspace previews into `<p>` tags

## Related Issues
<!-- List any related issues or tickets -->

[USER STORY 6755](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/6755)

## Changes
<!-- List the key changes in this PR -->

- Puts the number into a single `<p>` tag with the screen reader text (which now uses a span)

![image](https://github.com/user-attachments/assets/3b6e5050-3cb4-4654-9421-c98679411e0f)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Documentation updated (if necessary)
- [x] Tests added/updated (if necessary)
