### PR TITLE
🐛 (Hotfix) Re-enabling ADO posting

### DIFF
--- a/ServerlessOperations/src/Datahub.Functions/BugReport.cs
+++ b/ServerlessOperations/src/Datahub.Functions/BugReport.cs
@@ -27,7 +27,7 @@ namespace Datahub.Functions
         // TODO: enable configuration of these toggles
         private bool _postToTeams = true;
         private bool _sendEmailNotification = true;
-        private bool _postToDevops = false;
+        private bool _postToDevops = true;
 
         [Function("BugReport")]
         public async Task Run(


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->
ADO posting is currently disabled in the code. This PR enables it.

## Related Issues
<!-- List any related issues or tickets -->
none

## Changes
<!-- List the key changes in this PR -->

- Change `_postToDevops` to `true`

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Documentation updated (if necessary)
- [x] Tests added/updated (if necessary)
