### PR TITLE
Fix code scanning alert no. 11: Log entries created from user input

### DIFF
--- a/Portal/src/Datahub.Portal/Controllers/PrivateStorageController.cs
+++ b/Portal/src/Datahub.Portal/Controllers/PrivateStorageController.cs
@@ -36,7 +36,8 @@ public class PrivateStorageController : Controller
             var result = await _pubFileService.DownloadPublicUrlSharedFile(fileIdGuid, remoteIp);
             if (result == null)
             {
-                _logger.LogError($"File not found: {fileId}");
+                var sanitizedFileId = fileId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                _logger.LogError($"File not found: {sanitizedFileId}");
                 return NotFound();
             }
             else
@@ -46,7 +47,8 @@ public class PrivateStorageController : Controller
         }
         catch (FormatException)
         {
-            _logger.LogError($"Invalid file id (not a guid): {fileId}");
+            var sanitizedFileId = fileId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            _logger.LogError($"Invalid file id (not a guid): {sanitizedFileId}");
             return NotFound();
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/ssc-sp/datahub-portal/security/code-scanning/11](https://github.com/ssc-sp/datahub-portal/security/code-scanning/11)

To fix the problem, we need to sanitize the `fileId` before logging it. Since the log entries are plain text, we should remove any newline characters from the `fileId` to prevent log forging. This can be done using the `Replace` method to remove newline characters from the `fileId` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
