### PR TITLE
🐛 Hotfix to hide budget warning from users not in the workspace

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/WorkspaceInfo.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WorkspaceInfo.razor
@@ -13,7 +13,9 @@
             @_project?.ProjectName
         </MudText>
     </DHMainContentTitle>
-    <WorkspaceBudgetAlert PercentBudgetSpent="@_percentBudgetSpent"/>
+    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronym">
+        <WorkspaceBudgetAlert PercentBudgetSpent="@_percentBudgetSpent"/>
+    </DatahubAuthView>
     <DHMarkdown class="description" Content="@_projectDescription"/>
 </MudStack>
 


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Currently, all users are able to see the budget warning in a workspace:

![image](https://github.com/user-attachments/assets/ef5c732c-0a8d-4a37-9469-bbdeb203f980)

This PR hides this warning to users who aren't guest or higher in the workspace.

## Related Issues
<!-- List any related issues or tickets -->

[Bug 8249](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/8249)

## Changes
<!-- List the key changes in this PR -->

- Add DatahubAuthView for workspace guest or higher around budget warning

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested using DIE2 workspace

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
