### PR TITLE
🐛 Normalize resource type in ToTerraformTemplate method

### DIFF
--- a/Portal/src/Datahub.Core/Model/Projects/Project_Resources.cs
+++ b/Portal/src/Datahub.Core/Model/Projects/Project_Resources.cs
@@ -50,7 +50,7 @@ public class Project_Resources2
     /// <returns>A new instance of TerraformTemplate with the ResourceType and Status properties set.</returns>
     public TerraformTemplate ToTerraformTemplate()
     {
-        return new TerraformTemplate(ResourceType, Status);
+        return new TerraformTemplate(TerraformTemplate.NormalizeTemplateName(ResourceType), Status);
     }
 }
 

--- a/Portal/test/Datahub.SpecflowTests/Steps/WorkspaceDefinitionSteps.cs
+++ b/Portal/test/Datahub.SpecflowTests/Steps/WorkspaceDefinitionSteps.cs
@@ -58,7 +58,7 @@ public class WorkspaceDefinitionSteps(
         var workspaceDefinition = scenarioContext["workspaceDefinition"] as WorkspaceDefinition;
         workspaceDefinition!.Templates
             .Any(t => 
-                t.Name.EndsWith(TerraformTemplate.NewProjectTemplate) 
+                t.Name.Equals(TerraformTemplate.NewProjectTemplate) 
                 && t.Status == TerraformTemplate.TemplateStatus.Created)
             .Should()
             .BeTrue();


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->
Updated the ToTerraformTemplate method to normalize the resource type before passing it to the TerraformTemplate constructor. This ensures consistency in resource naming and prevents potential issues with case sensitivity or formatting in other systems.

## Related Issues
<!-- List any related issues or tickets -->

## Changes
<!-- List the key changes in this PR -->

- Added normalization when building the workspace definition
- Updated unit test to catch the bug

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Visual check
- Unit tests

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] I have run `Datahub.MissingTranslations` and verified there are no missing translations
- [x] Code follows dotnet coding standards
- [x] Documentation updated (if necessary)
- [x] Tests added/updated (if necessary)
