### PR TITLE
SAS Token generation hotfixes

### DIFF
--- a/Portal/src/Datahub.Core/Storage/ICloudStorageManager.cs
+++ b/Portal/src/Datahub.Core/Storage/ICloudStorageManager.cs
@@ -6,7 +6,7 @@ public interface ICloudStorageManager
 {
     Task<List<string>> GetContainersAsync();
 
-    Task<Uri> GenerateSasTokenAsync(string container, int days);
+    Task<Uri> GenerateSasTokenAsync(string container, TimeSpan timeSpan);
 
     Task<DfsPage> GetDfsPagesAsync(string container, string folderPath, string? continuationToken = default);
 

--- a/Portal/src/Datahub.Infrastructure/Services/Storage/AWSCloudStorageManager.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Storage/AWSCloudStorageManager.cs
@@ -170,10 +170,9 @@ public class AWSCloudStorageManager : ICloudStorageManager
 		}
 	}
 
-	public Task<Uri> GenerateSasTokenAsync(string container, int days)
+	public Task<Uri> GenerateSasTokenAsync(string container, TimeSpan timeSpan)
 	{
-		// not supported
-		return Task.FromResult(new Uri("http://none"));
+		throw new NotImplementedException();
 	}
 
 	public Task<StorageMetadata> GetStorageMetadataAsync(string container)

--- a/Portal/src/Datahub.Infrastructure/Services/Storage/AzureCloudStorageManager.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Storage/AzureCloudStorageManager.cs
@@ -60,12 +60,12 @@ public class AzureCloudStorageManager : ICloudStorageManager
         return new DfsPage(folders, files, continuationToken!);
     }
 
-    public Task<Uri> GenerateSasTokenAsync(string container, int days)
+    public Task<Uri> GenerateSasTokenAsync(string container, TimeSpan timeSpan)
     {
         ValidateContainerName(container);
 
         var containerClient = GetBlobContainerClient(container);
-        var sasBuilder = GetContainerSasBuild(container, days, BlobSasPermissions.All);
+        var sasBuilder = GetContainerSasBuild(container, timeSpan, BlobSasPermissions.All);
         var sharedKeyCred = GetSharedKeyCredentialAsync();
 
         var blobUriBuilder = new BlobUriBuilder(containerClient.Uri)
@@ -290,14 +290,14 @@ public class AzureCloudStorageManager : ICloudStorageManager
         return blobServiceClient.GetBlobContainerClient(containerName);
     }
 
-    static BlobSasBuilder GetContainerSasBuild(string containerName, int days, BlobSasPermissions permissions)
+    static BlobSasBuilder GetContainerSasBuild(string containerName, TimeSpan timeSpan, BlobSasPermissions permissions)
     {
         var sasBuilder = new BlobSasBuilder
         {
             BlobContainerName = containerName,
             Resource = "c",
-            StartsOn = DateTimeOffset.Now,
-            ExpiresOn = DateTimeOffset.Now.AddDays(days)
+            StartsOn = DateTimeOffset.UtcNow,
+            ExpiresOn = DateTimeOffset.UtcNow.Add(timeSpan)
         };
 
         sasBuilder.SetPermissions(permissions);

--- a/Portal/src/Datahub.Infrastructure/Services/Storage/DisabledCloudStorageManager.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Storage/DisabledCloudStorageManager.cs
@@ -53,7 +53,7 @@ namespace Datahub.Infrastructure.Services.Storage
             throw new NotImplementedException();
         }
 
-        public Task<Uri> GenerateSasTokenAsync(string container, int days)
+        public Task<Uri> GenerateSasTokenAsync(string container, TimeSpan timeSpan)
         {
             throw new NotImplementedException();
         }

--- a/Portal/src/Datahub.Infrastructure/Services/Storage/GoogleCloudStorageManager.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Storage/GoogleCloudStorageManager.cs
@@ -134,7 +134,7 @@ namespace Datahub.Infrastructure.Services.Storage
             }
         }
 
-        public Task<Uri> GenerateSasTokenAsync(string container, int days)
+        public Task<Uri> GenerateSasTokenAsync(string container, TimeSpan timeSpan)
         {
             throw new NotImplementedException();
         }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/ResourcePages/AzCopy.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/ResourcePages/AzCopy.razor
