### PR TITLE
🔧 Tool provisioning message and various adjustments

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/ResourceGroups/WorkspaceResourceGroupsManagementService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/ResourceGroups/WorkspaceResourceGroupsManagementService.cs
@@ -213,6 +213,7 @@ namespace Datahub.Infrastructure.Services.ResourceGroups
             var subId = subscriptionId.Contains("/") ? subscriptionId : $"/{SUBSCRIPTION_KEY}/{subscriptionId}";
             var sub = armClient.GetSubscriptionResource(new ResourceIdentifier(subId));
             var env = config["DataHub_ENVNAME"];
+            env ??= config["Hosting:EnvironmentName"];
             if (env is null)
             {
                 logger.LogError("Environment name not found in configuration");

--- a/Portal/src/Datahub.Portal/Components/Buttons/DHButton.razor
+++ b/Portal/src/Datahub.Portal/Components/Buttons/DHButton.razor
@@ -22,7 +22,7 @@
            Tag="@Tag"
            UserAttributes="@UserAttributes"
            OnClick="@OnClick">
-    <MudText>
+    <MudText Style="display: flex; justify-content: center; align-items: center">
         @ChildContent
     </MudText>
 </MudButton>

--- a/Portal/src/Datahub.Portal/Layout/MainLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/MainLayout.razor
@@ -50,6 +50,7 @@ else
 }
 
 @code
