### PR TITLE
🐛 Various bug fixes

### DIFF
--- a/Portal/src/Datahub.Application/Services/UserManagement/IUserSettingsService.cs
+++ b/Portal/src/Datahub.Application/Services/UserManagement/IUserSettingsService.cs
@@ -6,6 +6,7 @@ namespace Datahub.Application.Services.UserManagement
 {
     public interface IUserSettingsService
     {
+        Task<bool> RegisterUserSettingsAsync();
         Task<bool> HasUserAcceptedTAC();
         Task<bool> RegisterUserTAC();
         Task<bool> ClearUserSettingsAsync();

--- a/Portal/src/Datahub.Infrastructure.Offline/OfflineUserSettingsService.cs
+++ b/Portal/src/Datahub.Infrastructure.Offline/OfflineUserSettingsService.cs
@@ -6,6 +6,11 @@ namespace Datahub.Core.Services.Offline
 {
     public class OfflineUserSettingsService : IUserSettingsService
     {
+        public Task<bool> RegisterUserSettingsAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<bool> HasUserAcceptedTAC()
         {
             return Task.FromResult(true);

--- a/Portal/src/Datahub.Infrastructure/Services/UserManagement/UserSettingsService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/UserManagement/UserSettingsService.cs
@@ -1,7 +1,5 @@
-﻿#nullable enable
-using Datahub.Application.Services.UserManagement;
+﻿using Datahub.Application.Services.UserManagement;
 using Datahub.Core.Model.Context;
-using Datahub.Core.Model.Datahub;
 using Datahub.Core.Model.UserTracking;
 using Microsoft.AspNetCore.Components;
 using Microsoft.EntityFrameworkCore;
@@ -9,23 +7,40 @@ using Microsoft.Extensions.Logging;
 
 namespace Datahub.Infrastructure.Services.UserManagement
 {
-    public class UserSettingsService : IUserSettingsService
+    public class UserSettingsService(
+        IUserInformationService userInformationService,
+        IDbContextFactory<DatahubProjectDBContext> datahubContextFactory,
+        ILogger<UserSettingsService> logger,
+        NavigationManager navigationManager)
+        : IUserSettingsService
     {
-        private readonly IUserInformationService userInformationService;
-        private readonly IDbContextFactory<DatahubProjectDBContext> datahubContextFactory;
-        private readonly ILogger<UserSettingsService> logger;
-        private readonly NavigationManager navigationManager;
-
-        public UserSettingsService(
-            IUserInformationService userInformationService,
-            IDbContextFactory<DatahubProjectDBContext> datahubContextFactory, ILogger<UserSettingsService> logger, NavigationManager navigationManager)
+        /// <summary>
+        /// Registers the current user's settings.
+        /// </summary>
+        /// <returns>True if new user setting record was created, false otherwise</returns>
+        public async Task<bool> RegisterUserSettingsAsync()
         {
-            this.userInformationService = userInformationService;
-            this.datahubContextFactory = datahubContextFactory;
-            this.logger = logger;
-            this.navigationManager = navigationManager;
+            await using var ctx = await datahubContextFactory.CreateDbContextAsync();
+            var currentUser = await userInformationService.GetCurrentPortalUserAsync();
+            if (currentUser.UserSettings is null)
+            {
+                var userSettings = new UserSettings
+                {
+                    PortalUserId = currentUser.Id,
+                    UserName = currentUser.DisplayName
+                };
+                ctx.UserSettings.Add(userSettings);
+                await ctx.SaveChangesAsync();
+                return true;
+            }
+
+            return false;
         }
 
+        /// <summary>
+        /// Checks that the user has accepted the Terms and Conditions.
+        /// </summary>
+        /// <returns>True if they have, false otherwise</returns>
         public async Task<bool> HasUserAcceptedTAC()
         {
             await using var context = await datahubContextFactory.CreateDbContextAsync();
@@ -34,13 +49,19 @@ namespace Datahub.Infrastructure.Services.UserManagement
             {
                 return userSetting.AcceptedDate != null;
             }
+
             return false;
         }
 
+        /// <summary>
+        /// Registers that the user has accepted the Terms and Conditions.
+        /// </summary>
+        /// <returns>True if the operation was successful, false otherwise</returns>
         public async Task<bool> RegisterUserTAC()
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
-            logger.LogInformation($"User: {currentUser.DisplayName} has accepted Terms and Conditions.");
+            logger.LogInformation("User: {CurrentUserDisplayName} has accepted Terms and Conditions",
+                currentUser.DisplayName);
 
             try
             {
@@ -50,7 +71,8 @@ namespace Datahub.Infrastructure.Services.UserManagement
                 if (userSetting == null)
                 {
                     logger.LogError(
-                        $"User: {currentUser.DisplayName} with user id: {currentUser.Id} is not in DB to register TAC.");
+                        "User: {CurrentUserDisplayName} with user id: {CurrentUserId} is not in DB to register TAC",
+                        currentUser.DisplayName, currentUser.Id);
                     return false;
                 }
 
@@ -61,17 +83,22 @@ namespace Datahub.Infrastructure.Services.UserManagement
                     return true;
 
                 logger.LogInformation(
-                    $"User: {currentUser.DisplayName} has accepted Terms and Conditions. Changes NOT saved");
+                    "User: {CurrentUserDisplayName} has accepted Terms and Conditions. Changes NOT saved",
+                    currentUser.DisplayName);
                 return false;
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, $"User: {currentUser.DisplayName} registering TAC failed.");
+                logger.LogError(ex, "User: {CurrentUserDisplayName} registering TAC failed", currentUser.DisplayName);
             }
 
             return false;
         }
 
+        /// <summary>
+        /// Deletes the user's settings.
+        /// </summary>
+        /// <returns>True if a record was deleted, false if no record was deleted</returns>
         public async Task<bool> ClearUserSettingsAsync()
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -108,6 +135,10 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return false;
         }
 
+        /// <summary>
+        /// Gets a list of keys of alerts that were hidden by the user.
+        /// </summary>
+        /// <returns>The list of keys of hidden alerts. Empty list if nothing found</returns>
         public async Task<List<string>> GetHiddenAlerts()
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -117,7 +148,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
             if (userSetting == null)
             {
                 logger.LogError(
-                    "User: {CurrentUserDisplayName} with user id: {UserId} is not in DB.",
+                    "User: {CurrentUserDisplayName} with user id: {UserId} is not in DB",
                     currentUser.DisplayName, currentUser.Id);
                 return new List<string>();
             }
@@ -128,6 +159,11 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return userSetting.HiddenAlerts;
         }
 
+        /// <summary>
+        /// Adds an alert key to the list of hidden alerts for the user.
+        /// </summary>
+        /// <param name="alertKey">The key of the alert to hide</param>
+        /// <returns>True if the alert was added, false otherwise</returns>
         public async Task<bool> AddHiddenAlert(string alertKey)
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -145,8 +181,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
                     return false;
                 }
 
