### PR TITLE
🐛 Hotfix to handle <strong> tag appearing in bug reports

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Help/IssueForDisplaying.cs
+++ b/Portal/src/Datahub.Portal/Pages/Help/IssueForDisplaying.cs
@@ -40,22 +40,6 @@ namespace Datahub.Portal.Pages.Help
         /// </summary>
         public string ChangedDate { get; set; }
 
-        /// <summary>
-        /// Initializes a new instance of the IssueForDisplaying class.
-        /// </summary>
-        /// <param name="workItemDetails">The JObject containing the work item details.</param>
-        /// <param name="userView">A flag indicating whether the user view is enabled or not.</param>
-        public IssueForDisplaying(JObject workItemDetails, bool userView = true)
-        {
-            Id = (string)workItemDetails["id"];
-            Title = (string)workItemDetails["fields"]["System.Title"];
-            Description = CreateUserDescription((string)workItemDetails["fields"]["System.Description"]);
-            State = (string)workItemDetails["fields"]["System.State"];
-            Message = userView == true ? GetUserHelpStatusMessage(State) : State;
-            SubmittedDate = (string)workItemDetails["fields"]["System.CreatedDate"];
-            ChangedDate = (string)workItemDetails["fields"]["System.ChangedDate"]; ;
-        }
-
         public IssueForDisplaying(WorkItem workItem, bool userView = true)
         {
             Id = workItem.Id.ToString();

--- a/Portal/src/Datahub.Portal/Pages/Help/IssueForDisplaying.cs
+++ b/Portal/src/Datahub.Portal/Pages/Help/IssueForDisplaying.cs
@@ -49,7 +49,7 @@ namespace Datahub.Portal.Pages.Help
         {
             Id = (string)workItemDetails["id"];
             Title = (string)workItemDetails["fields"]["System.Title"];
-            Description = (string)workItemDetails["fields"]["System.Description"];
+            Description = CreateUserDescription((string)workItemDetails["fields"]["System.Description"]);
             State = (string)workItemDetails["fields"]["System.State"];
             Message = userView == true ? GetUserHelpStatusMessage(State) : State;
             SubmittedDate = (string)workItemDetails["fields"]["System.CreatedDate"];

--- a/Portal/src/Datahub.Portal/Pages/Help/IssueForDisplaying.cs
+++ b/Portal/src/Datahub.Portal/Pages/Help/IssueForDisplaying.cs
@@ -49,9 +49,7 @@ namespace Datahub.Portal.Pages.Help
         {
             Id = (string)workItemDetails["id"];
             Title = (string)workItemDetails["fields"]["System.Title"];
-            var description = (string)workItemDetails["fields"]["System.Description"];
-            description = description.Split("<b>Description:</b> ")[1].Split("<br>")[0];
-            Description = TrimDescription(description);
+            Description = (string)workItemDetails["fields"]["System.Description"];
             State = (string)workItemDetails["fields"]["System.State"];
             Message = userView == true ? GetUserHelpStatusMessage(State) : State;
             SubmittedDate = (string)workItemDetails["fields"]["System.CreatedDate"];
@@ -62,13 +60,30 @@ namespace Datahub.Portal.Pages.Help
         {
             Id = workItem.Id.ToString();
             Title = workItem.Fields["System.Title"].ToString();
-            var description = workItem.Fields["System.Description"].ToString();
-            description = description.Split("<b>Description:</b> ")[1].Split("<br>")[0];
-            Description = TrimDescription(description);
+            Description = CreateUserDescription(workItem.Fields["System.Description"].ToString());
             State = workItem.Fields["System.State"].ToString();
             Message = userView == true ? GetUserHelpStatusMessage(State) : State;
             SubmittedDate = workItem.Fields["System.CreatedDate"].ToString();
             ChangedDate = workItem.Fields["System.ChangedDate"].ToString();
+        }
+
+        /// <summary>
+        /// Retrieves the original description provided by the user.
+        /// </summary>
+        /// <param name="description">The full description from ADO</param>
+        /// <returns></returns>
+        private string CreateUserDescription(string description)
+        {
+            string temp;
+            try
+            {
+                temp = description.Split("<b>Description:</b> ")[1].Split("<br>")[0];
+            }
+            catch
+            {
+                temp = description.Split("<strong>Description:</strong> ")[1].Split("<br>")[0];
+            }
+            return TrimDescription(temp);
         }
 
         /// <summary>

--- a/Portal/test/Datahub.SpecflowTests/Features/SupportRequest.feature
+++ b/Portal/test/Datahub.SpecflowTests/Features/SupportRequest.feature
@@ -12,3 +12,11 @@ Scenario: Submit a support request
 	Then I should receive a confirmation message that my request has been submitted
 	And the support team should receive an email with my request
 	And the support request should be added to Azure DevOps
+
+Scenario: Handle old support requests that use <b> tags in issue parsing
+	Given I have an old support request with <b> tags in the description
+	Then it should parse the description properly
+
+Scenario: Handle new support requests that use <strong> tags in issue parsing   
+	Given I create a new workitem that uses <strong> tags in the description    
+	Then it should parse the description properly

--- a/Portal/test/Datahub.SpecflowTests/Features/SupportRequest.feature
+++ b/Portal/test/Datahub.SpecflowTests/Features/SupportRequest.feature
@@ -1,0 +1,14 @@
+Feature: Support Request
+	The Support Request Page allows users to submit a support request to the support team. The support team will receive the request and respond to the user via email. The user can also view their support request history.
+
+Scenario: Display the previous support requests on load
+	Given I have submitted support requests in the past
+	When I navigate to the Support Request Page
+	Then I should see a list of all my previous support requests and their status
+
+Scenario: Submit a support request
+	Given I am on the Support Request Page
+	When I fill out the support request form and submit it
+	Then I should receive a confirmation message that my request has been submitted
+	And the support team should receive an email with my request
+	And the support request should be added to Azure DevOps


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Currently, new bug reports are created that use `<strong>`, but parsing the description expects it to be `<b>`. This PR fixes this issue.

## Related Issues
<!-- List any related issues or tickets -->

[BUG 8044](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/8044)

## Changes
<!-- List the key changes in this PR -->

- Adds a `try` and `catch` to use `<strong>` if `<b>` fails
- Cleans up the code a bit

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Tested locally.
- New support requests are handled properly (ex Issue 8040).
- Old support requests are also handled properly.

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