@@ -15,7 +15,7 @@
                     @if (_isSasTokenEnabled)
                     {
                         <MudElement>
-                            <SASTokenButton OnSubstitutionsChanged="HandleSubstitutionsChanged" Container="@Container" ExpiryDays="3"/>
+                            <SASTokenButton OnSubstitutionsChanged="HandleSubstitutionsChanged" Container="@Container" />
                         </MudElement>
                     }
                     else

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/ResourcePages/AzCopy.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/ResourcePages/AzCopy.razor
@@ -7,22 +7,35 @@
 
 @if (TermsAcknowledged)
 {
-    <MudStack>
-    <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceLead" ProjectAcronym="@ProjectAcronym">
-        <Authorized>
-            @if (_isSasTokenEnabled)
-            {
-                    <MudElement>
-                        <SASTokenButton OnSubstitutionsChanged="HandleSubstitutionsChanged" Container="@Container" ExpiryDays="3"/>
-                    </MudElement>
-            }
-        </Authorized>
-
-    </DatahubAuthView>
-        <EmbeddedWiki PageNameEn="/UserGuide/Storage/Use-AzCopy.md"
-                      PageNameFr="/fr/UserGuide/Storage/Utilisez-AzCopy.md"
-                      Substitutions="_substitutions"/>
-    </MudStack>
+    @if(_isFinishedLoading)
+    {
+        <MudStack>
+            <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@ProjectAcronym">
+                <Authorized>
+                    @if (_isSasTokenEnabled)
+                    {
+                        <MudElement>
+                            <SASTokenButton OnSubstitutionsChanged="HandleSubstitutionsChanged" Container="@Container" ExpiryDays="3"/>
+                        </MudElement>
+                    }
+                    else
+                    {
+                        <MudAlert Severity="@Severity.Info">@Localizer["Shared Key Access is disabled. Please enable it in workspace settings to allow token generation."]</MudAlert>
+                    }
+                </Authorized>
+                <NotAuthorized>
+                    <MudAlert Severity="@Severity.Info">@Localizer["SAS Token generation is restricted. Please contact your workspace lead or administrators to get a token."]</MudAlert>
+                </NotAuthorized>
+            </DatahubAuthView>
+            <EmbeddedWiki PageNameEn="/UserGuide/Storage/Use-AzCopy.md"
+                          PageNameFr="/fr/UserGuide/Storage/Utilisez-AzCopy.md"
+                          Substitutions="_substitutions"/>
+        </MudStack>
+    }
+    else
+    {
+        <MudProgressCircular Indeterminate />
+    }
 }
 else
 {
@@ -49,6 +62,7 @@ else
 
     private List<(string, string)> _substitutions;
     private bool _isSasTokenEnabled;
+    private bool _isFinishedLoading = false;
 
     private void HandleSubstitutionsChanged(List<(string, string)> substitutions)
     {
@@ -64,6 +78,7 @@ else
         var armClient = WorkspaceSharedKeyAccessControl.BuildArmClient(_portalConfiguration);
         var storageResourceId = await WorkspaceSharedKeyAccessControl.LoadStorageResourceId(context, ProjectAcronym);
         _isSasTokenEnabled = await WorkspaceSharedKeyAccessControl.FetchStorageAllowSharedKeyAccess(armClient, new ResourceIdentifier(storageResourceId)) ?? false;
+        _isFinishedLoading = true;
     }
 
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/ResourcePages/UploaderCode.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/ResourcePages/UploaderCode.razor
@@ -7,17 +7,38 @@
 
 @if (TermsAcknowledged)
 {
+    @if (_isFinishedLoading)
+    {
     <MudStack>
-        <MudElement>
-            <SASTokenButton OnSubstitutionsChanged="HandleSubstitutionsChanged" Container="@Container"
-                UseUploadCode=true GenerateAndCopy=true
-                TokenName="Desktop Uploader Code"
-                />
-        </MudElement>
+        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@ProjectAcronym">
+            <Authorized>
+                @if (_isSasTokenEnabled)
+                {
+                <MudElement>
+                    <SASTokenButton OnSubstitutionsChanged="HandleSubstitutionsChanged" Container="@Container"
+                        UseUploadCode=true GenerateAndCopy=true
+                        TokenName="Desktop Uploader Code"
+                        />
+                </MudElement>
+                }
+                else
+                {
+                    <MudAlert Severity="@Severity.Info">@Localizer["Shared Key Access is disabled. Please enable it in workspace settings to allow token generation."]</MudAlert>
+                }
+            </Authorized>
+            <NotAuthorized>
+                <MudAlert Severity="@Severity.Info">@Localizer["SAS Token generation is restricted. Please contact your workspace lead or administrators to get a token."]</MudAlert>
+            </NotAuthorized>
+        </DatahubAuthView>
         <EmbeddedWiki PageNameEn="/UserGuide/Storage/Desktop-Uploader.md"
                       PageNameFr="/fr/UserGuide/Storage/Chargeur-de-bureau.md"
                       Substitutions="_substitutions" />
     </MudStack>
+    }
+    else
+    {
+        <MudProgressCircular Indeterminate />
+    }
 }
 else
 {
@@ -45,12 +66,13 @@ else
 
     private List<(string, string)> _substitutions;
     private bool _isSasTokenEnabled;
+    private bool _isFinishedLoading = false;
 
     private void HandleSubstitutionsChanged(List<(string, string)> substitutions)
     {
         _substitutions = substitutions;
     }
-    
+
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
@@ -60,5 +82,6 @@ else
         var armClient = WorkspaceSharedKeyAccessControl.BuildArmClient(_portalConfiguration);
         var storageResourceId = await WorkspaceSharedKeyAccessControl.LoadStorageResourceId(context, ProjectAcronym);
         _isSasTokenEnabled = await WorkspaceSharedKeyAccessControl.FetchStorageAllowSharedKeyAccess(armClient, new ResourceIdentifier(storageResourceId)) ?? false;
+        _isFinishedLoading = true;
     }
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/SASTokenButton.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/SASTokenButton.razor
@@ -26,7 +26,7 @@
     public CloudStorageContainer Container { get; set; }
 
     [Parameter]
-    public int ExpiryDays { get; set; } = 3;
+    public TimeSpan ExpiryTimeSpan { get; set; } = TimeSpan.FromMinutes(30);
 
     [Parameter]
     public bool UseUploadCode { get; set; } = false;
@@ -72,13 +72,13 @@
         
         if (string.IsNullOrWhiteSpace(_token))
         {
-            var uri = await Container.StorageManager.GenerateSasTokenAsync(Container.Name, ExpiryDays);
+            var uri = await Container.StorageManager.GenerateSasTokenAsync(Container.Name, ExpiryTimeSpan);
             if (UseUploadCode)
             {
                 _token = CredentialEncoder.EncodeCredentials(new UploadCredentials()
                     {
                         SASToken = uri.ToString(),
-                        SASTokenExpiry = DateTimeOffset.Now.AddDays(ExpiryDays),
+                        SASTokenExpiry = DateTimeOffset.UtcNow.Add(ExpiryTimeSpan),
                         WorkspaceCode = ProjectAcronym,
                         DataHubEnvironment = NavigationManager.BaseUri
                     });

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -2974,5 +2974,7 @@
   "{0} credits consumed yesterday": "{0} crédits consommés hier",
   "{0} is already added to your workspace": "{0} est déjà ajouté à votre espace de travail",
   "{0} remaining credits of {1}": "{0} crédits restant de {1}",
-  "{0} successfully added to your workspace": "{0} ajouté avec succès à votre espace de travail"
+  "{0} successfully added to your workspace": "{0} ajouté avec succès à votre espace de travail",
+  "Shared Key Access is disabled. Please enable it in workspace settings to allow token generation.": "L'accès par clé partagée est désactivé. Veuillez l'activer dans les paramètres de l'espace de travail pour permettre la génération de jetons.",
+  "SAS Token generation is restricted. Please contact your workspace lead or administrators to get a token.": "La génération de jetons SAS est restreinte. Veuillez contacter le responsable de votre espace de travail ou les administrateurs pour obtenir un jeton."
 }

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -2037,5 +2037,7 @@
   "{0} credits consumed yesterday": "{0} credits consumed yesterday",
   "{0} is already added to your workspace": "{0} is already added to your workspace",
   "{0} remaining credits of {1}": "{0} remaining credits of {1}",
-  "{0} successfully added to your workspace": "{0} successfully added to your workspace"
+  "{0} successfully added to your workspace": "{0} successfully added to your workspace",
+  "Shared Key Access is disabled. Please enable it in workspace settings to allow token generation.": "Shared Key Access is disabled. Please enable it in workspace settings to allow token generation.",
+  "SAS Token generation is restricted. Please contact your workspace lead or administrators to get a token.": "SAS Token generation is restricted. Please contact your workspace lead or administrators to get a token."
 }


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Adds messages when SAS token generation button is unavailable to indicate the reason. Also, updates the timeout for SAS tokens to 30 minutes.

![image](https://github.com/user-attachments/assets/fbbb07d1-d470-4f6e-8ede-16260b48f59e)


## Related Issues
<!-- List any related issues or tickets -->

- Bug 9677 - UAT R#1 - Generate Token button is missing in AZCopy
- Task 9717 - Ensure storage token expiry is set to 30 minutes
- Task 9718 - Add messaging for conditions where SAS token is unavailable
- Bug 9719 - SAS Tokens should be 30 minutes for Azcopy

## Changes
<!-- List the key changes in this PR -->

- Add messages when SAS token button is disabled or restricted by user's access level
- Add loading indicator while key generation setting is queried
- Update SAS Token generation functionality to accept a TimeSpan (previously: a count of days) for the timeout, defaulting to 30 minutes

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Manual testing
- Will add specflow tests when time allows

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