-                if (userSetting.HiddenAlerts == null)
-                    userSetting.HiddenAlerts = new List<string>();
+                userSetting.HiddenAlerts ??= new List<string>();
 
                 userSetting.HiddenAlerts.Add(alertKey);
                 context.UserSettings.Update(userSetting);
@@ -157,7 +192,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
                 }
 
                 logger.LogInformation(
-                    "User: {CurrentUserDisplayName} Alert {AlertKey} has not been added. Changes NOT saved.",
+                    "User: {CurrentUserDisplayName} Alert {AlertKey} has not been added. Changes NOT saved",
                     currentUser.DisplayName, alertKey);
             }
             catch (Exception ex)
@@ -169,6 +204,10 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return false;
         }
 
+        /// <summary>
+        /// Gets the user's preference for hiding alerts.
+        /// </summary>
+        /// <returns>True if all alerts should be hidden, false otherwise</returns>
         public async Task<bool> GetHideAlerts()
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -178,7 +217,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
             if (userSetting == null)
             {
                 logger.LogError(
-                    "User: {CurrentUserDisplayName} with user id: {UserId} is not in DB.",
+                    "User: {CurrentUserDisplayName} with user id: {UserId} is not in DB",
                     currentUser.DisplayName, currentUser.Id);
                 return false;
             }
@@ -186,6 +225,11 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return userSetting.HideAlerts;
         }
 
+        /// <summary>
+        /// Sets the user's preference for hiding alerts.
+        /// </summary>
+        /// <param name="hideAlerts">Whether all alerts should be hidden</param>
+        /// <returns>True if the setting was properly set, false otherwise</returns>
         public async Task<bool> SetHideAlerts(bool hideAlerts)
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -212,7 +256,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
                 }
 
                 logger.LogInformation(
-                    "User: {CurrentUserDisplayName} Hide alerts has not been set. Changes NOT saved.",
+                    "User: {CurrentUserDisplayName} Hide alerts has not been set. Changes NOT saved",
                     currentUser.DisplayName);
             }
             catch (Exception ex)
@@ -224,6 +268,11 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return false;
         }
 
+        /// <summary>
+        /// Sets the user's preference for hiding achievements.
+        /// </summary>
+        /// <param name="hideAchievements">Whether to hide achievements</param>
+        /// <returns>True if the setting was set, false otherwise</returns>
         public async Task<bool> SetHideAchievements(bool hideAchievements)
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -250,7 +299,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
                 }
 
                 logger.LogInformation(
-                    "User: {CurrentUserDisplayName} Hide achievements has not been set. Changes NOT saved.",
+                    "User: {CurrentUserDisplayName} Hide achievements has not been set. Changes NOT saved",
                     currentUser.DisplayName);
             }
             catch (Exception ex)
