### PR TITLE
updated APIs and URLs to add Databricks french extension when possible

### DIFF
--- a/Portal/src/Datahub.Application/Services/Notebooks/IDatabricksApiService.cs
+++ b/Portal/src/Datahub.Application/Services/Notebooks/IDatabricksApiService.cs
@@ -35,8 +35,9 @@ public interface IDatabricksApiService
     /// Get Databricks Url for the project
     /// </summary>
     /// <param name="projectAcronym"></param> 
-    /// <returns>Databricks Url</returns>
-    public Task<string>GetDatabricsWorkspaceUrlAsync(string projectAcronym);
+    /// <param name="isFrench">If language is French then sets adds URL parameter to open Databricks in French. Null if no localization should be done</param>
+    /// <returns>Databricks Url</returns>    
+    public Task<string>GetDatabricsWorkspaceUrlAsync(string projectAcronym, bool? isFrench);
 
     /// <summary>
     /// Adds user as an admin to Databricks admin group

--- a/Portal/src/Datahub.Core/Utils/TerraformOutputHelper.cs
+++ b/Portal/src/Datahub.Core/Utils/TerraformOutputHelper.cs
@@ -22,7 +22,7 @@ public static class TerraformOutputHelper
             expectedTerraformOutput = string.Join(",", expectedTerraformOutput,
                 GetExpectedTerraformOutputAzureDatabricksString());
             workspaceId ??= TerraformVariableExtraction.ExtractDatabricksWorkspaceId(project);
-            workspaceUrl ??= TerraformVariableExtraction.ExtractDatabricksUrl(project);
+            workspaceUrl ??= TerraformVariableExtraction.ExtractDatabricksUrl(project, null);
         }
 
         if (project.Resources.Any(r => r.ResourceType.Equals(TerraformTemplate.GetTerraformServiceType(TerraformTemplate.AzureAppService))))

--- a/Portal/src/Datahub.Core/Utils/TerraformVariableExtraction.cs
+++ b/Portal/src/Datahub.Core/Utils/TerraformVariableExtraction.cs
@@ -28,29 +28,52 @@ public static class TerraformVariableExtraction
     /// Extracts the databricks url from a Datahub Project. Be sure to include the project resources in the project object.
     /// </summary>
     /// <param name="project"></param>
+    /// <param name="isFrench">A flag indicating whether the Databricks preferred language is French</param>
     /// <returns>Databricks url of the project</returns>
-    public static string? ExtractDatabricksUrl(Datahub_Project? project)
+    public static string? ExtractDatabricksUrl(Datahub_Project? project, bool? isFrench)
     {
         var databricksTemplateName = TerraformTemplate.GetTerraformServiceType(TerraformTemplate.AzureDatabricks);
         var databricksUrlVariable = ExtractStringVariable(
             project?.Resources?.FirstOrDefault(r => r.ResourceType == databricksTemplateName)?.JsonContent,
             "workspace_url");
 
-        return FormatDatabricksUrl(databricksUrlVariable);
+        return AddLanguageURLParameter(FormatDatabricksUrl(databricksUrlVariable), isFrench);
+    }
+
+    private static string? AddLanguageURLParameter(string? databricksURL, bool? isFrench)
+    {
+        if (isFrench is null || databricksURL is null || isFrench == false)
+        {
+            return databricksURL;
+        }
+        if (isFrench == true)
+        {
+            var langParam = "?l=fr";
+            if (databricksURL.EndsWith("/"))
+            {
+                databricksURL = databricksURL + langParam;
+            }
+            else
+            {
+                databricksURL = databricksURL + "/" + langParam;
+            }
+        }
+        return databricksURL;
     }
 
     /// <summary>
     /// Extracts the Databricks URL from the specified project resource.
     /// </summary>
     /// <param name="projectResource">The project resource containing the JSON content.</param>
+    /// <param name="isFrench">A flag indicating whether the Databricks preferred language is French</param>
     /// <returns>The extracted Databricks URL or null if not found.</returns>
-    public static string? ExtractDatabricksUrl(Project_Resources2? projectResource)
+    public static string? ExtractDatabricksUrl(Project_Resources2? projectResource, bool isFrench)
     {
         var databricksUrlVariable = ExtractStringVariable(
             projectResource?.JsonContent,
             "workspace_url");
 
-        return FormatDatabricksUrl(databricksUrlVariable);
+        return AddLanguageURLParameter(FormatDatabricksUrl(databricksUrlVariable), isFrench);
     }
 
     /// <summary>
