### PR TITLE
🐛 Re-implementing truncation of long links in Recent Links

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
@@ -24,7 +24,7 @@
                             @foreach (var recentActivity in _recentLinks)
                             {
                                 <li>
-                                    <MudLink Href="@GetSectionViewUrl(recentActivity)" Style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
+                                    <MudLink Href="@GetSectionViewUrl(recentActivity)">
                                         <DHIcon Icon="@GetIcon(recentActivity)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" Color="Color.Dark"/>
                                         @GetLabel(recentActivity)
                                     </MudLink>
@@ -126,7 +126,7 @@
 
     private string GetLabel((UserRecentLink userRecentLink, Datahub_Project datahubProject) recentActivity)
     {
-        return recentActivity.userRecentLink.LinkType switch
+        var label = recentActivity.userRecentLink.LinkType switch
         {
             DatahubLinkType.DataProject => recentActivity.datahubProject?.ProjectName ?? recentActivity.userRecentLink.DataProject ?? "Workspace",
             DatahubLinkType.Databricks => $"{Localizer["Databricks"]} - {recentActivity.datahubProject.ProjectName}",
@@ -135,6 +135,12 @@
             DatahubLinkType.ResourceArticle => recentActivity.userRecentLink.ResourceArticleTitle,
             _ => recentActivity.datahubProject.ProjectName
         };
+
+        if (label.Length > 40)
+        {
+            return label.Substring(0, 40) + "...";
+        }
+        return label;
     }
 
 }

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
@@ -127,7 +127,7 @@
 
     private string GetLabel((UserRecentLink userRecentLink, Datahub_Project datahubProject) recentActivity)
     {
-        var label = recentActivity.userRecentLink.LinkType switch
+        return recentActivity.userRecentLink.LinkType switch
         {
             DatahubLinkType.DataProject => recentActivity.datahubProject?.ProjectName ?? recentActivity.userRecentLink.DataProject ?? "Workspace",
             DatahubLinkType.Databricks => $"{Localizer["Databricks"]} - {recentActivity.datahubProject.ProjectName}",
@@ -136,8 +136,6 @@
             DatahubLinkType.ResourceArticle => recentActivity.userRecentLink.ResourceArticleTitle,
             _ => recentActivity.datahubProject.ProjectName
         };
-
-        return label;
     }
 
 }

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
@@ -24,10 +24,11 @@
                             @foreach (var recentActivity in _recentLinks)
                             {
                                 <li>
-                                    <MudLink Href="@GetSectionViewUrl(recentActivity)">
-                                        <DHIcon Icon="@GetIcon(recentActivity)" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" Color="Color.Dark"/>
-                                        @GetLabel(recentActivity)
-                                    </MudLink>
+                                    <DHButton Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
+                                        <MudText Style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:40ch; display:inline-block">
+                                            @GetLabel(recentActivity)
+                                        </MudText>
+                                    </DHButton>
                                 </li>
                             }
                         </ul>
@@ -136,10 +137,6 @@
             _ => recentActivity.datahubProject.ProjectName
         };
 
-        if (label.Length > 40)
-        {
-            return label.Substring(0, 40) + "...";
-        }
         return label;
     }
 

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
@@ -24,18 +24,11 @@
                             @foreach (var recentActivity in _recentLinks)
                             {
                                 <li>
-                                    <MudTooltip Text="@GetLabel(recentActivity)" Placement="Placement.Top">
-                                        <DHButton Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
-                                            <MudText Style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:40ch; display:inline-block">
-                                                @GetLabel(recentActivity)
-                                            </MudText>
-                                        </DHButton>
-                                    </MudTooltip>
-                                    @* <DHButton Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
+                                    <DHButton title="@GetLabel(recentActivity)" Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
                                         <MudText Style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:40ch; display:inline-block">
                                             @GetLabel(recentActivity)
                                         </MudText>
-                                    </DHButton> *@
+                                    </DHButton>
                                 </li>
                             }
                         </ul>

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeNav.razor
@@ -24,11 +24,18 @@
                             @foreach (var recentActivity in _recentLinks)
                             {
                                 <li>
-                                    <DHButton Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
+                                    <MudTooltip Text="@GetLabel(recentActivity)" Placement="Placement.Top">
+                                        <DHButton Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
+                                            <MudText Style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:40ch; display:inline-block">
+                                                @GetLabel(recentActivity)
+                                            </MudText>
+                                        </DHButton>
+                                    </MudTooltip>
+                                    @* <DHButton Underline NoWrap StartIcon="@GetIcon(recentActivity)" Href="@GetSectionViewUrl(recentActivity)" Variant="Variant.Text" Color="Color.Primary">
                                         <MudText Style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:40ch; display:inline-block">
                                             @GetLabel(recentActivity)
                                         </MudText>
-                                    </DHButton>
+                                    </DHButton> *@
                                 </li>
                             }
                         </ul>


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Recent links were intended to truncate to be the same size as the other navigation boxes, but this was not functional.

This PR caps the length of the labels at 40 characters.

### Before

![image](https://github.com/user-attachments/assets/8b6018d6-39e8-4a14-8e33-4a13c9734d81)

### After

![image](https://github.com/user-attachments/assets/38ec8d54-3ff0-4304-9c67-955631f0c3e6)

## Related Issues
<!-- List any related issues or tickets -->

TASK 8502

## Changes
<!-- List the key changes in this PR -->

- Replaces current recent activity display to use a DHButton
- Adds truncation using styling on the DHButton

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