@@ -262,6 +311,11 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return false;
         }
 
+        /// <summary>
+        /// Registers the user's selected language.
+        /// </summary>
+        /// <param name="language">The two letter language code, i.e. "en" or "fr"</param>
+        /// <returns>True if the operation was successful, false otherwise</returns>
         public async Task<bool> RegisterUserLanguage(string language)
         {
             var currentUser = await userInformationService.GetCurrentPortalUserAsync();
@@ -277,8 +331,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
 
                 if (userSetting == null)
                 {
-                    userSetting = new UserSettings { PortalUserId = currentUser.Id, UserName = currentUser.DisplayName, Language = language };
-                    context.UserSettings.Add(userSetting);
+                    await RegisterUserSettingsAsync();
                 }
                 else
                 {
@@ -302,6 +355,12 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return false;
         }
 
+        /// <summary>
+        /// Sets the user's language preference.
+        /// </summary>
+        /// <param name="language">The two letter language code, i.e. "en" or "fr"</param>
+        /// <param name="redirectUrl">The url to redirect to once the language is set</param>
+        /// <returns>True if the language was changed, false otherwise</returns>
         public async Task<bool> SetLanguage(string language, string redirectUrl = "")
         {
             await using var context = await datahubContextFactory.CreateDbContextAsync();
@@ -331,6 +390,10 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return true;
         }
 
+        /// <summary>
+        /// Gets the user's selected language.
+        /// </summary>
+        /// <returns>The two letter language code, or empty string if no language found</returns>
         public async Task<string> GetUserLanguage()
         {
             var userSetting = await GetUserSettingsAsync();
@@ -338,12 +401,20 @@ namespace Datahub.Infrastructure.Services.UserManagement
             return userSetting != null ? userSetting.Language : string.Empty;
         }
 
+        /// <summary>
+        /// Checks if the user's selected language is French.
+        /// </summary>
+        /// <returns>True if french, false otherwise</returns>
         public async Task<bool> IsFrench()
         {
             var lang = await GetUserLanguage();
             return !lang.ToLower().Contains("en");
         }
 
+        /// <summary>
+        /// Gets the user's settings. Not tracked.
+        /// </summary>
+        /// <returns>The UserSettings of the current user, null if none found if there was an error</returns>
         public async Task<UserSettings?> GetUserSettingsAsync()
         {
             try
@@ -357,7 +428,7 @@ namespace Datahub.Infrastructure.Services.UserManagement
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Unable to fetch current user at this time.");
+                logger.LogError(ex, "Unable to fetch current user at this time");
                 return null;
             }
         }

--- a/Portal/src/Datahub.Portal/Controllers/HealthCheckController.cs
+++ b/Portal/src/Datahub.Portal/Controllers/HealthCheckController.cs
@@ -9,6 +9,7 @@ using Datahub.Core.Model.Health;
 using Datahub.Shared.Configuration;
 using Azure.Core;
 using System.Net.Http.Headers;
+using Datahub.Core.Data;
 using Datahub.Infrastructure.Services.Azure;
 using Microsoft.AspNetCore.Authorization;
 
@@ -23,10 +24,12 @@ namespace Datahub.Portal.Controllers
         private readonly IMemoryCache _cache;
         private readonly HttpClient _httpClient;
         private readonly DatahubPortalConfiguration _portalConfiguration;
