### PR TITLE
🐛 Fixing an issue on the Support page when workspaces have duplicate names

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
@@ -274,8 +274,11 @@
 
         foreach (var project in _userRoles.Select(userRole => userRole.Project))
         {
-            _ticketWorkspaces.Add(project.Project_Name, false);
-            _ticketWorkspaceAcronyms.Add(project.Project_Name, project.Project_Acronym_CD);
+            if (!_ticketWorkspaces.ContainsKey(project.Project_Name))
+            {
+                _ticketWorkspaces.Add(project.Project_Name, false);
+                _ticketWorkspaceAcronyms.Add(project.Project_Name, project.Project_Acronym_CD);
+            }
         }
 
         StateHasChanged();


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

The Support page retrieves the user's workspaces and uses a dictionary to let them indicate which workspace is having issues. The key in this dictionary is the project name. If the user is part of 2 or more workspaces with the same name, this will cause a crash.

This PR resolves this issue by first checking that the dictionary does not contain the key before attempting to add the workspace.

This is an edge case that does not affect any actual users, but probably good to clean it up anyways.

## Related Issues
<!-- List any related issues or tickets -->

[ISSUE 8444](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/8444)

## Changes
<!-- List the key changes in this PR -->

- Check that the dictionary does NOT contain the key before trying to add it.

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
