### PR TITLE
🐛 Prioritize 'new-project-template' module execution

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/RepositoryService.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/RepositoryService.cs
@@ -444,6 +444,9 @@ public partial class RepositoryService : IRepositoryService
         var repositoryUpdateEvents = new List<RepositoryUpdateEvent>();
 
         await ValidateWorkspaceVersion(terraformWorkspace);
+        
+        // Execute each module but make sure the `new-project-template` module is first
+        modules = modules.OrderBy(x => x.Name != TerraformTemplate.NewProjectTemplate).ToList();
 
         foreach (var module in modules)
         {


### PR DESCRIPTION
Ensure 'new-project-template' module is executed first by reordering the modules list. This change improves the setup sequence, increasing reliability for new projects.