### PR TITLE
potential fix to the deletion of workspaces

### DIFF
--- a/ServerlessOperations/src/Datahub.Functions/InactivityScheduler.cs
+++ b/ServerlessOperations/src/Datahub.Functions/InactivityScheduler.cs
@@ -61,7 +61,7 @@ namespace Datahub.Functions
         private async Task<List<int>> GetProjects()
         {
             using var ctx = await dbContextFactory.CreateDbContextAsync();
-            return ctx.Projects.AsNoTracking().Select(x => x.Project_ID).Distinct().ToList();
+            return ctx.Projects.Where(w => !w.IsDeleted).AsNoTracking().Select(x => x.Project_ID).Distinct().ToList();
         }
 
         private async Task<List<int>> GetUsers()

--- a/ServerlessOperations/src/Datahub.Functions/ProjectInactiveHandler.cs
+++ b/ServerlessOperations/src/Datahub.Functions/ProjectInactiveHandler.cs
@@ -49,15 +49,19 @@ public class ProjectInactiveHandler(
 
     private async Task HandleInactiveProject(ProjectInactiveMessage output)
     {
-        await using var ctx = await dbContextFactory.CreateDbContextAsync();
-        var project = await ctx.Projects
-            .Include(p => p.Resources)
-            .FirstAsync(p => p.Project_Acronym_CD == output.WorkspaceAcronym);
-        
-        project.Deleted_DT = DateTime.UtcNow;
-        ctx.Projects.Update(project);
-        await ctx.SaveChangesAsync();
-        
+        _logger.LogInformation("This workspace should be set to be deleted, but functionality is not ready yet.");
+
+        //TODO -> Once we have the delete resources and delete workspaces service working, plug it in here.
+
+        //await using var ctx = await dbContextFactory.CreateDbContextAsync();
+        //var project = await ctx.Projects
+        //    .Include(p => p.Resources)
+        //    .FirstAsync(p => p.Project_Acronym_CD == output.WorkspaceAcronym);
+
+        //project.Deleted_DT = DateTime.UtcNow;
+        //ctx.Projects.Update(project);
+        //await ctx.SaveChangesAsync();
+
         // TODO: mark each resource as to be deleted
         // TODO: send workspace definition to resource run queue
     }

--- a/ServerlessOperations/src/Datahub.Functions/ProjectInactivityNotifier.cs
+++ b/ServerlessOperations/src/Datahub.Functions/ProjectInactivityNotifier.cs
@@ -61,7 +61,8 @@ namespace Datahub.Functions
             var project = await ctx.Projects
                 .Include(p => p.Users)
                 .ThenInclude(u => u.PortalUser)
-                .AsNoTracking().Where(x => x.Project_ID == message.ProjectId)
+                .AsNoTracking()
+                .Where(x => x.Project_ID == message.ProjectId)
                 .FirstOrDefaultAsync(ct);
 
             // get project info
@@ -90,7 +91,15 @@ namespace Datahub.Functions
 
             // check if project to be deleted
             var projectToBeDeleted = CheckIfProjectToBeDeleted(daysSinceLastLogin, operationalWindow, hasCostRecovery);
-
+            if (projectToBeDeleted)
+            {
+                _logger.LogInformation($"Workspace {project.Project_Acronym_CD} is set to be deleted.");
+                _logger.LogInformation($"Workspace has not been logged into for {daysSinceLastLogin} days.");
+            }
+            else
+            { 
+                _logger.LogInformation($"Workspace {project.Project_Acronym_CD} is safe from deletion");            
+            }
             // if project to be deleted, send to terraform delete queue
             if (projectToBeDeleted)
             {

--- a/ServerlessOperations/src/Datahub.Functions/ProjectInactivityNotifier.cs
+++ b/ServerlessOperations/src/Datahub.Functions/ProjectInactivityNotifier.cs
@@ -58,7 +58,10 @@ namespace Datahub.Functions
             await using var ctx = await dbContextFactory.CreateDbContextAsync(ct);
 
             // get project
-            var project = await ctx.Projects.AsNoTracking().Where(x => x.Project_ID == message.ProjectId)
+            var project = await ctx.Projects
+                .Include(p => p.Users)
+                .ThenInclude(u => u.PortalUser)
+                .AsNoTracking().Where(x => x.Project_ID == message.ProjectId)
                 .FirstOrDefaultAsync(ct);
 
             // get project info


### PR DESCRIPTION
# Pull Request

## Description
project notifier cleans up and deletes workspaces when they shouldn't be deleted. 

## Related Issues
8489 investigate and stop the workspaces from being needlessly deleted

## Changes
The user records were missing from the project, this was a bug


## Testing
Need to test on cloud

