### PR TITLE
🐛 Fixing links to /news

### DIFF
--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -109,7 +109,7 @@
 
     private void HandleReadMore(int newId)
     {
-        _navigationManager.NavigateTo(Localizer["/announcements"]); // $"/news/{newId}"
+        _navigationManager.NavigateTo(Localizer[PageRoutes.News]); // $"/news/{newId}"
     }
 
 }

--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -109,7 +109,7 @@
 
     private void HandleReadMore(int newId)
     {
-        _navigationManager.NavigateTo("/news"); // $"/news/{newId}"
+        _navigationManager.NavigateTo(Localizer["/announcements"]); // $"/news/{newId}"
     }
 
 }

--- a/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementEditor.razor
+++ b/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementEditor.razor
@@ -132,7 +132,7 @@
         {
             if (Id != "new")
             {
-                _navigationManager.NavigateTo(Localizer["/announcements"]);
+                _navigationManager.NavigateTo(Localizer[PageRoutes.News]);
             }
             else
             {
@@ -207,7 +207,7 @@
         if (success)
         {
             _snackbar.Add(Localizer["Article saved"], Severity.Success);
-            _navigationManager.NavigateTo(Localizer["/announcements"]);
+            _navigationManager.NavigateTo(Localizer[PageRoutes.News]);
         }
         else
         {

--- a/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementEditor.razor
+++ b/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementEditor.razor
@@ -132,7 +132,7 @@
         {
             if (Id != "new")
             {
-                _navigationManager.NavigateTo("/news");
+                _navigationManager.NavigateTo(Localizer["/announcements"]);
             }
             else
             {
@@ -207,7 +207,7 @@
         if (success)
         {
             _snackbar.Add(Localizer["Article saved"], Severity.Success);
-            _navigationManager.NavigateTo("/news");
+            _navigationManager.NavigateTo(Localizer["/announcements"]);
         }
         else
         {


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

There are two incorrect redirects to `/news` instead of `/announcements`:
- Read more on home page
- Redirect after saving an announcement (for admins, it still saves properly)

## Related Issues
<!-- List any related issues or tickets -->

## Changes
<!-- List the key changes in this PR -->

- Swaps `/news` links to `Localizer["/announcements"]`

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

Tested locally

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Documentation updated (if necessary)
- [x] Tests added/updated (if necessary)
