### PR TITLE
🌐 Removing outdated note from workspace metadata editor

### DIFF
--- a/Portal/src/Datahub.Portal.Metadata/Components/MetadataEditor.razor
+++ b/Portal/src/Datahub.Portal.Metadata/Components/MetadataEditor.razor
@@ -6,15 +6,6 @@
 @if (Definitions != null && FieldValues != null && Profile != null)
 {
     <MudStack>
-        @if (_showTranslationNote)
-        {
-            <MudItem Class="mb-4">
-                <MudAlert Severity="Severity.Info" Icon="@Icons.Material.Filled.GTranslate">
-                    @(new MarkupString(Localizer["METADATA-PAGE.TranslationNote"]))
-                </MudAlert>
-            </MudItem>
-        }
-
         @{ _totalFields = 0; }
 
         @foreach (var s in Profile.Sections)


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

The text explaining the metadata auto-translate feature was removed from localization but the alert was still present.

This PR removes the alert from the metadata page.

## Related Issues
<!-- List any related issues or tickets -->

BUG 8127

## Changes
<!-- List the key changes in this PR -->

- Removes the note from the metadata editor

Before:

![image](https://github.com/user-attachments/assets/a3d2406d-5f83-410a-9a4d-731591d1ae64)

After:

![image](https://github.com/user-attachments/assets/744219d2-67f2-4d2f-905f-d2d781fa8e6b)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally validated
- No changes to tests needed

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