+
 {
     private bool? _isSessionEnabled;
     private bool _isLoaded = false;
@@ -68,7 +69,6 @@ else
         try
         {
             var user = await _userInformationService.GetAuthenticatedUser(true);
-            var userSettings = await _userSettingsService.GetUserSettingsAsync();
 
             if (!user.Identity?.IsAuthenticated ?? true)
             {
@@ -76,12 +76,6 @@ else
                 _navigationManager.NavigateTo($"/login?redirectUri={returnUrl}", forceLoad: true);
                 return;
             }
-
-            if (userSettings == null)
-            {
-                await _userSettingsService.RegisterUserSettingsAsync();
-            }
-
 
             _isUserValid = await _userSettingsService.HasUserAcceptedTAC();
             _isSessionEnabled = await _userCircuitCounterService.IsSessionEnabled();
@@ -94,6 +88,7 @@ else
 
         // register and or update authenticated portal user
         await _userInformationService.RegisterAuthenticatedPortalUser();
+        await _userSettingsService.RegisterUserSettingsAsync();
 
         _isLoaded = true;
     }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
@@ -20,6 +20,7 @@
 @inject IWorkspaceCostManagementService _costMgmt
 @inject ISnackbar _snackbar
 @inject ILogger<WorkspaceCostingReport> _logger
+@inject IJSRuntime _jsRuntime
 
 @if (_loading)
 {
@@ -37,29 +38,30 @@
 }
 
 <MudStack>
+    <MudStack Row>
+        <MudText Typo="Typo.h2">@Localizer["Cost Analysis"]</MudText>
+        <DatahubAuthView ProjectAcronym="@WorkspaceAcronym" AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin">
+            <MudSpacer/>
+            <DHButton StartIcon="@(_refreshing ? "" : SidebarIcons.Restart)" Variant="Variant.Outlined"
+                      Color="Color.Dark" OnClick="HandleRefresh">
+                @if (_refreshing)
+                {
+                    <MudProgressCircular Indeterminate="true" Size="Size.Small"/>
+                }
+                else
+                {
+                    @Localizer["Refresh"]
+                }
+            </DHButton>
+        </DatahubAuthView>
+    </MudStack>
     @if (_currentPerService?.Count > 0)
     {
-        <MudStack Row>
-            <MudText Typo="Typo.h2">@Localizer["Cost Analysis"]</MudText>
-            <DatahubAuthView ProjectAcronym="@WorkspaceAcronym" AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin">
-                <MudSpacer/>
-                <DHButton StartIcon="@(_refreshing ? "" : SidebarIcons.Restart)" Variant="Variant.Outlined" Color="Color.Dark" OnClick="HandleRefresh">
-                    @if (_refreshing)
-                    {
-                        <MudProgressCircular Indeterminate="true" Size="Size.Small"/>
-                    }
-                    else
-                    {
-                        @Localizer["Refresh"]
-                    }
-                </DHButton>
-            </DatahubAuthView>
-        </MudStack>
 
         @if (_lastUpdateValid)
         {
             <MudText Style="font-style: italic">
-                @Localizer["Last updated {0} {1}", $"{ConvertToLocalTime(_projectCredits.LastUpdate!.Value):yyyy-MM-dd HH:mm}", TimeZone.CurrentTimeZone.StandardName]
+                @Localizer["Last updated {0} {1}", $"{ConvertToLocalTime(_projectCredits.LastUpdate!.Value):yyyy-MM-dd HH:mm}", _timezone]
             </MudText>
         }
 
@@ -74,7 +76,8 @@
         {
             <MudGrid Justify="Justify.FlexStart" Spacing="10" Class="pt-2">
                 <MudItem xs="12">
-                    <MudText Typo="Typo.h6" Align="Align.Center">@Localizer["Refreshing your data. This may take some time..."]</MudText>
+                    <MudText Typo="Typo.h6"
+                             Align="Align.Center">@Localizer["Refreshing your data. This may take some time..."]</MudText>
                 </MudItem>
                 <MudItem xs="6">
                     <MudStack>
@@ -128,7 +131,8 @@
             @if (_projectCosts.Count > 0)
             {
                 <MudStack Style="width: 100%; height: 100%">
-                    <DailyCostsStackBar DailyCosts="@_last30DaysCosts" Title="@Localizer["Daily costs (last 30 days)"]"/>
+                    <DailyCostsStackBar DailyCosts="@_last30DaysCosts"
+                                        Title="@Localizer["Daily costs (last 30 days)"]"/>
                 </MudStack>
             }
         </MudStack>
@@ -174,7 +178,7 @@
                     <strong>@Localizer["Project_Remaining_Credit_label"]</strong> @(string.Format(Localizer["Project_Remaining_Credit_text"], _remainingBudget, _projectBudget))
                 </MudText>
 
-                <MudText >
+                <MudText>
                     <strong>@Localizer["Storage Equivalent:"]</strong> @(string.Format(Localizer["Project_Remaining_Credit_Storage"], _remainingBudget, _storageEquivalentFormatted))
                 </MudText>
 
@@ -243,6 +247,8 @@
     private decimal _remainingBudget;
     private SpendingEstimation _spendingEstimation;
     private string _storageEquivalentFormatted;
+    private IJSObjectReference _module;
+    private string _timezone;
 
 
     protected override async Task OnInitializedAsync()
@@ -268,7 +274,26 @@
 
         if (AreCreditsValid()) HydrateCosts();
         StateHasChanged();
+
+
         _loading = false;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Workspace/Reports/WorkspaceCostingReport.razor.js");
+            }
+            catch (Exception e)
+            {
+                _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor.js");
+            }
+
+            _timezone = await _module.InvokeAsync<string>("retrieveTimeZone");
+        }
     }
 
     private async Task<Datahub_Project> GetProject()

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor.js
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor.js
@@ -1,0 +1,4 @@
+﻿export function retrieveTimeZone() {
+    let date = new Date();
+    return date.toLocaleDateString(undefined, { day: '2-digit', timeZoneName: 'long' }).substring(4)
+}

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostsTable.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostsTable.razor
@@ -9,7 +9,8 @@
             @Localizer["Your workspace's daily costs"]
         </MudText>
         <MudSpacer/>
-        <DHButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@SidebarIcons.Download" OnClick="HandleDownload" Class="mr-4">
+        <DHButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@SidebarIcons.Download"
+                  OnClick="HandleDownload" Class="mr-4">
             @Localizer["Download to CSV"]
         </DHButton>
     </ToolBarContent>
@@ -57,7 +58,21 @@
             .OrderByDescending(c => c.Date)
             .ToListAsync();
         Costs = projectCosts.Select(c => new CostDisplay { Cost = (decimal)c.CadCost, Date = c.Date.ToString("d"), Source = c.ServiceName }).ToList();
