### PR TITLE
Fix code scanning alert no. 14: Log entries created from user input

### DIFF
--- a/Portal/src/Datahub.Portal/Controllers/PublicController.cs
+++ b/Portal/src/Datahub.Portal/Controllers/PublicController.cs
@@ -74,7 +74,7 @@ public class PublicController: Controller
             var result = await _pubFileService.DownloadPublicUrlSharedFile(fileIdGuid, remoteIp);
             if (result == null)
             {
-                _logger.LogError($"File not found: {fileId}");
+                _logger.LogError($"File not found: {fileId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}");
                 return NotFound();
             }
             else
@@ -84,7 +84,7 @@ public class PublicController: Controller
         }
         catch (FormatException)
         {
-            _logger.LogError($"Invalid file id (not a guid): {fileId}");
+            _logger.LogError($"Invalid file id (not a guid): {fileId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}");
             return NotFound();
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/ssc-sp/datahub-portal/security/code-scanning/14](https://github.com/ssc-sp/datahub-portal/security/code-scanning/14)

To fix the problem, we need to sanitize the `fileId` before logging it. Since the log entries are plain text, we should remove any newline characters from the `fileId` to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
