### PR TITLE
🔧 Code owner change, workspace creation redirect, fix Azure subscription admin tool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 /.github/CODEOWNERS @KingBain
 
-*       @ErikApption @Sean-Stilwell @davidreneuw @yjmrobert
+*       @ErikApption @Sean-Stilwell @davidreneuw @gcnabeel
 

--- a/Portal/src/Datahub.Portal/Pages/Tools/AzureSubscriptionManagement/AzureSubscriptionsPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/AzureSubscriptionManagement/AzureSubscriptionsPage.razor
@@ -11,9 +11,18 @@
     <MudText Typo="Typo.h2">DataHub Azure Subscriptions</MudText>
     <MudText>This page shows the current Azure subscriptions that are being monitored by the DataHub service.</MudText>
 
-    <MudText Class="my-6">
-        The active subscription for new workspaces is <code>@_activeSubscription?.Nickname (@_activeSubscription?.SubscriptionName)</code>
-    </MudText>
+    @if (!_outOfSubscriptions)
+    {
+        <MudText Class="my-6">
+            The active subscription for new workspaces is <code>@_activeSubscription?.Nickname (@_activeSubscription?.SubscriptionName)</code>
+        </MudText>
+    }
+    else
+    {
+        <MudText Class="my-6">
+            There are no active subscriptions for new workspaces. Please add a new subscription.
+        </MudText>
+    }
 
     <CreateAzureSubscription OnSubscriptionSubmitted="@HandleSubscriptionSubmitted"/>
 
@@ -97,6 +106,7 @@
     private List<DatahubAzureSubscription> _subscriptions;
     private DatahubAzureSubscription _elementBeforeEdit;
     private DatahubAzureSubscription _activeSubscription;
+    private bool _outOfSubscriptions = false;
 
     private readonly Dictionary<string, int> _numberOfWorkspaceRemaining = new();
 
@@ -104,7 +114,15 @@
     {
         await base.OnInitializedAsync();
         _subscriptions = await _datahubAzureSubscriptionService.ListSubscriptionsAsync();
-        _activeSubscription = await _datahubAzureSubscriptionService.NextSubscriptionAsync();
+        try
+        {
+            _activeSubscription = await _datahubAzureSubscriptionService.NextSubscriptionAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to get the next subscription");
+            _outOfSubscriptions = true;
+        }
 
         // Get the number of workspaces remaining for each subscription
         foreach (var subscription in _subscriptions)

--- a/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
@@ -171,7 +171,7 @@
             {
                 await _projectCreationService.SaveProjectCreationDetailsAsync(_projectAcronym, _interestedFeatures);
                 //MudDialog.Close(DialogResult.Ok(_projectAcronym));
-                _navigationManager.NavigateTo(PageRoutes.Home);
+                _navigationManager.NavigateTo(PageRoutes.WorkspaceDefault.Replace("{WorkspaceAcronymParam}", _projectAcronym));
             }
             else
             {


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->
Removes Yannick from CODEOWNERS file and adds @gcnabeel (I don't know if this is the account he will use). While testing I also noticed that the workspace creation form redirects to home instead of to the new workspace that is created, so I fixed that. There has also been an issue with the Admin tool Yannick made for Azure subscription where if there is no more space in the subs, the tool would fail to open (making it impossible to add new subscriptions), so I fixed that as well

## Related Issues
<!-- List any related issues or tickets -->

## Changes
<!-- List the key changes in this PR -->

- Replaces Yannick with Nabeel
- Fixes the redirect on project creation to redirect to the actual workspace
- Fixes an error we had with the Azure sub admin tool

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- All existing tests pass

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
