### PR TITLE
Fix bug where creating a folder created another folder inside it with the same name

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/Storage/AzureCloudStorageManager.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Storage/AzureCloudStorageManager.cs
@@ -127,8 +127,9 @@ public class AzureCloudStorageManager : ICloudStorageManager
 
     public async Task<bool> CreateFolderAsync(string container, string currentWorkingDirectory, string directoryPath)
     {
-        var dirClient = GetDirectoryClient(container, directoryPath);
-        return await dirClient.CreateSubDirectoryAsync(directoryPath) is not null;
+        var dirClient = GetDirectoryClient(container, currentWorkingDirectory);
+        var createResult = await dirClient.CreateSubDirectoryAsync(directoryPath);
+        return createResult is not null;
     }
 
     public async Task<bool> DeleteFileAsync(string container, string filePath)


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

This fixes a bug with folder creation that would result in an additional folder being created inside the folder, with the same name. E.g. creating a folder called "test" would create "test" and "test/test" in the root of the storage container. Now, only one folder is created in the correct place in the directory structure.

## Related Issues
<!-- List any related issues or tickets -->

Bug 8361 - Nested duplicate folders sometimes appear in Storage Explorer
Task 8366 - Fix nested duplicate folder bug

## Changes
<!-- List the key changes in this PR -->

- Fix CreateFolderAsync method in AzureCloudStorageManager

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Created folders in root and inside other folders

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
