### PR TITLE
Added handling for missing and unknown templates in python sync function

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner_PyFunctions/function_app.py
+++ b/ResourceProvisioner/src/ResourceProvisioner_PyFunctions/function_app.py
@@ -29,7 +29,11 @@ def get_sync_func_mappings():
         "azure-storage-blob": ("storage account policies", sync_storage_workspace_users_function),
         "azure-databricks": ("databricks users", sync_databricks_workspace_users_function)
     }
-    return mappings
+
+    # add prefixed versions of the template keys for compatibility
+    mappings_pre = {f"terraform:{k}": mappings[k] for k in mappings}
+    
+    return {**mappings, **mappings_pre}
 
 @app.function_name(name="SynchronizeWorkspaceUsersHttpTrigger")
 @app.route(route="sync-workspace-users") # HTTP Trigger
@@ -138,21 +142,31 @@ def new_sync_workspace(workspace_definition):
     workspace_name = workspace_definition["Workspace"]["Acronym"]
     logging.info(f"Synchronizing workspace users for {workspace_name}")
 
-    template_names = [t["Name"] for t in workspace_definition["Templates"]]
-    logging.info(f"Got template names: {template_names}")
+    workspace_templates = workspace_definition["Templates"]
+    if not workspace_templates:
+        error_msg = f"Workspace {workspace_name} has no templates"
+        logging.error(error_msg)
+        errors.append(error_msg)
+    else:
+        template_names = [t["Name"] for t in workspace_templates]
+        logging.info(f"Got template names: {template_names}")
 
-    for t in template_names:
-        name, sync_fn = sync_mappings[t]
-        logging.debug(f"name: {name}, func: {sync_fn.__name__}")
+        for t in template_names:
+            if t not in sync_mappings:
+                logging.info(f"Skipping template {t}")
+                continue
 
-        try:
-            logging.info(f"Synchronizing {name} for {workspace_name}.")
-            sync_fn(workspace_definition)
-        except Exception as e:
-            error_msg = f"Error synchronizing {name} for {workspace_name}: {e}"
-            logging.error(error_msg)
-            errors.append(error_msg)
-            send_exception_to_service_bus(error_msg)
+            name, sync_fn = sync_mappings[t]
+            logging.debug(f"name: {name}, func: {sync_fn.__name__}")
+
+            try:
+                logging.info(f"Synchronizing {name} for {workspace_name}.")
+                sync_fn(workspace_definition)
+            except Exception as e:
+                error_msg = f"Error synchronizing {name} for {workspace_name}: {e}"
+                logging.error(error_msg)
+                errors.append(error_msg)
+                send_exception_to_service_bus(error_msg)
     
     errors_joined = ERROR_DETAILS_JOINER.join(errors)
     health_status = hcm.HealthcheckMessage.STATUS_UNHEALTHY if errors_joined else hcm.HealthcheckMessage.STATUS_HEALTHY


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Fixes recurring errors in the Python sync function from missing or unknown project templates.

## Related Issues
<!-- List any related issues or tickets -->

Issue #6977: KeyErrors in some workspace definitions in Python function

## Changes
<!-- List the key changes in this PR -->

- Add support for template names prefixed with "terraform:"
- Log unhealthy status when project definition has no templates
- Skip unsupported templates (e.g. "terraform:azure-app-service" has nothing to sync)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Tested sync function with known working payloads as well as ones that had previously caused errors

## Checklist
<!-- Ensure the following tasks are complete -->

- [ ] I have run `Datahub.MissingTranslations` and verified there are no missing translations
- [x] Code follows dotnet coding standards
- [ ] Documentation updated (if necessary)
- [ ] Tests added/updated (if necessary)