-        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new ConcurrentDictionary<string, SemaphoreSlim>();
+
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _locks =
+            new ConcurrentDictionary<string, SemaphoreSlim>();
 
 
-        public HealthCheckController(DatahubProjectDBContext dbProjectContext, 
+        public HealthCheckController(DatahubProjectDBContext dbProjectContext,
             IMemoryCache cache,
             DatahubPortalConfiguration portalConfiguration,
             HttpClient httpClient)
@@ -46,7 +49,8 @@ namespace Datahub.Portal.Controllers
 
             try
             {
-                if (!_cache.TryGetValue("InfrastructureHealthChecks", out List<InfrastructureHealthCheck> infrastructureHealth))
+                if (!_cache.TryGetValue("InfrastructureHealthChecks",
+                        out List<InfrastructureHealthCheck> infrastructureHealth))
                 {
                     infrastructureHealth = await LoadCheckData();
                     _cache.Set("InfrastructureHealthChecks", infrastructureHealth);
@@ -59,7 +63,7 @@ namespace Datahub.Portal.Controllers
                 semaphore.Release();
             }
         }
-         
+
         [HttpGet("logstream")]
         [Authorize]
         public async Task<IActionResult> GetKuduLogStream()
@@ -68,10 +72,12 @@ namespace Datahub.Portal.Controllers
             {
                 return Unauthorized("User is not authenticated.");
             }
+
             if (!User.Identity.Name.EndsWith("@ssc-spc.gc.ca"))
             {
                 return Forbid("User is not part of SSC SPC team.");
             }
+
             var env = _portalConfiguration?.Hosting?.EnvironmentName;
             if (string.IsNullOrEmpty(env) || env == "local")
             {
@@ -79,7 +85,7 @@ namespace Datahub.Portal.Controllers
             }
 
             var kuduUrl = $"https://fsdh-portal-app-{env}.scm.azurewebsites.net/api/logstream";
-            var access_token = await GetAccessTokenAsync();            
+            var access_token = await GetAccessTokenAsync();
             var request = new HttpRequestMessage(HttpMethod.Get, kuduUrl);
 
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", access_token);
@@ -91,16 +97,17 @@ namespace Datahub.Portal.Controllers
                 Response.ContentType = "text/event-stream";
 
                 using (var streamReader = new StreamReader(stream))
-                using(var writer = new StreamWriter(Response.Body))
+                using (var writer = new StreamWriter(Response.Body))
                 {
                     var buffer = new char[8192];
                     int charsRead;
-                    while((charsRead = await streamReader.ReadAsync(buffer,0,buffer.Length)) >  0 && charsRead > 0)
+                    while ((charsRead = await streamReader.ReadAsync(buffer, 0, buffer.Length)) > 0 && charsRead > 0)
                     {
-                        await writer.WriteAsync(buffer,0,charsRead);
+                        await writer.WriteAsync(buffer, 0, charsRead);
                         await writer.FlushAsync();
                     }
                 }
+
                 return new EmptyResult();
                 // [VB] could not use FileStreamResult - it did not stream as supposed to
                 //return new FileStreamResult(stream, new MediaTypeHeaderValue("text/event-stream").MediaType); 
@@ -126,13 +133,17 @@ namespace Datahub.Portal.Controllers
                 return Unauthorized("Workspace name is missing.");
             }
 
-            // Check if the user has the admin role for the specified workspace
-            var isAdminForWorkspace = User.Claims.Any(claim =>
-                claim.Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" && claim.Value == $"{ws}-admin");
+            // Check if the user has the admin, workspace lead or datahub admin role for the specified workspace
+            var allowed = User.Claims.Any(
+                claim =>
+                    claim.Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" &&
+                    (claim.Value == $"{ws}{RoleConstants.ADMIN_SUFFIX}" ||
+                     claim.Value == $"{ws}{RoleConstants.WORKSPACE_LEAD_SUFFIX}") ||
+                    claim.Value == RoleConstants.DATAHUB_ROLE_ADMIN);
 
-            if (!isAdminForWorkspace)
+            if (!allowed)
             {
-                return Forbid("User does not have admin role for the specified workspace.");
+                return Forbid("User does not have admin or lead role for the specified workspace.");
             }
 
             var env = _portalConfiguration?.Hosting?.EnvironmentName;
@@ -140,15 +151,16 @@ namespace Datahub.Portal.Controllers
             {
                 env = "dev";
             }
-                        
+
             var kuduUrl = $"https://fsdh-proj-{ws.ToLower()}-webapp-{env}.scm.azurewebsites.net/api/logstream";
-            var access_token = await GetAccessTokenAsync();    
+            var access_token = await GetAccessTokenAsync();
             //await HttpContext.GetTokenAsync("access_token");
 
             if (string.IsNullOrEmpty(access_token))
             {
                 return Unauthorized("Access token is missing.");
             }
+
             var request = new HttpRequestMessage(HttpMethod.Get, kuduUrl);
 
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", access_token);
@@ -166,12 +178,14 @@ namespace Datahub.Portal.Controllers
                     {
                         var buffer = new char[8192];
                         int charsRead;
-                        while ((charsRead = await streamReader.ReadAsync(buffer, 0, buffer.Length)) > 0 && charsRead > 0)
+                        while ((charsRead = await streamReader.ReadAsync(buffer, 0, buffer.Length)) > 0 &&
+                               charsRead > 0)
                         {
                             await writer.WriteAsync(buffer, 0, charsRead);
                             await writer.FlushAsync();
                         }
                     }
+
                     return new EmptyResult();
                     // [VB] could not use FileStreamResult - it did not stream as supposed to
                     //return new FileStreamResult(stream, new MediaTypeHeaderValue("text/event-stream").MediaType); 
@@ -186,9 +200,11 @@ namespace Datahub.Portal.Controllers
                 return new EmptyResult();
             }
         }
