### PR TITLE
🔧 Switching the hosting services controller to use Route and moving Authorize to method

### DIFF
--- a/Portal/src/Datahub.Portal/Controllers/HostingServicesController.cs
+++ b/Portal/src/Datahub.Portal/Controllers/HostingServicesController.cs
@@ -4,14 +4,14 @@ using Microsoft.AspNetCore.Authorization;
 namespace Datahub.Portal.Controllers;
 
 [ApiController]
-[Authorize]
 public class HostingServicesController : ControllerBase
 {
     /// <summary>
     /// Handles the authenticated HTTP POST request to the "api/auth-echo" endpoint.
     /// </summary>
     /// <returns>The IActionResult representing the response.</returns>
-    [HttpPost("api/auth-echo")]
+    [Route("api/auth-echo")]
+    [Authorize]
     public async Task<IActionResult> PostAuth()
     {
         return await ProcessRequest(Request);
@@ -21,7 +21,7 @@ public class HostingServicesController : ControllerBase
     /// Handles the anonymous HTTP POST request to the "api/anon-echo" endpoint.
     /// </summary>
     /// <returns></returns>
-    [HttpPost("api/anon-echo")]
+    [Route("api/anon-echo")]
     [AllowAnonymous]
     public async Task<IActionResult> PostAnon()
     {


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

This PR implements a fix for the endpoint used for hosting services calls.

## Related Issues
<!-- List any related issues or tickets -->

n/a

## Changes
<!-- List the key changes in this PR -->

- Swaps the endpoints to use `Route` instead of `HttpPost`
- Moves `[Authorize]` to the method, rather than the controller

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested and validated with Python `requests` library.
- Passing SpecFlow tests locally.
- No new tests added, behaviour already covered.

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
