### PR TITLE
Allow Workspace Leads to Delete Workspaces

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Delete/WorkspaceDeletionPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Delete/WorkspaceDeletionPage.razor
@@ -14,58 +14,66 @@
 
 @inject NavigationManager _navigationManager
 
-<MudStack Class="px-4">
-    <MudGrid>
-       <MudItem xs="12">
-           <MudStack>
-                <MudText Typo="Typo.h4">
-                    @Localizer["Are you sure you want to delete the following workspace: {0}?", WorkspaceAcronym]
-                </MudText>
-                <MudText Typo="Typo.body1">
-                    @Localizer["This action is permanent. Upon deletion, the workspace and all its resources will be deleted"]
-                </MudText>
-                <MudText Typo="Typo.body1">
-                    @Localizer["Please type {0} to confirm the deletion.", WorkspaceAcronym]
-                </MudText>
-                <MudGrid>
-                    <MudItem xs="5">
-                        <MudTextField @bind-Value="_deleteConfirmation" Variant="Variant.Text"></MudTextField>
-                    </MudItem>
-                </MudGrid>
-            </MudStack>
-            
-            @if (_error.Equals("_emptyConfirmation"))
-            {
-                <MudAlert Severity="Severity.Error">
-                    <MudText Typo="Typo.body2">@Localizer["Please enter a workspace acronym."]</MudText>
-                </MudAlert>
-            }
-            else if (_error.Equals("_badConfirmation"))
-            {
-                <MudAlert Severity="Severity.Error">
-                    <MudText Typo="Typo.body2">@Localizer["Incorrect workspace acronym."]</MudText>
-                </MudAlert>
-            }
-        </MudItem>
-        <MudItem xs="3">
-            <DHButton Variant="@Variant.Filled" Color="@Color.Default" Href="@_settingsPage">
-                @Localizer["Cancel"]
-            </DHButton>
-        </MudItem>
-        <MudItem xs="3">
-            <DHButton Disabled="@_deleteRequested" Variant="@Variant.Filled" Color="@Color.Error" OnClick="@ConfirmDeletion">
-                @_deleteButtonText
-                <DHIcon Icon="@SidebarIcons.Delete" Class="ml-2" Style="font-size: 0.8rem;" />
-            </DHButton>
-        </MudItem>
-    </MudGrid>
-</MudStack>
+<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceLead" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="true">
+    <Authorized>
+        <MudStack Class="px-4">
+            <MudGrid>
+                <MudItem xs="12">
+                    <MudStack>
+                        <MudText Typo="Typo.h4">
+                            @Localizer["Are you sure you want to delete the following workspace: {0}?", WorkspaceAcronym]
+                        </MudText>
+                        <MudText Typo="Typo.body1">
+                            @Localizer["This action is permanent. Upon deletion, the workspace and all its resources will be deleted"]
+                        </MudText>
+                        <MudText Typo="Typo.body1">
+                            @Localizer["Please type {0} to confirm the deletion.", WorkspaceAcronym]
+                        </MudText>
+                        <MudGrid>
+                            <MudItem xs="5">
+                                <MudTextField @bind-Value="_deleteConfirmation" Variant="Variant.Text"></MudTextField>
+                            </MudItem>
+                        </MudGrid>
+                    </MudStack>
 
+                    @if (_error.Equals("_emptyConfirmation"))
+                    {
+                        <MudAlert Severity="Severity.Error">
+                            <MudText Typo="Typo.body2">@Localizer["Please enter a workspace acronym."]</MudText>
+                        </MudAlert>
+                    }
+                    else if (_error.Equals("_badConfirmation"))
+                    {
+                        <MudAlert Severity="Severity.Error">
+                            <MudText Typo="Typo.body2">@Localizer["Incorrect workspace acronym."]</MudText>
+                        </MudAlert>
+                    }
+                </MudItem>
+                <MudItem xs="3">
+                    <DHButton Variant="@Variant.Filled" Color="@Color.Default" Href="@_settingsPage">
+                        @Localizer["Cancel"]
+                    </DHButton>
+                </MudItem>
+                <MudItem xs="3">
+                    <DHButton Disabled="@_deleteRequested" Variant="@Variant.Filled" Color="@Color.Error" OnClick="@ConfirmDeletion">
+                        @_deleteButtonText
+                        <DHIcon Icon="@SidebarIcons.Delete" Class="ml-2" Style="font-size: 0.8rem;" />
+                    </DHButton>
+                </MudItem>
+            </MudGrid>
+        </MudStack>
+    </Authorized>
+    <NotAuthorized>
+        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Style="color: #000;" Class="mb-6">
+            @Localizer["Access Denied"]
+        </MudAlert>
+    </NotAuthorized>
+</DatahubAuthView>
 @code
 {
     [Parameter]
     public string WorkspaceAcronym { get; set; }
-    [Parameter] 
+    [Parameter]
     public bool ElevatedWorkspaceAccessEnabled { get; set; } = true;
 
     private string _deleteConfirmation;
@@ -91,7 +99,7 @@
 
         if (WorkspaceAcronym == null)
         {
-            _snackbar.Add(Localizer["Invalid parameters, redirecting"], Severity.Error);            
+            _snackbar.Add(Localizer["Invalid parameters, redirecting"], Severity.Error);
             _navigationManager.NavigateTo(_settingsPage);
             return;
         }
@@ -105,7 +113,7 @@
             _snackbar.Add(Localizer["Please enter a workspace acronym."], Severity.Error);
             _error = "_emptyConfirmation";
         }
-        else if(!_deleteConfirmation.Equals(WorkspaceAcronym))
+        else if (!_deleteConfirmation.Equals(WorkspaceAcronym))
         {
             _snackbar.Add(Localizer["Incorrect workspace acronym."], Severity.Error);
             _error = "_badConfirmation";

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Settings/WorkspaceSettingsPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Settings/WorkspaceSettingsPage.razor
@@ -64,7 +64,7 @@
                 <WorkspaceBudgetControl Disabled InitialValue="@_budget"/>
             </NotAuthorized>
         </DatahubAuthView>
-        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.DatahubSupport" ProjectAcronym="@WorkspaceAcronym">
+        <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceLead" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="true">
             <Authorized>
                 <WorkspaceDeleteControl WorkspaceAcronym="@WorkspaceAcronym"/>
             </Authorized>


### PR DESCRIPTION
# Pull Request

## Description
In the workspace setting tabs, the 'delete workspace' functionality was reserved for only Datahub Support. Workspace leads can now also access this functionality

## Related Issues
Allow workspace leads to delete workspaces (6641)

## Changes
Added permissions to delete functionality for workspace leads and datahub support
Added authorization tags to the actual delete pages, preventing any strays from getting to the page

## Testing
Unit tested UI locally

## Checklist

- [✔️ ] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