+
         private async Task<List<InfrastructureHealthCheck>> LoadCheckData()
         {
-            var projects = await _dbProjectContext.Projects.AsNoTracking().Include(p => p.Resources).Select(p => p.Project_Acronym_CD).ToListAsync();
+            var projects = await _dbProjectContext.Projects.AsNoTracking().Include(p => p.Resources)
+                .Select(p => p.Project_Acronym_CD).ToListAsync();
             var infrastructureHealth = await _dbProjectContext.InfrastructureHealthChecks
                 .Where(h => h.ResourceType == InfrastructureHealthResourceType.AzureSqlDatabase ||
                             h.ResourceType == InfrastructureHealthResourceType.AzureDatabricks ||
@@ -220,7 +236,8 @@ namespace Datahub.Portal.Controllers
                 { "scope", $"{audience}.default" },
                 { "resource", audience }
             });
-            var tokenResponse = await _httpClient.PostAsync<AccessTokenResponse>(url, default, content, cancellationToken);
+            var tokenResponse =
+                await _httpClient.PostAsync<AccessTokenResponse>(url, default, content, cancellationToken);
             return tokenResponse?.access_token;
         }
     }

--- a/Portal/src/Datahub.Portal/Layout/MainLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/MainLayout.razor
@@ -68,6 +68,7 @@ else
         try
         {
             var user = await _userInformationService.GetAuthenticatedUser(true);
+            var userSettings = await _userSettingsService.GetUserSettingsAsync();
 
             if (!user.Identity?.IsAuthenticated ?? true)
             {
@@ -75,6 +76,12 @@ else
                 _navigationManager.NavigateTo($"/login?redirectUri={returnUrl}", forceLoad: true);
                 return;
             }
+
+            if (userSettings == null)
+            {
+                await _userSettingsService.RegisterUserSettingsAsync();
+            }
+
 
             _isUserValid = await _userSettingsService.HasUserAcceptedTAC();
             _isSessionEnabled = await _userCircuitCounterService.IsSessionEnabled();

--- a/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
@@ -251,6 +251,7 @@
         return sectionView switch
         {
             SectionViews.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(_project),
+            SectionViews.WebApp => PageRoutes.WorkspaceWebAppShare.Replace("{WorkspaceAcronymParam}", WorkspaceAcronym),
             _ => $"{_path}/{sectionView}"
         };
     }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/AppServiceCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/AppServiceCard.razor
@@ -5,7 +5,7 @@
 <MudPaper Outlined Class="pa-4">
     <MudStack>
         <MudStack Row AlignItems="AlignItems.Center">
-            <DHIcon Icon="@SidebarIcons.WebApp" Size="Size.Medium" />
+            <DHIcon Icon="@SidebarIcons.WebApp" Size="Size.Medium"/>
             <MudText Typo="Typo.h3">@Localizer["Web Application"]</MudText>
             <MudSpacer/>
 
@@ -13,29 +13,32 @@
         <MudText>
             @Localizer["Navigate to the Azure App Service to view your web application, where you can serve interactive and user-friendly dashboards."]
         </MudText>
-        @if (ProjectResource.CreatedAt.HasValue)
-        {
-            <MudElement HtmlTag="div">
-                <DHButton
-                    Href="@GetWebAppUrl()"
-                    Target="_blank"
-                    Color="Color.Primary"
-                    Variant="@Variant.Text"
-                    EndIcon="@SidebarIcons.External"
-                    Underline>
-                    @Localizer["Navigate to Web App"]
-                </DHButton>
-            </MudElement>
-            <MudElement HtmlTag="div">
-                <DHButton Href=@($"/{PageRoutes.WorkspacePrefix}/{WorkspaceAcronym}/{_reverseProxyConfigService.WebAppPrefix}")
-                          Color="Color.Primary"
-                          Variant="@Variant.Text"
-                          EndIcon="@Icons.Material.Outlined.KeyboardDoubleArrowRight"
-                          Underline>
-                    @Localizer["View Web App configuration"]
-                </DHButton>
-            </MudElement>
-        }
+        <MudElement HtmlTag="div">
+            @if (ProjectResource.CreatedAt.HasValue)
+            {
+                <MudStack Row>
+                    <DHButton
+                        Href="@GetWebAppUrl()"
+                        Color="Color.Primary"
+                        Variant="@Variant.Text"
+                        EndIcon="@SidebarIcons.External"
+                        Underline>
+                        @Localizer["Navigate to Web App"]
+                    </DHButton>
+                    <DHButton Href=@($"/{PageRoutes.WorkspacePrefix}/{WorkspaceAcronym}/{_reverseProxyConfigService.WebAppPrefix}")
+                              Color="Color.Primary"
+                              Variant="@Variant.Text"
+                              EndIcon="@Icons.Material.Outlined.KeyboardDoubleArrowRight"
+                              Underline>
+                        @Localizer["View Web App configuration"]
+                    </DHButton>
+                </MudStack>
+            }
+            else
+            {
+                <ToolBeingProvisionedButton/>
+            }
+        </MudElement>
     </MudStack>
 </MudPaper>
 

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/WorkspaceUserCardList.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/WorkspaceUserCardList.razor
@@ -7,38 +7,69 @@
 
 
 <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.Authenticated" ProjectAcronym="@ProjectAcronym">