@@ -115,9 +138,9 @@ public static class TerraformVariableExtraction
     /// <returns>A list of string, corresponding to the keys of the environment variables stored in the workspace keyvault</returns>
     public static IList<string> ExtractEnvironmentVariableKeys(Project_Resources2 projectResources)
     {
-     var envVarsString = ExtractStringVariable(projectResources?.InputJsonContent, "environment_variables_keys") ?? "[]";
-     var envVars = JsonSerializer.Deserialize<List<string>>(envVarsString);
-     return envVars ?? new List<string>();
+        var envVarsString = ExtractStringVariable(projectResources?.InputJsonContent, "environment_variables_keys") ?? "[]";
+        var envVars = JsonSerializer.Deserialize<List<string>>(envVarsString);
+        return envVars ?? new List<string>();
     }
 
     /// <summary>

--- a/Portal/src/Datahub.Infrastructure.Offline/OfflineDatabricksApiService.cs
+++ b/Portal/src/Datahub.Infrastructure.Offline/OfflineDatabricksApiService.cs
@@ -26,7 +26,7 @@ public class OfflineDatabricksApiService : IDatabricksApiService
     {
         return Task.FromResult(true);
     }
-    public Task<string> GetDatabricsWorkspaceUrlAsync(string projectAcronym)
+    public Task<string> GetDatabricsWorkspaceUrlAsync(string projectAcronym, bool? isFrench)
     {
         return Task.FromResult(string.Empty);
     }

