### PR TITLE
🔧 Create workspace form improvements

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/ProjectCreationService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/ProjectCreationService.cs
@@ -55,10 +55,18 @@ public class ProjectCreationService(
             _ => words.Select(w => w[0]).Aggregate("", (a, b) => a + b).ToUpperInvariant()
         };
         var enumerable = existingAcronyms.ToArray();
+        if (acronym.Length > 7) // Ensure acronym is not too long
+        {
+            acronym = acronym.Substring(0, 7);
+        }
         if (!enumerable.Contains(acronym)) return acronym;
         var largestNumber = enumerable.Where(a => a.StartsWith(acronym)).Select(
             a => a.Length > acronym.Length && int.TryParse(a[acronym.Length..], out var n) ? n : 0
         ).Max();
+        if (acronym.Length > 7 - (largestNumber + 1).ToString().Length) // If acronym would be too long with a number, shorten it
+        {
+            acronym = acronym.Substring(0, 7 - (largestNumber + 1).ToString().Length);
+        }
         acronym += (largestNumber + 1).ToString();
         return await Task.FromResult(acronym);
     }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
@@ -22,7 +22,9 @@
                           RequiredError="@Localizer["Workspace Title is required"]"
                           HelperText="@Localizer["Enter a descriptive title for the workspace"]"
                           DebounceInterval="500"
-                          OnDebounceIntervalElapsed="UpdateProjectAcronym" />
+                          OnDebounceIntervalElapsed="UpdateProjectAcronym" 
+                          Validation="@(new Func<string, Task<string>>(ValidateTitle))"
+                          MaxLength="@MaxTitleLength" />
 
             <MudTextField T="string"
                           @bind-Value="_projectAcronym"
@@ -37,7 +39,8 @@
                           @ref="_acronymField"
                           alt=@Localizer["A unique alphanumeric acronym to identify the workspace. Click the icon to generate an acronym based on the title."]
                           Required
-                          Validation="@(new Func<string, Task<string>>(ValidateAcronym))" />
+                          Validation="@(new Func<string, Task<string>>(ValidateAcronym))"
+                          MaxLength="@MaxAcronymLength"/>
 
             <MudSelect T="string"
                        Label="@Localizer["(Optional) Which features are of interest to you?"]"
@@ -98,6 +101,7 @@
 
 #nullable enable
     private const int MaxAcronymLength = 7;
+    private const int MaxTitleLength = 100;
     private string? _errorMessage;
     private string _projectTitle = string.Empty;
     private string _projectAcronym = string.Empty;
@@ -139,6 +143,13 @@
         return (acronym.Length > MaxAcronymLength ? Localizer["Acronym must be {0} characters or less", MaxAcronymLength] : null)!;
     }
 
+    private async Task<string?> ValidateTitle(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return Localizer["Workspace Title is required"];
+        return (title.Length > MaxTitleLength ? Localizer["Workspace Title must be {0} characters or less", MaxTitleLength] : null)!;
+    }
+
     private readonly Converter<string> _converter = new()
         {
             SetFunc = value => value?.ToUpperInvariant() ?? string.Empty,
@@ -154,6 +165,7 @@
     private async Task CreateProject()
     {
         _success = string.IsNullOrWhiteSpace(await ValidateAcronym(_projectAcronym)); // Force validation - users can avoid otherwise by clicking the button while the field is selected.
+        _success = _success && string.IsNullOrWhiteSpace(await ValidateTitle(_projectTitle));
 
         if (_success)
         {

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -2827,6 +2827,7 @@
   "Workspace Title": "Titre de l'espace de travail",
   "Workspace Title is required": "Le titre de l'espace de travail est obligatoire",
   "Workspace Title is required to generate an acronym": "Le titre de l'espace de travail est requis pour générer un acronyme",
+  "Workspace Title must be {0} characters or less": "Le titre de l'espace de travail doit comporter {0} caractères ou moins",
   "Workspace Tools": "Outils de l'espace de travail",
   "Workspace Users": "Utilisateurs de l'espace de travail",
   "Workspace Version": "Version de l'espace de travail",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1931,6 +1931,7 @@
   "Workspace Title": "Workspace Title",
   "Workspace Title is required": "Workspace Title is required",
   "Workspace Title is required to generate an acronym": "Workspace Title is required to generate an acronym",
+  "Workspace Title must be {0} characters or less": "Workspace Title must be {0} characters or less",
   "Workspace Tools": "Workspace Tools",
   "Workspace Users": "Workspace Users",
   "Workspace Version": "Workspace Version",


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

There are some issues with the create workspace form identified during UAT:
* The form does not validate titles and will hang if a title is over 100 characters.
* The automatically generated acronyms can break rules (such as max 7 characters).

This PR corrects these issues.

## Related Issues
<!-- List any related issues or tickets -->

[TASK 8499](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/8499)
[TASK 8500](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/8500)

## Changes
<!-- List the key changes in this PR -->

- Add `MaxLength` parameters to workspace title and acronym in the form.
    - Validation for titles is also performed along with acronym validation
- Changes `ProjectCreationService.cs` to prevent it from generating invalid acronyms.
- Adds i18n for new error messages.

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested, replicating UAT conditions that led to issues

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
