### PR TITLE
Fix PathNotFound when switching storage containers

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor.cs
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor.cs
@@ -34,6 +34,7 @@ public partial class FileExplorer
     {
         if (_lastContainer != Container)
         {
+            _currentFolder = _root;
             await RefreshStoragePageAsync();
         }            
     }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor.cs
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor.cs
@@ -34,8 +34,7 @@ public partial class FileExplorer
     {
         if (_lastContainer != Container)
         {
-            _currentFolder = _root;
-            await RefreshStoragePageAsync();
+            await SetCurrentFolder(_root);
         }            
     }
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorerPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorerPage.razor
@@ -62,37 +62,38 @@
                             {
                                 <FileExplorer ProjectId=@_projectId Container="@_selectedContainer"/>
                             }
-                            </MudTabPanel>
-                            <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym">
-                                @if (SelectedContainer is null || SelectedContainer.StorageManager.AzCopyEnabled)
-                                {
-                                    <MudTabPanel Text="@Localizer["AzCopy"]" Icon="fas fa-info-circle">
-                                        <MudStack Class="py-6 px-2">
-                                            <AzCopy Container=@SelectedContainer 
-                                                TermsAcknowledged=@_tokenTermsAcknowledged 
-                                                OnTermsAccepted=@AgreeToAccessTokenTerms />
-                                        </MudStack>
-                                    </MudTabPanel>
-                                }
-                                @if (SelectedContainer is null || SelectedContainer.StorageManager.DatabrickEnabled)
-                                {
-                                    <MudTabPanel Text="@Localizer["Databricks Access"]" Icon="fas fa-info-circle">
-                                        <MudStack Class="py-6 px-2">
-                                            <Databricks Container="@SelectedContainer"/>
-                                        </MudStack>
-                                    </MudTabPanel>
-                                }
-                                @if (SelectedContainer is null || SelectedContainer.StorageManager.AzCopyEnabled)
-                                {
-                                    <MudTabPanel Text="@Localizer["DataHub Uploader"]" Icon="fas fa-info-circle">
-                                        <MudStack Class="py-6 px-2">
-                                            <UploaderCode Container=@SelectedContainer/>
-                                        </MudStack>
-                                    </MudTabPanel>
-                                }
-                            </DatahubAuthView>
-                        </MudTabs>
-                    }
+                        </MudTabPanel>
+                        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym">
+                            @if (SelectedContainer is null || SelectedContainer.StorageManager.AzCopyEnabled)
+                            {
+                                <MudTabPanel Text="@Localizer["AzCopy"]" Icon="fas fa-info-circle">
+                                    <MudStack Class="py-6 px-2">
+                                        <AzCopy Container=@SelectedContainer 
+                                            TermsAcknowledged=@_tokenTermsAcknowledged 
+                                            OnTermsAccepted=@AgreeToAccessTokenTerms />
+                                    </MudStack>
+                                </MudTabPanel>
+                            }
+                            @if (SelectedContainer is null || SelectedContainer.StorageManager.DatabrickEnabled)
+                            {
+                                <MudTabPanel Text="@Localizer["Databricks Access"]" Icon="fas fa-info-circle">
+                                    <MudStack Class="py-6 px-2">
+                                        <Databricks Container="@SelectedContainer"/>
+                                    </MudStack>
+                                </MudTabPanel>
+                            }
+                            @if (SelectedContainer is null || SelectedContainer.StorageManager.AzCopyEnabled)
+                            {
+                                <MudTabPanel Text="@Localizer["DataHub Uploader"]" Icon="fas fa-info-circle">
+                                    <MudStack Class="py-6 px-2">
+                                        <UploaderCode Container=@SelectedContainer
+                                            TermsAcknowledged=@_tokenTermsAcknowledged
+                                            OnTermsAccepted=@AgreeToAccessTokenTerms />
+                                    </MudStack>
+                                </MudTabPanel>
+                            }
+                        </DatahubAuthView>
+                    </MudTabs>
                 </MudPaper>
             </CascadingValue>
         </CascadingValue>
@@ -122,7 +123,7 @@
     private bool _failedToLoadContainers = false;
     private bool MultiContainer => _cloudContainers?.Count > 1;
     private bool _isUserProjectAdmin = false;
-    private bool ShouldShowContainerDropdown => _loading && (MultiContainer || _isUserProjectAdmin);
+    private bool ShouldShowContainerDropdown => !_loading && (MultiContainer || _isUserProjectAdmin);
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

When switching between containers in Storage Explorer, if the user had navigated to a path that wasn't present in the new container, it would throw a PathNotFound exception. With this update, switching containers will reset the path to root every time to prevent this. Also fixed a couple minor bugs.

## Related Issues
<!-- List any related issues or tickets -->
Bug 8237 - PathNotFound when switching storage containers in Storage Explorer
Task 8347 - Fix PathNotFound error in Storage Explorer
Issue 8359 - Storage container dropdown not showing when multiple containers are present


## Changes
<!-- List the key changes in this PR -->

- Fix the PathNotFound issue
- Restored storage container dropdown - it was not showing for workspaces with multiple storage containers
- Fixed some issues likely caused by a merge conflict: stray "}" character showing up in storage explorer as well as missing parameters on UploaderCode component

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Tested by navigating around storage and changing containers

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
