### PR TITLE
Update .NET Core SDK version to 8.0.1

### DIFF
--- a/pipelines/ado-dsd-fsdh-dev-ci-linux.yml
+++ b/pipelines/ado-dsd-fsdh-dev-ci-linux.yml
@@ -30,9 +30,9 @@ jobs:
     lfs: true
     fetchTags: false
   - task: UseDotNet@2
-    displayName: Use .NET Core sdk 8.0.x
+    displayName: Use .NET Core sdk 8.0.1
     inputs:
-      version: 8.0.x
+      version: 8.0.1
       includePreviewVersions: true
       performMultiLevelLookup: true
   - task: UseNode@1

--- a/pipelines/fsdh-portal-tests.yml
+++ b/pipelines/fsdh-portal-tests.yml
@@ -10,9 +10,9 @@ steps:
       azurePowerShellVersion: 'LatestVersion'
       
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 8.0.x'
+    displayName: 'Use .NET Core sdk 8.0.1'
     inputs:
-      version: 8.0.x
+      version: 8.0.1
       includePreviewVersions: true
       performMultiLevelLookup: true
 

--- a/pipelines/fsdh-resource-provisioner-tests.yml
+++ b/pipelines/fsdh-resource-provisioner-tests.yml
@@ -10,9 +10,9 @@ steps:
       azurePowerShellVersion: 'LatestVersion'  
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 8.0.x'
+    displayName: 'Use .NET Core sdk 8.0.1'
     inputs:
-      version: 8.0.x
+      version: 8.0.1
       includePreviewVersions: true
       performMultiLevelLookup: true
 


### PR DESCRIPTION
Changed .NET Core SDK version specification from 8.0.x to 8.0.1 across multiple pipeline configuration files. This ensures consistency and precision in the SDK version used.

