### PR TITLE
Script to deal with powershell restriction policies

### DIFF
--- a/gen-all-settings.vbs
+++ b/gen-all-settings.vbs
@@ -1,0 +1,10 @@
+' Create a Wscript.Shell object to run external programs
+Set objShell = CreateObject("Wscript.Shell")
+
+' Run PowerShell with:
+' -noexit: Keep the window open
+' -ExecutionPolicy Bypass: Bypass script execution restrictions
+' -File: Run the specified script in the current directory
+' Ensure the script is in the same directory or provide the full path.
+
+objShell.run "powershell -noexit -ExecutionPolicy Bypass -File .\gen-all-settings.ps1"


### PR DESCRIPTION
# Pull Request

## Description
Script to deal with powershell restriction policies

## Related Issues
Cant run script from corporate desktops because of powershell restriction policy

## Changes
Use VBS to launch powershell

## Testing
works for me 

before 
![image](https://github.com/user-attachments/assets/3bf19a3b-3b1e-4555-9a45-30e883cfb712)

after 
![image](https://github.com/user-attachments/assets/341c8c88-398c-4d62-b503-80d7cb68d841)

## Checklist
<!-- Ensure the following tasks are complete -->

- [X] Code follows dotnet coding standards
- [X] Tests added/updated to cover changes
No tests for this 🙏