+    <MudText Class="sr-only" Typo="Typo.h2">
+        @Localizer["List of workspace users"]
+    </MudText>
     <MudStack>
         <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-2">
-            @if (_projectAdmins.Any())
-            {
-                <MudText Typo="Typo.h5">@Localizer["Admins"]</MudText>
-            }
+            <MudText Typo="Typo.h3">@_head</MudText>
             <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceCollaborator" ProjectAcronym="@ProjectAcronym">
                 <DHButton Variant="Variant.Text" Color="Color.Primary" Href="@_viewMembersHref" Underline>
                     @Localizer["View Members"]
                 </DHButton>
             </DatahubAuthView>
         </MudStack>
-        <ul style="display: grid; gap: 12px">
-            @foreach (var admin in _projectAdmins)
-            {
-                var graphId = admin.PortalUser?.GraphGuid;
-                if (!string.IsNullOrEmpty(graphId))
+        
+        @if (_projectLeads.Any())
+        {
+            <ul style="display: grid; gap: 12px">
+                @foreach (var lead in _projectLeads)
                 {
-                    <li>
-                        <UserCard ViewedUserGraphId=@graphId Size="Size.Medium" ShowProfileLink/>
-                    </li>
+                    var graphId = lead.PortalUser?.GraphGuid;
+                    if (!string.IsNullOrEmpty(graphId))
+                    {
+                        <li>
+                            <UserCard ViewedUserGraphId=@graphId Size="Size.Medium" ShowProfileLink/>
+                        </li>
+                    }
                 }
+            </ul>
+        }
+
+        @if (_projectAdmins.Any())
+        {
+            @if (_headRole == Project_Role.RoleNames.WorkspaceLead)
+            {
+                <MudDivider Class="my-4"/>
+                <MudStack Class="mb-2">
+                    <MudText Typo="Typo.h3">@Localizer["Workspace admins"]</MudText>
+                </MudStack>
             }
-        </ul>
+
+            <ul style="display: grid; gap: 12px">
+                @foreach (var admin in _projectAdmins)
+                {
+                    var graphId = admin.PortalUser?.GraphGuid;
+                    if (!string.IsNullOrEmpty(graphId))
+                    {
+                        <li>
+                            <UserCard ViewedUserGraphId=@graphId Size="Size.Medium" ShowProfileLink/>
+                        </li>
+                    }
+                }
+            </ul>
+        }
 
         @if (_projectMembers.Any())
         {
-            <MudDivider Class="my-4"/>
+            @if(_headRole != Project_Role.RoleNames.Collaborator)
+            {
+                <MudDivider Class="my-4"/>
+                <MudStack Class="mb-2">
+                    <MudText Typo="Typo.h3">@Localizer["Collaborators"]</MudText>
+                </MudStack>
+            }
 
-            <MudStack Class="mb-2">
-                <MudText Typo="Typo.h5">@Localizer["Collaborators"]</MudText>
-            </MudStack>
             <ul style="display: grid; gap: 12px">
                 @foreach (var member in _projectMembers)
                 {
@@ -59,8 +90,11 @@
 
     [Parameter] public string ProjectAcronym { get; set; }
 
+    private List<Datahub_Project_User> _projectLeads = new();
     private List<Datahub_Project_User> _projectAdmins = new();
     private List<Datahub_Project_User> _projectMembers = new();
+    private string _head => _projectLeads.Any() ? @Localizer["Workspace lead"] : _projectAdmins.Any() ? Localizer["Admins"] : Localizer["Collaborators"];
+    private Project_Role.RoleNames _headRole => _projectLeads.Any() ? Project_Role.RoleNames.WorkspaceLead : _projectAdmins.Any() ? Project_Role.RoleNames.Admin : Project_Role.RoleNames.Collaborator;
 
     private string _viewMembersHref => $"{PageRoutes.WorkspacePrefix}/{ProjectAcronym}/{WorkspaceSidebar.SectionViews.Users}";
 
@@ -71,10 +105,14 @@
 
         var workspaceMembers = await _projectUserManagementService.GetProjectUsersAsync(ProjectAcronym);
 
+        _projectLeads = workspaceMembers
+            .Where(m => m.RoleId
+                is (int)Project_Role.RoleNames.WorkspaceLead)
+            .ToList();
+
         _projectAdmins = workspaceMembers
             .Where(m => m.RoleId
-                is (int)Project_Role.RoleNames.Admin
-                or (int)Project_Role.RoleNames.WorkspaceLead)
+                is (int)Project_Role.RoleNames.Admin)
             .ToList();
 
         _projectMembers = workspaceMembers

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/Charts/DailyCostsStackBar.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/Charts/DailyCostsStackBar.razor
@@ -14,7 +14,7 @@
             <ApexPointSeries
                 TItem="DailyServiceCost"
                 Name="@service"
-                Items="@DailyCosts.Where(c => c.Source == service)"
+                Items="@_dailyCosts.Where(c => c.Source == service)"
                 XValue="@(c => c.Date.Date.ToString("yyyy-MM-dd"))"
                 YAggregate="@(e => e.Sum(c => c.Amount))"
                 SeriesType="SeriesType.Bar"/>
@@ -45,6 +45,7 @@
     [Parameter] public string Title { get; set; }
     [CascadingParameter] public List<ChartLocale> Locales { get; set; }
 
+    private List<DailyServiceCost> _dailyCosts = new();
     private ApexChart<DailyServiceCost> _dailyCostChart = new();
     private ApexChartOptions<DailyServiceCost> _dailyCostChartOptions = new();
     private List<string> _distinctServices => DailyCosts.Select(c => c.Source).Distinct().ToList();
@@ -53,7 +54,42 @@
     protected override void OnParametersSet()
     {
         _locale = CultureService.IsEnglish ? ICultureService.English : ICultureService.French;
+        _dailyCosts = FillDailyCosts();
         DefineOptions();
+    }
+    
+    public List<DailyServiceCost> FillDailyCosts()
+    {
+        
+        var distinctDays = DailyCosts.Select(c => c.Date.Date).Distinct().ToList();
+        
+        var dailyCosts = new List<DailyServiceCost>();
+        foreach (var service in _distinctServices)
+        {
+            foreach (var day in distinctDays)
+            {
+                var cost = DailyCosts.FirstOrDefault(c => c.Source == service && c.Date.Date == day);
+                if (cost != null)
+                {
+                    dailyCosts.Add(new DailyServiceCost
+                    {
+                        Date = day,
+                        Source = service,
+                        Amount = cost.Amount
+                    });
+                }
+                else
+                {
+                    dailyCosts.Add(new DailyServiceCost
+                    {
+                        Date = day,
+                        Source = service,
+                        Amount = 0
+                    });
+                }
+            }
+        }
+        return dailyCosts;
     }
 
     public async Task Refresh()

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/Charts/MonthlyCostsStackBar.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/Charts/MonthlyCostsStackBar.razor
@@ -46,11 +46,7 @@
     [Parameter] public string Title { get; set; }
     [CascadingParameter] public List<ChartLocale> Locales { get; set; }
 
-    private List<MonthlyCost> monthlyCosts => Costs
-        .GroupBy(c => (c.Date.ToString("MMMM yyyy"), c.Source))
-        .Select(g => new MonthlyCost { Month = g.Key.Item1, Cost = g.Sum(c => c.Amount), Service = g.Key.Source })
-        .OrderBy(c => DateTime.ParseExact(c.Month, "MMMM yyyy", _culture))
-        .ToList();
+    private List<MonthlyCost> monthlyCosts = new();
 
     private ApexChart<MonthlyCost> _monthlyCostsChart = new();
     private ApexChartOptions<MonthlyCost> _monthlyCostsChartOptions = new();
@@ -70,7 +66,39 @@
     {
         _locale = CultureService.IsEnglish ? ICultureService.English : ICultureService.French;
         _culture = new(_locale + "-CA");
+        monthlyCosts = FillMonthlyCosts();
         DefineOptions();
+    }
+
+    private List<MonthlyCost> FillMonthlyCosts()
+    {
+        var uncleanMonthlyCosts = Costs
+            .GroupBy(c => (c.Date.ToString("MMMM yyyy"), c.Source))
+            .Select(g => new MonthlyCost { Month = g.Key.Item1, Cost = g.Sum(c => c.Amount), Service = g.Key.Source })
+            .OrderBy(c => DateTime.ParseExact(c.Month, "MMMM yyyy", _culture))
+            .ToList();
+
+        var distinctMonths = uncleanMonthlyCosts.Select(c => c.Month).Distinct().ToList();
+        var distinctServices = uncleanMonthlyCosts.Select(c => c.Service).Distinct().ToList();
+
+        var tempMonthlyCosts = new List<MonthlyCost>();
+        foreach (var month in distinctMonths)
+        {
+            foreach (var service in distinctServices)
+            {
+                var cost = uncleanMonthlyCosts.FirstOrDefault(c => c.Month == month && c.Service == service);
+                if (cost == null)
+                {
+                    tempMonthlyCosts.Add(new MonthlyCost { Month = month, Cost = 0, Service = service });
+                }
+                else
+                {
+                    tempMonthlyCosts.Add(cost);
+                }
+            }
+        }
+
+        return tempMonthlyCosts;
     }
 
     public async Task Refresh()

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
@@ -249,7 +249,7 @@
         {
             TerraformTemplate.AzureDatabricks => Localizer["Azure Databricks"],
             TerraformTemplate.AzureStorageBlob => Localizer["Azure Storage Blob"],
-            TerraformTemplate.AzureAppService => Localizer["Azure App Service"],
+            TerraformTemplate.AzureAppService => Localizer["Web Application"],
             TerraformTemplate.AzurePostgres => Localizer["Azure Postgres"],
             TerraformTemplate.AzureArcGis => Localizer["Azure ArcGIS"],
             TerraformTemplate.AzureAPI => Localizer["Azure API Management"],
@@ -263,7 +263,7 @@
         {
             TerraformTemplate.AzureDatabricks => Localizer["Azure Databricks is a fast, easy, and collaborative Apache Spark-based analytics platform. Accelerate big data analytics and artificial intelligence (AI) solutions with Azure Databricks, a fast, easy and collaborative Apache Spark-based analytics service."],
             TerraformTemplate.AzureStorageBlob => Localizer["Azure Blob storage is Microsoft's object storage solution for the cloud. Blob storage is optimized for storing massive amounts of unstructured data, such as text or binary data."],
-            TerraformTemplate.AzureAppService => Localizer["Azure App Service is a fully managed web hosting service for building web apps, mobile back ends, and RESTful APIs. It offers auto-scaling and high availability, supports both Windows and Linux, and enables automated deployments from GitHub, Azure DevOps, or any Git repo."],
+            TerraformTemplate.AzureAppService => Localizer["Web Application is a fully managed web hosting service for building web apps, mobile back ends, and RESTful APIs. It offers auto-scaling and high availability, supports both Windows and Linux, and enables automated deployments from GitHub, Azure DevOps, or any Git repo."],
             TerraformTemplate.AzurePostgres => Localizer["Azure Database for PostgreSQL is a relational database service based on the open-source Postgres database engine. It's a fully managed database-as-a-service offering that can handle mission-critical workloads with predictable performance, security, high availability, and dynamic scalability."],
             TerraformTemplate.AzureArcGis => Localizer["ArcGIS is a geographic information system (GIS) for working with maps and geographic information. It is used for creating and using maps, compiling geographic data, analyzing mapped information, sharing and discovering geographic information, using maps and geographic information in a range of applications, and managing geographic information in a database."],
             TerraformTemplate.AzureAPI => Localizer["Azure API Management is a fully managed service that enables participants to publish, secure, transform, maintain, and monitor APIs. To use API Management, you must first create an Azure App Service."],


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->
This PR fixes a few bugs listed in DevOps. These being overlapping stacked bars in the reports page, incorrect permissions for web app logs, ensure user settings get properly set, have the webapp sidebar item navigate to the share link, fixed the web app dashboard card and added a new header to workspace users list to directly show who the workspace lead is and improved the logic there. Also renamed Azure App Service to Web Application in toolbox

## Related Issues
<!-- List any related issues or tickets -->
[In workspace toolbox, we should use "Web Application" instead of "Azure App Service" for consistency](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8377)
[As a fsdh user, I need to know who the workspace lead is](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8375)
[Web app log view permissions not adjusted for workspace leads](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8364)
[When logging in for the first time, the usersettings are not set prior to checking acheivments](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8333)
[Webapp in workspace tools should open share](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8323)
[Overlapping stacked bars in cost reports](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23)

## Changes
<!-- List the key changes in this PR -->

- Renamed "Azure App Service" to "Web Application" in toolbox page
- In workspace user list on the dashboard, added a header for workspace lead and improved the render logic a bit to always look nice
- Adjusted the permission requirements in the webapp logstream controller to allow workspace leads and datahub admins to view logstream
- Modified the UserSettingsService to better control how UserSettings records are created and added a check on MainLayout to create UserSettings if required. Also added a bunch of documentation for this service
- Changed the "Web app" item in workspace sidebar to lead to the share link of the existing web app
- Fixed the web app dashboard card to show navigation links in a row (like other cards) instead of in a column, and also added the "tool is being provisioned" message in the card when it is being provisioned, which was missing on this specific card
- Added a method to add zeros to cost charts when there were no costs (instead of just not having a record) which fixed the issue we had with overlapping values in bar charts on the workspace report (thanks to [this thread](https://github.com/apexcharts/apexcharts.js/issues/1173))

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- All existing tests pass

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