--- a/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
@@ -318,7 +318,7 @@ namespace Datahub.Infrastructure.Services.Helpers
                 else
                 {
                     // We attempt to retrieve the databricks URL. If we cannot, we return an unhealthy status.
-                    var databricksUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project);
+                    var databricksUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project, null);
 
                     if (databricksUrl == null)
                     {

--- a/Portal/src/Datahub.Infrastructure/Services/Notebooks/DatabricksApiService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Notebooks/DatabricksApiService.cs
@@ -60,7 +60,7 @@ public class DatabricksApiService : IDatabricksApiService
 
     public async Task<List<RepositoryInfoDto>> ListWorkspaceRepositoriesAsync(string projectAcronym, string accessToken)
     {
-        var workspaceDatabricksUrl = await GetWorkspaceDatabricksUrl(projectAcronym);
+        var workspaceDatabricksUrl = await GetWorkspaceDatabricksUrl(projectAcronym, null);
 
         // Use the access token to call a protected web API.
         var httpClient = _httpClientFactory.CreateClient();
@@ -138,11 +138,17 @@ public class DatabricksApiService : IDatabricksApiService
         return true;
     }
 
-    public async Task<string> GetDatabricsWorkspaceUrlAsync(string projectAcronym)
+    /// <summary>
+    /// Get Databricks Url for the project
+    /// </summary>
+    /// <param name="projectAcronym">Acronym</param>
+    /// <param name="isFrench">If true adds parameter to change the language to French</param>
+    /// <returns></returns>
+    public async Task<string> GetDatabricsWorkspaceUrlAsync(string projectAcronym, bool? isFrench)
     {
         try
         {
-            var workspaceDatabricksUrl = await GetWorkspaceDatabricksUrl(projectAcronym);
+            var workspaceDatabricksUrl = await GetWorkspaceDatabricksUrl(projectAcronym, isFrench);
             return workspaceDatabricksUrl;
         }
         catch (Exception)
@@ -155,7 +161,7 @@ public class DatabricksApiService : IDatabricksApiService
     {
         try
         {
-            var workspaceDatabricksUrl = await GetWorkspaceDatabricksUrl(projectAcronym);
+            var workspaceDatabricksUrl = await GetWorkspaceDatabricksUrl(projectAcronym, null);
 
             // Use the access token to call a protected web API.
             var httpClient = _httpClientFactory.CreateClient();
@@ -234,7 +240,7 @@ public class DatabricksApiService : IDatabricksApiService
             .ToDictionaryAsync(pr => pr.RepositoryUrl, pr => pr.IsPublic);
     }
 
-    private async Task<string> GetWorkspaceDatabricksUrl(string projectAcronym)
+    private async Task<string> GetWorkspaceDatabricksUrl(string projectAcronym, bool? isFrench)
     {
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
         var project = await dbContext.Projects
@@ -247,7 +253,7 @@ public class DatabricksApiService : IDatabricksApiService
             throw new ArgumentException($"Project with acronym {projectAcronym} not found");
         }
 
-        var databricksUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project);
+        var databricksUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project, isFrench);
         if (databricksUrl == null)
         {
             _logger.LogError("Databricks url not found for project {ProjectAcronym}", projectAcronym);

--- a/Portal/src/Datahub.Infrastructure/Services/ResourceMessagingService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/ResourceMessagingService.cs
@@ -67,7 +67,7 @@ public class ResourceMessagingService(
             Templates = templates,
             AppData = new WorkspaceAppData
             {
-                DatabricksHostUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project),
+                DatabricksHostUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project, null),
                 AppServiceConfiguration = TerraformVariableExtraction.ExtractAppServiceConfiguration(project)
             },
             RequestingUserEmail = requestingUserEmail,

--- a/Portal/src/Datahub.Portal/Layout/PersonalSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/PersonalSidebar.razor
@@ -12,6 +12,7 @@
 @inject IDbContextFactory<DatahubProjectDBContext> _dbContextFactory
 @inject IDialogService _dialogService
 @inject NavigationManager _navigationManager
+@inject ICultureService CultureService
 
 @if (!_isLoaded)
 {
@@ -279,7 +280,7 @@
         return recentActivity.userRecentLink.LinkType switch
         {
             DatahubLinkType.DataProject => $"{PageRoutes.WorkspacePrefix}/{recentActivity.userRecentLink.DataProject}",
-            DatahubLinkType.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(recentActivity.datahubProject),
+            DatahubLinkType.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(recentActivity.datahubProject, CultureService.IsFrench),
             DatahubLinkType.Repository => $"{PageRoutes.WorkspacePrefix}/{recentActivity.userRecentLink.DataProject}/{WorkspaceSidebar.SectionViews.Repositories}",
             DatahubLinkType.Storage => $"{PageRoutes.WorkspacePrefix}/{recentActivity.userRecentLink.DataProject}/{WorkspaceSidebar.SectionViews.Storage}",
             DatahubLinkType.ResourceArticle => $"{PageRoutes.ResourcePrefix}/{recentActivity.userRecentLink.ResourceArticleId}",

--- a/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
@@ -14,6 +14,7 @@
 @inject UserLocationManagerService _userLocationManagerService
 @inject IDbContextFactory<DatahubProjectDBContext> _dbContextFactory
 @inject DatahubPortalConfiguration _datahubPortalConfiguration
+@inject ICultureService CultureService
 
 <MudStack Class="px-4 mt-6" id="nav">
     <MudDrawerHeader Style="padding: 0">
@@ -259,7 +260,7 @@
     {
         return sectionView switch
         {
-            SectionViews.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(_project),
+            SectionViews.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(_project, CultureService.IsFrench),
             SectionViews.WebApp => PageRoutes.WorkspaceWebAppShare.Replace("{WorkspaceAcronymParam}", WorkspaceAcronym),
             _ => $"{_path}/{sectionView}"
         };

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
@@ -9,6 +9,7 @@
 @inject IUserInformationService _userInformationService
 @inject UserLocationManagerService _userLocationManagerService
 @inject IDbContextFactory<DatahubProjectDBContext> _dbContextFactory
+@inject ICultureService CultureService
 
 <MudText Typo="Typo.h2">@Localizer["Quick links"]</MudText>
 <div role="group">
@@ -102,7 +103,7 @@
         return recentActivity.userRecentLink.LinkType switch
         {
             DatahubLinkType.DataProject => $"{PageRoutes.WorkspacePrefix}/{recentActivity.userRecentLink.DataProject}",
-            DatahubLinkType.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(recentActivity.datahubProject),
+            DatahubLinkType.Databricks => TerraformVariableExtraction.ExtractDatabricksUrl(recentActivity.datahubProject, CultureService.IsFrench),
             DatahubLinkType.Repository => $"{PageRoutes.WorkspacePrefix}/{recentActivity.userRecentLink.DataProject}/{WorkspaceSidebar.SectionViews.Repositories}",
             DatahubLinkType.Storage => $"{PageRoutes.WorkspacePrefix}/{recentActivity.userRecentLink.DataProject}/{WorkspaceSidebar.SectionViews.Storage}",
             DatahubLinkType.ResourceArticle => $"{PageRoutes.ResourcePrefix}/{recentActivity.userRecentLink.ResourceArticleId}",

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/DatabricksCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Dashboard/DatabricksCard.razor
@@ -1,4 +1,5 @@
 @using Datahub.Core.Model.Projects
+@inject ICultureService CultureService
 
 <MudPaper Outlined Class="pa-4">
     <MudStack>
@@ -41,7 +42,7 @@
 
     private string ExtractDatabricksUrl()
     {
-        return TerraformVariableExtraction.ExtractDatabricksUrl(ProjectResource);
+        return TerraformVariableExtraction.ExtractDatabricksUrl(ProjectResource, CultureService.IsFrench);
     }
 
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Metadata/WorkspaceMetadataPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Metadata/WorkspaceMetadataPage.razor
@@ -17,6 +17,7 @@
 @inject ILogger<WorkspaceMetadataPage> Logger
 @inject IServiceAuthManager _serviceAuthManager
 @inject IUserInformationService _userInformationService
+@inject ICultureService CultureService
 
 <MudPaper Class="py-4 px-6">
     <MudStack>
@@ -58,7 +59,7 @@
 
             if (projectDatabricks is { CreatedAt: not null })
             {
-                var databricksUrlVariable = TerraformVariableExtraction.ExtractDatabricksUrl(projectDatabricks);
+                var databricksUrlVariable = TerraformVariableExtraction.ExtractDatabricksUrl(projectDatabricks, CultureService.IsFrench);
 
                 MetadataBrokerService.CreateChildMetadata(project.Project_Acronym_CD, $"{project.Project_Acronym_CD}-Databricks",
                     MetadataObjectType.Databricks, databricksUrlVariable, true);

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Sudo/WorkspaceSudoPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Sudo/WorkspaceSudoPage.razor
@@ -166,7 +166,7 @@
 
     private async Task AddToDatabricksAdmins()
     {
-        var dataBricksUrl = await _databricksApiService.GetDatabricsWorkspaceUrlAsync(WorkspaceAcronym);
+        var dataBricksUrl = await _databricksApiService.GetDatabricsWorkspaceUrlAsync(WorkspaceAcronym, null);
         if (string.IsNullOrEmpty(dataBricksUrl))
         {
             _snackbar.Add(Localizer["Your workspace does not have Databricks"], Severity.Error);

--- a/Portal/test/Datahub.Infrastructure.UnitTests/Services/DatabricksApiServiceTests.cs
+++ b/Portal/test/Datahub.Infrastructure.UnitTests/Services/DatabricksApiServiceTests.cs
@@ -5,6 +5,7 @@ using Datahub.Core.Model.Context;
 using Datahub.Core.Model.Datahub;
 using Datahub.Core.Model.Projects;
 using Datahub.Core.Services;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Graph.Models;
 using Moq;
@@ -48,7 +49,17 @@ public class DatabricksApiServiceTests
     public async Task ShouldReturnDatabricsWorkspaceUrl(string projectAcronym, string expectedResult)
     {
         await SeedDatabase();
-        var dataBricksUrl = await _databricksApiService.GetDatabricsWorkspaceUrlAsync(projectAcronym);
+        var dataBricksUrl = await _databricksApiService.GetDatabricsWorkspaceUrlAsync(projectAcronym, false);
+        Assert.That(dataBricksUrl, Is.EqualTo(expectedResult));
+    }
+
+    [Test]
+    [TestCase("TEST1", "https://test.azuredatabricks.net/?l=fr")]
+    [TestCase("UNKNOWN", "")]
+    public async Task ShouldReturnDatabricsWorkspaceUrlFr(string projectAcronym, string expectedResult)
+    {
+        await SeedDatabase();
+        var dataBricksUrl = await _databricksApiService.GetDatabricsWorkspaceUrlAsync(projectAcronym, true);
         Assert.That(dataBricksUrl, Is.EqualTo(expectedResult));
     }
 

--- a/Portal/test/Datahub.SpecflowTests/Steps/TerraformVariableExtractionSteps.cs
+++ b/Portal/test/Datahub.SpecflowTests/Steps/TerraformVariableExtractionSteps.cs
@@ -51,7 +51,7 @@ public sealed class TerraformVariableExtractionSteps
     public void WhenICallTheMethodToExtractTheDatabricksWorkspaceUrl()
     {
         var project = _scenarioContext["project"] as Datahub_Project;
-        var databricksUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project);
+        var databricksUrl = TerraformVariableExtraction.ExtractDatabricksUrl(project, null);
         _scenarioContext["databricksUrl"] = databricksUrl;
     }
 


### PR DESCRIPTION
# Pull Request

Extended internal APIs to add `?l=fr` to databricks URLs in the portal when user has language configured to French.

## Checklist

- [X] Code follows dotnet coding standards
- [X] Tests added/updated to cover changes
