### PR TITLE
Only let Datahub Support remove workspace leads from workspaces

### DIFF
--- a/Portal/src/Datahub.Core/Datahub.Core.csproj
+++ b/Portal/src/Datahub.Core/Datahub.Core.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="AElemental.Blazor.Theme" Version="1.6.22173.2" />
 
 		<PackageReference Include="Azure.Identity" Version="1.12.*" />
-		<PackageReference Include="AspNetCore.Localizer.Json" Version="0.1.*" />
+		<PackageReference Include="AspNetCore.Localizer.Json" Version="0.1.0" />
 
 		<PackageReference Include="Azure.Monitor.Query" Version="1.3.*" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.5.*" />

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
@@ -171,7 +171,8 @@
                 @rowContext.PortalUser.Email
             </MudTd>
             <MudTd Style="@(IsModified(rowContext) ? _modifiedCellStyle : string.Empty)">
-                <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym">
+                
+                <DatahubAuthView AuthLevel="@GetAuthLevel(rowContext)" ProjectAcronym="@WorkspaceAcronym">
                     <Authorized>
                         @{
                             var updateCommand = _usersToUpdate.FirstOrDefault(x => x.ProjectUser.PortalUser.Id == rowContext.PortalUser.Id);
@@ -231,4 +232,9 @@
     private List<Datahub_Project_User> _currentlySelected = new();
 
     private string _modifiedCellStyle;
+
+    private DatahubAuthView.AuthLevels GetAuthLevel(Datahub_Project_User projectUser)
+    {
+        return projectUser.Role?.Id == 2 ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.WorkspaceAdmin;
+    }
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor
@@ -233,8 +233,5 @@
 
     private string _modifiedCellStyle;
 
-    private DatahubAuthView.AuthLevels GetAuthLevel(Datahub_Project_User projectUser)
-    {
-        return projectUser.Role?.Id == 2 ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.WorkspaceAdmin;
-    }
+    
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor.cs
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Datahub.Application.Commands;
 using Datahub.Application.Services;
+using Datahub.Core.Components.AuthViews;
 using Datahub.Core.Model.Projects;
 using Datahub.Shared.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -100,7 +101,10 @@ namespace Datahub.Portal.Pages.Workspace.Users
         {
             return _usersToUpdate.Any(x => x.ProjectUser.PortalUser.GraphGuid == projectUser.PortalUser.GraphGuid);
         }
-
+        private DatahubAuthView.AuthLevels GetAuthLevel(Datahub_Project_User projectUser)
+        {
+            return projectUser.Role?.Id == 2 ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.WorkspaceAdmin;
+        }
         private void ChangeDataStewardFlag(Datahub_Project_User projectUser, bool newValue)
         {
             projectUser.IsDataSteward = newValue;


### PR DESCRIPTION
# Pull Request

## Description
In the workspace user management screen, only datahub support should be allowed to remove workspace leads,

## Related Issues
9660 - Only let Datahub Support remove workspace leads

## Changes
added a method to determine access level in the users table

## Checklist
- [✔️ ] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
