### PR TITLE
🔧 Renaming ShowToAdmins to ElevatedWorkspaceAccessEnabled

### DIFF
--- a/Portal/src/Datahub.Core/Components/AuthViews/DatahubAuthView.razor
+++ b/Portal/src/Datahub.Core/Components/AuthViews/DatahubAuthView.razor
@@ -36,7 +36,7 @@
     public string UserGraphId { get; set; }
 
     [Parameter]
-    public bool ShowToAdmins { get; set; } = false;
+    public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     public enum AuthLevels
     {
@@ -77,25 +77,25 @@
         var collaboratorRole = $"{ProjectAcronym}{RoleConstants.COLLABORATOR_SUFFIX}";
         var adminRole = $"{ProjectAcronym}{RoleConstants.ADMIN_SUFFIX}";
         var workspaceLeadRole = $"{ProjectAcronym}{RoleConstants.WORKSPACE_LEAD_SUFFIX}";
-        var datahubAdminRole = RoleConstants.DATAHUB_ROLE_ADMIN;
+        var datahubSupportRole = RoleConstants.DATAHUB_ROLE_ADMIN;
         var datahubAdminAsGuestRole = RoleConstants.DATAHUB_ROLE_ADMIN_AS_GUEST;
 
         switch (AuthLevel)
         {
             case AuthLevels.Personal:
-                return $"{UserGraphId},{datahubAdminRole}";
+                return $"{UserGraphId},{datahubSupportRole}";
             case AuthLevels.WorkspaceGuest:
-                return ShowToAdmins ? $"{guestRole},{collaboratorRole},{adminRole},{workspaceLeadRole},{datahubAdminRole}" : $"{guestRole},{collaboratorRole},{adminRole},{workspaceLeadRole}";
+                return ElevatedWorkspaceAccessEnabled ? $"{guestRole},{collaboratorRole},{adminRole},{workspaceLeadRole},{datahubSupportRole}" : $"{guestRole},{collaboratorRole},{adminRole},{workspaceLeadRole}";
             case AuthLevels.WorkspaceCollaborator:
-                return ShowToAdmins ? $"{collaboratorRole},{adminRole},{workspaceLeadRole},{datahubAdminRole}" : $"{collaboratorRole},{adminRole},{workspaceLeadRole}";
+                return ElevatedWorkspaceAccessEnabled ? $"{collaboratorRole},{adminRole},{workspaceLeadRole},{datahubSupportRole}" : $"{collaboratorRole},{adminRole},{workspaceLeadRole}";
             case AuthLevels.WorkspaceAdmin:
-                return ShowToAdmins ? $"{adminRole},{workspaceLeadRole},{datahubAdminRole}" : $"{adminRole},{workspaceLeadRole}";
+                return ElevatedWorkspaceAccessEnabled ? $"{adminRole},{workspaceLeadRole},{datahubSupportRole}" : $"{adminRole},{workspaceLeadRole}";
             case AuthLevels.WorkspaceLead:
-                return ShowToAdmins ? $"{workspaceLeadRole},{datahubAdminRole}" : workspaceLeadRole;
+                return ElevatedWorkspaceAccessEnabled ? $"{workspaceLeadRole},{datahubSupportRole}" : workspaceLeadRole;
             case AuthLevels.DatahubAdminGuestView:
-                return $"{datahubAdminRole},{datahubAdminAsGuestRole}";
+                return $"{datahubSupportRole},{datahubAdminAsGuestRole}";
             case AuthLevels.DatahubSupport:
-                return datahubAdminRole;
+                return datahubSupportRole;
             case AuthLevels.Unauthorized:
                 return "🏗️ Unauthorized";
             default:

--- a/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
@@ -48,7 +48,7 @@
                     <ul>
                         @foreach (var toolSection in _workspaceTools.Where(ShouldToolBeShown))
                         {
-                            <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToDatahubAdmins">
+                            <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
                                 <li>
                                     <MudNavLink Href="@GetSectionViewUrl(Localizer[toolSection])" Target="@GetTarget(toolSection)" Disabled="@IsDisabled(toolSection)">
                                         <span @onclick="@(async () => await RegisterClickTelemetry(toolSection))">
@@ -66,7 +66,7 @@
                     </ul>
                 </MudNavMenu>
             </MudStack>
-            <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToDatahubAdmins">
+            <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
                 <MudStack Spacing="2" Class="ml-2">
                     <MudText Typo="Typo.h2" Class="ml-2" Style="font-size: 1rem; text-wrap: nowrap">
                         <strong>
@@ -78,7 +78,7 @@
                             @foreach (var toolSection in _workspaceAdministration)
                             {
                                 <li>
-                                    <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToDatahubAdmins">
+                                    <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
                                         <MudNavLink Href="@GetSectionViewUrl(Localizer[toolSection])" Target="@GetTarget(toolSection)" Match="NavLinkMatch.All">
                                             <MudStack Row AlignItems="AlignItems.Center">
                                                 <DHIcon Icon="@GetIcon(toolSection)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>

--- a/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
@@ -42,7 +42,7 @@
             <ul>
                 @foreach (var toolSection in _workspaceTools.Where(ShouldToolBeShown))
                 {
-                    <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToDatahubAdmins">
+                    <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
                         <li>
                             <MudNavLink Href="@GetSectionViewUrl(Localizer[toolSection])" Target="@GetTarget(toolSection)" Disabled="@IsDisabled(toolSection)">
                                 <span @onclick="@(async () => await RegisterClickTelemetry(toolSection))">
@@ -61,7 +61,7 @@
         </MudNavMenu>
     </MudStack>
 
-    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToDatahubAdmins">
+    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
         <MudStack Spacing="2" Class="ml-12">
             <MudText Typo="Typo.h2" Class="ml-2" Style="font-size: 1rem; text-wrap: nowrap">
                 <strong>
@@ -73,7 +73,7 @@
                     @foreach (var toolSection in _workspaceAdministration)
                     {
                         <li>
-                            <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToDatahubAdmins">
+                            <DatahubAuthView AuthLevel="@GetAuthLevel(toolSection)" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
                                 <MudNavLink Href="@GetSectionViewUrl(Localizer[toolSection])" Target="@GetTarget(toolSection)" Match="NavLinkMatch.All">
                                     <MudStack Row AlignItems="AlignItems.Center">
                                         <DHIcon Icon="@GetIcon(toolSection)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;"/>
@@ -94,7 +94,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToDatahubAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
     [CascadingParameter] private DHSidebarDrawer Drawer { get; set; }
 
     private Datahub_Project _project;

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/WorkspaceDashboard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/WorkspaceDashboard.razor
@@ -20,12 +20,12 @@
         <WorkspaceInfo WorkspaceAcronym="@WorkspaceAcronym"/>
     </MudItem>
     <MudItem xs="12" sm="4">
-        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
             <WorkspaceAdminInfo WorkspaceAcronym="@WorkspaceAcronym"/>
         </DatahubAuthView>
     </MudItem>
     <MudItem xs="12" sm="8">
-        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
             <Authorized>
                 @if (_resources.Any())
                 {
@@ -105,7 +105,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private Datahub_Project _project;
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Database/WorkspaceDatabasePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Database/WorkspaceDatabasePage.razor
@@ -27,7 +27,7 @@
         Port="@_port" />
 
     <MudText Typo="Typo.caption">@Localizer["Connection info can only be displayed by the workspace lead."]</MudText>
-    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceLead" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceLead" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
         <DHButton style="width: fit-content;" OnClick="ToggleContentVisibility" Color=@Color.Primary Variant=@Variant.Filled>@Localizer[_message]</DHButton>
         <DatabaseAdminSetupInfo />
     </DatahubAuthView>
@@ -61,7 +61,7 @@
 
     [Parameter, EditorRequired] 
     public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private string _pythonConnectionInfo;
     private string _rConnectionInfo;

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Delete/ResourceDeletionPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Delete/ResourceDeletionPage.razor
@@ -61,7 +61,7 @@
 @code
 {
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = true;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = true;
     [Parameter]
     public string SubSection { get; set; }
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Healthcheck/WorkspaceHealthcheckPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Healthcheck/WorkspaceHealthcheckPage.razor
@@ -109,7 +109,7 @@
     public string _userID;
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     protected override async Task OnInitializedAsync()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Metadata/WorkspaceMetadataPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Metadata/WorkspaceMetadataPage.razor
@@ -37,7 +37,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     protected override async Task OnInitializedAsync()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Publishing/PublishingDashboard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Publishing/PublishingDashboard.razor
@@ -47,7 +47,7 @@
             <MudText>@Localizer["Please wait"]</MudText>
         }
 
-        <DatahubAuthView AuthLevel=@DatahubAuthView.AuthLevels.WorkspaceAdmin ProjectAcronym=@WorkspaceAcronym ShowToAdmins=@ShowToAdmins>
+        <DatahubAuthView AuthLevel=@DatahubAuthView.AuthLevels.WorkspaceAdmin ProjectAcronym=@WorkspaceAcronym ElevatedWorkspaceAccessEnabled=@ElevatedWorkspaceAccessEnabled>
 
             <MudCard>
                 <MudCardHeader>
@@ -103,7 +103,7 @@
 @code {
     [Parameter]
     public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private Datahub_Project _project;
     private List<OpenDataSubmission> _publishingProcesses;

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceReports.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceReports.razor
@@ -22,7 +22,7 @@
 
 @code {
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     public List<ChartLocale> Locales => new()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Repositories/RepositoryManagementPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Repositories/RepositoryManagementPage.razor
@@ -8,9 +8,9 @@
 @inject MicrosoftIdentityConsentAndConditionalAccessHandler _consentHandler
 
 
-<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceGuest" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
     <MudStack>
-        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
             <Authorized>
                 <MudAlert Severity="Severity.Info">
                     <MudText>@Localizer["You are an administrator and can view all the repositories linked to your instance of Databricks. Collaborators can only view their own linked repositories."]</MudText>
@@ -59,7 +59,7 @@
 
     [Parameter]
     public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private List<RepositoryInfoDto> _repositoryInfos = new();
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Settings/WorkspaceSettingsPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Settings/WorkspaceSettingsPage.razor
@@ -36,8 +36,8 @@
     </MudStack>
     <MudStack>
             <SettingsField Label="@Localizer["Grant Support Access"]" Description="@Localizer["This setting lets the FSDH Support Team add and remove users, edit settings, and access your tools."]">
-                <MudSwitch T="bool" Label="@Localizer["Enable Temporary Administrative Access to FSDH Support Team"]" Value="@ShowToAdmins" Color="Color.Primary" ValueChanged="@ToggleAdminAccess" Class="pb-2"/>
-                @if (ShowToAdmins)
+                <MudSwitch T="bool" Label="@Localizer["Enable Temporary Administrative Access to FSDH Support Team"]" Value="@ElevatedWorkspaceAccessEnabled" Color="Color.Primary" ValueChanged="@ToggleAdminAccess" Class="pb-2"/>
+                @if (ElevatedWorkspaceAccessEnabled)
                 {
                     <MudText Typo="Typo.body2">
                         @Localizer["FSDH Support Team access is enabled until {0}", _accessDate.ToString()]
@@ -71,7 +71,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private Datahub_Project _workspace;
     private DateTime _accessDate;
@@ -111,13 +111,13 @@
         if (WorkspacePage.DisplayToSupport(project))
         {
             dbContext.Projects.Update(CancelAdminAccess(project));
-            ShowToAdmins = false;
+            ElevatedWorkspaceAccessEnabled = false;
             _snackbar.Add(Localizer["Support access has been revoked"], Severity.Success);
         }
         else
         {
             dbContext.Projects.Update(ExtendAdminAccess(project));
-            ShowToAdmins = true;
+            ElevatedWorkspaceAccessEnabled = true;
             _snackbar.Add(Localizer["Support access granted until {0}", project.AllowDatahubSupport.ToString()], Severity.Success);
         }
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorerPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorerPage.razor
@@ -103,7 +103,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private Datahub_Project _project;
     private int? _projectId;

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Sudo/WorkspaceSudoPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Sudo/WorkspaceSudoPage.razor
@@ -110,7 +110,7 @@
     private DatahubAuthView.AuthLevels _authLevel = DatahubAuthView.AuthLevels.Unauthorized;
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private static readonly string[] DatabricksScopes =
     {
@@ -143,7 +143,7 @@
 
         _expectedTerraformOutput = $"```json\n{TerraformOutputHelper.GetExpectedTerraformOutput(_project)}\n```";
 
-        if (ShowToAdmins)
+        if (ElevatedWorkspaceAccessEnabled)
         {
             _authLevel = DatahubAuthView.AuthLevels.DatahubSupport;
         }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
@@ -107,7 +107,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private Datahub_Project _workspace;
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
@@ -18,7 +18,7 @@
 
 <MudStack>
 
-    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
         <MudStack>
             @if (_usersToAdd.Any() || _usersToUpdate.Any())
             {
@@ -91,7 +91,7 @@
     <MudStack Row Class="mt-6 mb-4">
         <DHMainContentTitle Title="@Localizer["Workspace Users"]" />
         <MudSpacer/>
-        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ShowToAdmins="@ShowToAdmins">
+        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
             <DHButton Variant="Variant.Filled" Color="Color.Primary" EndIcon="@Icons.Material.Outlined.PersonAdd" OnClick="OpenDialog">
                 @Localizer["Invite New User"]
             </DHButton>
@@ -209,7 +209,7 @@
 @code {
 
     [Parameter] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private string _filterString = null;
     private string _tabStyle;

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WebApp/WorkspaceWebAppPage.razor
@@ -239,7 +239,7 @@
 @code {
 
     [Parameter, EditorRequired] public string WorkspaceAcronym { get; set; }
-    [Parameter] public bool ShowToAdmins { get; set; } = false;
+    [Parameter] public bool ElevatedWorkspaceAccessEnabled { get; set; } = false;
 
     private string _webAppHost = "<web_app_host>";
     private string _webAppId = "<web_app_id>";

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WorkspacePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WorkspacePage.razor
@@ -31,7 +31,7 @@
 </PageTitle>
 
 <DHSidebarDrawer>
-    <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" ShowToDatahubAdmins="@_showToDatahubAdmins" />
+    <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" ElevatedWorkspaceAccessEnabled="@_showToDatahubAdmins" />
 </DHSidebarDrawer>
 
 @{
@@ -40,7 +40,7 @@
     var parameters = new Dictionary<string, object>
     {
         { "WorkspaceAcronym", WorkspaceAcronymParam },
-        { "ShowToAdmins", _showToDatahubAdmins}
+        { "ElevatedWorkspaceAccessEnabled", _showToDatahubAdmins}
     };
 
     if (!string.IsNullOrEmpty(SubSection))
@@ -50,7 +50,7 @@
 
     if (containsKey)
     {
-        <DatahubAuthView AuthLevel="@WorkspaceSidebar.GetAuthLevel(Section)" ProjectAcronym="@WorkspaceAcronymParam" ShowToAdmins="@_showToDatahubAdmins">
+        <DatahubAuthView AuthLevel="@WorkspaceSidebar.GetAuthLevel(Section)" ProjectAcronym="@WorkspaceAcronymParam" ElevatedWorkspaceAccessEnabled="@_showToDatahubAdmins">
             <Authorized>
                 <DynamicComponent Type=@SwitchDynamicComponentType() Parameters="@parameters"/>
             </Authorized>
@@ -63,9 +63,9 @@
     {
         _logger.LogWarning("The section {Section} is not a valid section for the workspace page", Section);
         <DatahubAuthView AuthLevel="@WorkspaceSidebar.GetAuthLevel(WorkspaceSidebar.SectionViews.Dashboard)"
-                         ProjectAcronym="@WorkspaceAcronymParam" ShowToAdmins="@_showToDatahubAdmins">
+                         ProjectAcronym="@WorkspaceAcronymParam" ElevatedWorkspaceAccessEnabled="@_showToDatahubAdmins">
             <Authorized>
-                <WorkspaceDashboard WorkspaceAcronym="@WorkspaceAcronymParam" ShowToAdmins="@_showToDatahubAdmins"/>
+                <WorkspaceDashboard WorkspaceAcronym="@WorkspaceAcronymParam" ElevatedWorkspaceAccessEnabled="@_showToDatahubAdmins" />
             </Authorized>
             <NotAuthorized>
                 <NotAuthorizedMessage/>


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

In `DatahubAuthView`, the name of the parameter `ShowToAdmins` caused some confusion.

This PR renames it to `ElevatedWorkspaceAccessEnabled`

## Related Issues
<!-- List any related issues or tickets -->

[TASK 8382](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/8382)

## Changes
<!-- List the key changes in this PR -->

- Replaces all instances of `ShowToAdmins` to `ElevatedWorkspaceAccessEnabled`

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Existing tests pass, no new functionality
- Locally tested changes

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