-        _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Workspace/Reports/WorkspaceCostsTable.razor.js");
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Workspace/Reports/WorkspaceCostsTable.razor.js");
+            }
+            catch
+            {
+                _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostsTable.razor.js");
+            }
+        }
     }
 
     private async Task HandleDownload()

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Toolbox/WorkspaceToolboxPage.razor
@@ -25,21 +25,30 @@
 
     <MudDivider Class="my-6"/>
 
-    @if (_metadataRequired)
-    {
-        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Style="color: #000;" Class="mb-6">
-            @Localizer["The workspace metadata is currently incomplete. No resources can be provisioned until the project metadata has been filled"].
-            <MudLink Href="@_metadataUrl">
-                @Localizer["Click here to edit the metadata."]
-            </MudLink>
-        </MudAlert>
-    }
-    else
-    {
-        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Style="color: #000;" Class="mb-6">
-            @Localizer["The \"Add to Workspace\" button will show the state your tool request after being clicked."]
-        </MudAlert>
-    }
+    <MudStack Spacing="0" >
+        @if (_metadataRequired)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Style="color: #000;" Class="mb-6">
+                @Localizer["The workspace metadata is currently incomplete. No resources can be provisioned until the project metadata has been filled"].
+                <MudLink Href="@_metadataUrl">
+                    @Localizer["Click here to edit the metadata."]
+                </MudLink>
+            </MudAlert>
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Style="color: #000;" Class="mb-6">
+                @Localizer["The \"Add to Workspace\" button will show the state your tool request after being clicked."]
+            </MudAlert>
+        }
+
+        @if (_toolDisplayStatusMap.Any(s => s.Value is TerraformStatus.CreateRequested or TerraformStatus.InProgress or TerraformStatus.DeleteRequested or TerraformStatus.DeleteInProgress))
+        {
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Style="color: #000;" Class="mb-6">
+                @Localizer["Your tool request was put in the queue and is being processed. Most requests in the queue are processed within an hour. Please come back later and refresh this page. If it takes longer than expected, please submit a support request."]
+            </MudAlert>
+        }
+    </MudStack>
 
     <MudGrid>
         @foreach (var tool in _toolList)
@@ -71,29 +80,36 @@
                                     break;
                                 case TerraformStatus.Completed:
                                     <MudStack>
-                                        <ToolboxButton Status="@status" Disabled="@true" Icon="fa-light fa-check-to-slot"/>
-                                        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym">
-                                            <DHButton Variant="@Variant.Filled" Color="@Color.Error" OnClick="@(() => NavigateToResourceDeletePage(tool))">
+                                        <ToolboxButton Status="@status" Disabled="@true"
+                                                       Icon="fa-light fa-check-to-slot"/>
+                                        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin"
+                                                         ProjectAcronym="@WorkspaceAcronym">
+                                            <DHButton Variant="@Variant.Filled" Color="@Color.Error"
+                                                      OnClick="@(() => NavigateToResourceDeletePage(tool))">
                                                 @Localizer["Remove Tool from Workspace"]
-                                                <DHIcon Icon="@SidebarIcons.Delete" Class="ml-2" Style="font-size: 0.8rem;"/>
+                                                <DHIcon Icon="@SidebarIcons.Delete" Class="ml-2"
+                                                        Style="font-size: 0.8rem;"/>
                                             </DHButton>
                                         </DatahubAuthView>
                                     </MudStack>
                                     break;
                                 case AvailabilityStatus.Available:
-                                    <ToolboxButton Status="@status" Icon="@SidebarIcons.CreateNew" OnClick="@(async () => await AddResourceToWorkspace(tool))"/>
+                                    <ToolboxButton Status="@status" Icon="@SidebarIcons.CreateNew"
+                                                   OnClick="@(async () => await AddResourceToWorkspace(tool))"/>
                                     break;
                                 case AvailabilityStatus.Disabled:
-                                    <ToolboxButton Status="@status" Disabled="@true" Icon="@SidebarIcons.CreateNew"/>
+                                    <ToolboxButton Status="@status" Disabled="@true"
+                                                   Icon="@SidebarIcons.CreateNew"/>
                                     break;
                                 case AvailabilityStatus.UnderDevelopment:
-                                    <ToolboxButton Status="@status" Disabled="@true" Icon="fa-light fa-space-station-moon-construction"/>
+                                    <ToolboxButton Status="@status" Disabled="@true"
+                                                   Icon="fa-light fa-space-station-moon-construction"/>
                                     break;
                                 case AvailabilityStatus.MetadataRequired:
                                     <ToolboxButton Status="@status" Disabled="@true" Icon="@SidebarIcons.Metadata"/>
                                     break;
                                 default:
-                                    <ToolboxButton Status="Error" Disabled="@true" />
+                                    <ToolboxButton Status="Error" Disabled="@true"/>
                                     break;
                             }
                         </MudStack>
@@ -173,7 +189,7 @@
                 _toolDisplayStatusMap[tool] = resourceStatus;
             }
         }
-        
+
         _initializing = false;
         await InvokeAsync(StateHasChanged);
     }
@@ -187,14 +203,14 @@
 
         var resource = _workspace.Resources
             .FirstOrDefault(r => r.ResourceType == TerraformTemplate.GetTerraformServiceType(resourceType));
-        
-        if(resource is null)
+
+        if (resource is null)
         {
             return AvailabilityStatus.Available;
         }
 
         if (resource.Status is not null) return resource.Status;
-        
+
         _logger.LogWarning("Resource {ResourceType} in workspace {WorkspaceAcronym} has no status", resourceType, WorkspaceAcronym);
         // TODO: Add a default status for resources that have no status
         return TerraformStatus.Completed;
@@ -210,10 +226,10 @@
         {
             var resourceType = TerraformTemplate.GetTerraformServiceType(resource);
             await using var ctx = await _contextFactory.CreateDbContextAsync();
-            
+
             var exists = await ctx.Project_Resources2
                 .AnyAsync(r => r.ProjectId == _workspace.Project_ID && r.ResourceType == resourceType);
-            
+
             if (exists)
             {
                 _snackbar.Add(Localizer["{0} is already added to your workspace", GetLabel(resource)], Severity.Info);
@@ -225,14 +241,14 @@
             await _requestManagementService.HandleTerraformRequestServiceAsync(_workspace, template, currentUser);
             _logger.LogInformation("Tool {Tool} successfully added to workspace {WorkspaceAcronym}", resource, WorkspaceAcronym);
             _snackbar.Add(Localizer["{0} successfully added to your workspace", GetLabel(resource)], Severity.Success);
-            
+
             _toolDisplayStatusMap[resource] = TerraformStatus.InProgress;
             await InvokeAsync(StateHasChanged);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error adding tool {Tool} to workspace {WorkspaceAcronym}", resource, WorkspaceAcronym);
-            
+
             _toolDisplayStatusMap[resource] = TerraformStatus.Failed;
             _snackbar.Add(Localizer["Error adding {0} to your workspace", GetLabel(resource)], Severity.Error);
         }


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->
Cleans up the user settings a bit more following the previous bug we had. Centers the text in provisioning buttons, displays the correct timezone in the costing reports and improves the costing reports layout a bit.

Also includes the following message when tools are being provisioned or deleted
![image](https://github.com/user-attachments/assets/bbd6e781-dc0d-4e6a-a969-ff45bb45a005)



## Related Issues
<!-- List any related issues or tickets -->
[Refresh costs is not accessible when no costs yet](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8431)
[Cost reports page shows time in UTC](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8429)
[UserSettings log a minor error in unauthenticated pages](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.23?workitem=8427)
[As a FSDH user, I need to be aware that provisioning is not instantaneous](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_sprints/taskboard/FSDH%20Dev%20Team/FSDH%20SSC/Sprint%203.24?workitem=8412)

## Changes
<!-- List the key changes in this PR -->

- Mainstreamed user settings to be created in a better location to avoid errors on public pages
- Centers the text in toolbox buttons to look better:
Before: 
![image](https://github.com/user-attachments/assets/a0d8d52e-8516-4f56-aeaa-a274a3650245)
After:
![image](https://github.com/user-attachments/assets/d63cbb36-360d-4c1f-9702-a404568abeaf)
-  Shows the correct timezone for the user in the cost report page
- Makes the "Refresh" button accessible even when there are no costs yet
- Moves JS interoperability to better location to avoid some minor errors
- Provides context information when tools are being provisioned   

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Existing tests pass

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes