### PR TITLE
🔧 Restricting registration and workspace creation to Datahub admins in production

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
@@ -93,7 +93,7 @@
         <NotAuthorized>
             <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
                 <MudText Typo="Typo.body1">
-                    @Localizer["The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment"] 
+                    @Localizer["The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment"]
                 </MudText>
                 <MudLink Typo="Typo.body1" Href="https://poc.fsdh-dhsf.science.cloud-nuage.canada.ca/">
                     @Localizer["Click here to access the proof-of-concept environment"]</MudLink>
@@ -127,7 +127,7 @@
 
     protected override void OnInitialized()
     {
-        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "dev";
         _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
 
         _emailFieldText = Localizer["Government of Canada Email"];

--- a/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
@@ -92,7 +92,11 @@
         </Authorized>
         <NotAuthorized>
             <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
-                @Localizer["The production environment is not available yet. Use the proof-of-concept environment instead."]
+                <MudText Typo="Typo.body1">
+                    @Localizer["The production environment is not available yet. Use the proof-of-concept environment instead."] 
+                </MudText>
+                <MudLink Typo="Typo.body1" Href="https://poc.fsdh-dhsf.science.cloud-nuage.canada.ca/">
+                    @Localizer["Click here to access the proof-of-concept environment"]</MudLink>
             </MudAlert>
         </NotAuthorized>
     </DatahubAuthView>
@@ -124,7 +128,7 @@
     protected override void OnInitialized()
     {
         var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
+        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Unauthorized;
 
         _emailFieldText = Localizer["Government of Canada Email"];
         if (!string.IsNullOrEmpty(Email))

--- a/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
@@ -93,7 +93,7 @@
         <NotAuthorized>
             <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
                 <MudText Typo="Typo.body1">
-                    @Localizer["The production environment is not available yet. Use the proof-of-concept environment instead."] 
+                    @Localizer["The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment"] 
                 </MudText>
                 <MudLink Typo="Typo.body1" Href="https://poc.fsdh-dhsf.science.cloud-nuage.canada.ca/">
                     @Localizer["Click here to access the proof-of-concept environment"]</MudLink>
@@ -128,7 +128,7 @@
     protected override void OnInitialized()
     {
         var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Unauthorized;
+        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
 
         _emailFieldText = Localizer["Government of Canada Email"];
         if (!string.IsNullOrEmpty(Email))

--- a/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
@@ -1,6 +1,7 @@
 @using Datahub.Application.Services.Metadata
 @using Datahub.Application.Services
 @using Datahub.Core.Model.Achievements
+@using static Datahub.Core.DevTools
 @using Datahub.Infrastructure.Extensions
 @using Datahub.Infrastructure.Queues.Messages
 @using Datahub.Shared.Configuration
@@ -22,84 +23,82 @@
 <PageTitle>@Localizer["Registration - Federal Science DataHub"]</PageTitle>
 
 <MudStack >
-    <DatahubAuthView AuthLevel="_authLevel">
-        <Authorized>
-            <MudForm @ref="@_form" @bind-IsValid="@_success" @bind-Errors="@_errors">
-                <MudStack>
-                    <MudTextField T="string"
-                                  Label=@_emailFieldText
-                                  Required
-                                  Variant="Variant.Outlined"
-                                  @bind-Value="@_email"
-                                  RequiredError=@Localizer["Government of Canada Email is required"]
-                                  Validation=@(new Func<string, string>(EmailValidation))/>
+    @if (!_isProd)
+    {
+        <MudForm @ref="@_form" @bind-IsValid="@_success" @bind-Errors="@_errors">
+            <MudStack>
+                <MudTextField T="string"
+                                Label=@_emailFieldText
+                                Required
+                                Variant="Variant.Outlined"
+                                @bind-Value="@_email"
+                                RequiredError=@Localizer["Government of Canada Email is required"]
+                                Validation=@(new Func<string, string>(EmailValidation))/>
 
-                    <MudTextField T="string"
-                                  Label=@Localizer["(Optional) How did you hear about the Federal Science DataHub?"]
-                                  Variant="Variant.Outlined"
-                                  Lines="5"
-                                  @bind-Value="@_comment"/>
+                <MudTextField T="string"
+                                Label=@Localizer["(Optional) How did you hear about the Federal Science DataHub?"]
+                                Variant="Variant.Outlined"
+                                Lines="5"
+                                @bind-Value="@_comment"/>
 
-                    <MudCheckBox T="bool"
-                                 Required
-                                 RequiredError=@Localizer["Agreement with the Terms and conditions is required"]
-                                 Class="mt-4">
+                <MudCheckBox T="bool"
+                                Required
+                                RequiredError=@Localizer["Agreement with the Terms and conditions is required"]
+                                Class="mt-4">
 
-                        <MudText Typo="Typo.body1">
-                            @Localizer["I agree to the "]
-                            <MudLink Href="@Localizer[PageRoutes.TermsAndConditions]" Typo="Typo.body1" Target="_blank">
-                                @Localizer["Terms and conditions"]
-                            </MudLink>
-                            @Localizer[" of use for the FSDH"]
+                    <MudText Typo="Typo.body1">
+                        @Localizer["I agree to the "]
+                        <MudLink Href="@Localizer[PageRoutes.TermsAndConditions]" Typo="Typo.body1" Target="_blank">
+                            @Localizer["Terms and conditions"]
+                        </MudLink>
+                        @Localizer[" of use for the FSDH"]
+                    </MudText>
+
+                </MudCheckBox>
+                <p>
+                    <MudStack Justify="Justify.Center">
+
+                        <MudText Class="text-center">
+                            <strong>@Localizer["Click here once the form is complete to register"]:</strong>
+                            @if (_isRegistering)
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled Class="mx-4 px-16 my-2">
+                                    <MudText>
+                                        @Localizer["Registering"]
+                                    </MudText>
+                                    <MudProgressCircular Class="ml-4" Color="Color.Default" Size="Size.Small" Indeterminate="true"/>
+                                </MudButton>
+                                @if (_timedOut)
+                                {
+                                    <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-2" Style="color: #000">
+                                        <MudText>
+                                            @Localizer["This is taking longer than normal... Please try signing in and contact support if you encounter any issue."]
+                                        </MudText>
+                                    </MudAlert>
+                                }
+                            }
+                            else
+                            {
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_success)" Class="mx-4 my-2 px-16" OnClick="HandleValidSubmit">
+                                    <MudText>
+                                        @Localizer["Register"]
+                                    </MudText>
+                                </MudButton>
+                            }
                         </MudText>
-
-                    </MudCheckBox>
-                    <p>
-                        <MudStack Justify="Justify.Center">
-
-                            <MudText Class="text-center">
-                                <strong>@Localizer["Click here once the form is complete to register"]:</strong>
-                                @if (_isRegistering)
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled Class="mx-4 px-16 my-2">
-                                        <MudText>
-                                            @Localizer["Registering"]
-                                        </MudText>
-                                        <MudProgressCircular Class="ml-4" Color="Color.Default" Size="Size.Small" Indeterminate="true"/>
-                                    </MudButton>
-                                    @if (_timedOut)
-                                    {
-                                        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-2" Style="color: #000">
-                                            <MudText>
-                                                @Localizer["This is taking longer than normal... Please try signing in and contact support if you encounter any issue."]
-                                            </MudText>
-                                        </MudAlert>
-                                    }
-                                }
-                                else
-                                {
-                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_success)" Class="mx-4 my-2 px-16" OnClick="HandleValidSubmit">
-                                        <MudText>
-                                            @Localizer["Register"]
-                                        </MudText>
-                                    </MudButton>
-                                }
-                            </MudText>
-                        </MudStack>
-                    </p>
-                </MudStack>
-            </MudForm>
-        </Authorized>
-        <NotAuthorized>
-            <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
-                <MudText Typo="Typo.body1">
-                    @Localizer["The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment"]
-                </MudText>
-                <MudLink Typo="Typo.body1" Href="https://poc.fsdh-dhsf.science.cloud-nuage.canada.ca/">
-                    @Localizer["Click here to access the proof-of-concept environment"]</MudLink>
-            </MudAlert>
-        </NotAuthorized>
-    </DatahubAuthView>
+                    </MudStack>
+                </p>
+            </MudStack>
+        </MudForm>
+    } else {
+        <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
+            <MudText Typo="Typo.body1">
+                @Localizer["The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment"] 
+            </MudText>
+            <MudLink Typo="Typo.body1" Href="https://poc.fsdh-dhsf.science.cloud-nuage.canada.ca/">
+                @Localizer["Click here to access the proof-of-concept environment"]</MudLink>
+        </MudAlert>
+    }
     <p>
         <MudText Typo="Typo.body1" Align="Align.Start">
             @Localizer["Already registered?"]
@@ -123,12 +122,11 @@
     private bool _isRegistering;
     private string[] _errors = { };
     private MudForm _form;
-    private DatahubAuthView.AuthLevels _authLevel;
+    private bool _isProd;
 
     protected override void OnInitialized()
     {
-        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "dev";
-        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
+        _isProd = TopBarEnvironment() == TopBarEnvironments.Production || TopBarEnvironment() == TopBarEnvironments.ProductionProtected;
 
         _emailFieldText = Localizer["Government of Canada Email"];
         if (!string.IsNullOrEmpty(Email))

--- a/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/RegisterPage.razor
@@ -22,71 +22,80 @@
 <PageTitle>@Localizer["Registration - Federal Science DataHub"]</PageTitle>
 
 <MudStack >
-    <MudForm @ref="@_form" @bind-IsValid="@_success" @bind-Errors="@_errors">
-        <MudStack>
-            <MudTextField T="string"
-                          Label=@_emailFieldText
-                          Required
-                          Variant="Variant.Outlined"
-                          @bind-Value="@_email"
-                          RequiredError=@Localizer["Government of Canada Email is required"]
-                          Validation=@(new Func<string, string>(EmailValidation))/>
+    <DatahubAuthView AuthLevel="_authLevel">
+        <Authorized>
+            <MudForm @ref="@_form" @bind-IsValid="@_success" @bind-Errors="@_errors">
+                <MudStack>
+                    <MudTextField T="string"
+                                  Label=@_emailFieldText
+                                  Required
+                                  Variant="Variant.Outlined"
+                                  @bind-Value="@_email"
+                                  RequiredError=@Localizer["Government of Canada Email is required"]
+                                  Validation=@(new Func<string, string>(EmailValidation))/>
 
-            <MudTextField T="string"
-                          Label=@Localizer["(Optional) How did you hear about the Federal Science DataHub?"]
-                          Variant="Variant.Outlined"
-                          Lines="5"
-                          @bind-Value="@_comment"/>
+                    <MudTextField T="string"
+                                  Label=@Localizer["(Optional) How did you hear about the Federal Science DataHub?"]
+                                  Variant="Variant.Outlined"
+                                  Lines="5"
+                                  @bind-Value="@_comment"/>
 
-            <MudCheckBox T="bool"
-                         Required
-                         RequiredError=@Localizer["Agreement with the Terms and conditions is required"]
-                         Class="mt-4">
+                    <MudCheckBox T="bool"
+                                 Required
+                                 RequiredError=@Localizer["Agreement with the Terms and conditions is required"]
+                                 Class="mt-4">
 
-                <MudText Typo="Typo.body1">
-                    @Localizer["I agree to the "]
-                    <MudLink Href="@Localizer[PageRoutes.TermsAndConditions]" Typo="Typo.body1" Target="_blank">
-                        @Localizer["Terms and conditions"]
-                    </MudLink>
-                    @Localizer[" of use for the FSDH"]
-                </MudText>
+                        <MudText Typo="Typo.body1">
+                            @Localizer["I agree to the "]
+                            <MudLink Href="@Localizer[PageRoutes.TermsAndConditions]" Typo="Typo.body1" Target="_blank">
+                                @Localizer["Terms and conditions"]
+                            </MudLink>
+                            @Localizer[" of use for the FSDH"]
+                        </MudText>
 
-            </MudCheckBox>
-            <p>
-                <MudStack Justify="Justify.Center">
+                    </MudCheckBox>
+                    <p>
+                        <MudStack Justify="Justify.Center">
 
-                    <MudText Class="text-center">
-                        <strong>@Localizer["Click here once the form is complete to register"]:</strong>
-                        @if (_isRegistering)
-                        {
-                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled Class="mx-4 px-16 my-2">
-                                <MudText>
-                                    @Localizer["Registering"]
-                                </MudText>
-                                <MudProgressCircular Class="ml-4" Color="Color.Default" Size="Size.Small" Indeterminate="true"/>
-                            </MudButton>
-                            @if (_timedOut)
-                            {
-                                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-2" Style="color: #000">
-                                    <MudText>
-                                        @Localizer["This is taking longer than normal... Please try signing in and contact support if you encounter any issue."]
-                                    </MudText>
-                                </MudAlert>
-                            }
-                        }
-                        else
-                        {
-                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_success)" Class="mx-4 my-2 px-16" OnClick="HandleValidSubmit">
-                                <MudText>
-                                    @Localizer["Register"]
-                                </MudText>
-                            </MudButton>
-                        }
-                    </MudText>
+                            <MudText Class="text-center">
+                                <strong>@Localizer["Click here once the form is complete to register"]:</strong>
+                                @if (_isRegistering)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled Class="mx-4 px-16 my-2">
+                                        <MudText>
+                                            @Localizer["Registering"]
+                                        </MudText>
+                                        <MudProgressCircular Class="ml-4" Color="Color.Default" Size="Size.Small" Indeterminate="true"/>
+                                    </MudButton>
+                                    @if (_timedOut)
+                                    {
+                                        <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Class="mt-2" Style="color: #000">
+                                            <MudText>
+                                                @Localizer["This is taking longer than normal... Please try signing in and contact support if you encounter any issue."]
+                                            </MudText>
+                                        </MudAlert>
+                                    }
+                                }
+                                else
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_success)" Class="mx-4 my-2 px-16" OnClick="HandleValidSubmit">
+                                        <MudText>
+                                            @Localizer["Register"]
+                                        </MudText>
+                                    </MudButton>
+                                }
+                            </MudText>
+                        </MudStack>
+                    </p>
                 </MudStack>
-            </p>
-        </MudStack>
-    </MudForm>
+            </MudForm>
+        </Authorized>
+        <NotAuthorized>
+            <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
+                @Localizer["The production environment is not available yet. Use the proof-of-concept environment instead."]
+            </MudAlert>
+        </NotAuthorized>
+    </DatahubAuthView>
     <p>
         <MudText Typo="Typo.body1" Align="Align.Start">
             @Localizer["Already registered?"]
@@ -110,9 +119,13 @@
     private bool _isRegistering;
     private string[] _errors = { };
     private MudForm _form;
+    private DatahubAuthView.AuthLevels _authLevel;
 
     protected override void OnInitialized()
     {
+        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
+
         _emailFieldText = Localizer["Government of Canada Email"];
         if (!string.IsNullOrEmpty(Email))
         {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
@@ -8,92 +8,99 @@
 
 <PageTitle>@Localizer["Create a Workspace - Federal Science DataHub"]</PageTitle>
 
-<DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.Authenticated">
-    <MudStack Spacing="6">
-        <DHMainContentTitle Title="@Localizer["Create a new Workspace"]" />
-        <MudText>
-            @Localizer["Please complete the following information to create a new workspace"]
-        </MudText>
+<DatahubAuthView AuthLevel="_authLevel">
+    <Authorized>
+        <MudStack Spacing="6">
+            <DHMainContentTitle Title="@Localizer["Create a new Workspace"]" />
+            <MudText>
+                @Localizer["Please complete the following information to create a new workspace"]
+            </MudText>
 
-        <MudForm Class="mb-4" @bind-IsValid="@_success">
-            <MudTextField T="string"
-                          @bind-Value="_projectTitle"
-                          Label="@Localizer["Workspace Title"]" Required
-                          RequiredError="@Localizer["Workspace Title is required"]"
-                          HelperText="@Localizer["Enter a descriptive title for the workspace"]"
-                          DebounceInterval="500"
-                          OnDebounceIntervalElapsed="UpdateProjectAcronym" 
-                          Validation="@(new Func<string, Task<string>>(ValidateTitle))"
-                          MaxLength="@MaxTitleLength" />
+            <MudForm Class="mb-4" @bind-IsValid="@_success">
+                <MudTextField T="string"
+                              @bind-Value="_projectTitle"
+                              Label="@Localizer["Workspace Title"]" Required
+                              RequiredError="@Localizer["Workspace Title is required"]"
+                              HelperText="@Localizer["Enter a descriptive title for the workspace"]"
+                              DebounceInterval="500"
+                              OnDebounceIntervalElapsed="UpdateProjectAcronym" 
+                              Validation="@(new Func<string, Task<string>>(ValidateTitle))"
+                              MaxLength="@MaxTitleLength" />
 
-            <MudTextField T="string"
-                          @bind-Value="_projectAcronym"
-                          Label="@Localizer["Workspace Acronym"]"
-                          AdornmentIcon="fa-light fa-arrows-rotate"
-                          HelperText="@Localizer["A unique alphanumeric acronym to identify the workspace. Click the icon to generate an acronym based on the title."]"
-                          Adornment="Adornment.End"
-                          OnAdornmentClick="GenerateAcronym"
-                          AdornmentAriaLabel="@Localizer["Generate Acronym"]"
-                          RequiredError="@Localizer["Workspace Acronym is required"]"
-                          Converter="_converter"
-                          @ref="_acronymField"
-                          alt=@Localizer["A unique alphanumeric acronym to identify the workspace. Click the icon to generate an acronym based on the title."]
-                          Required
-                          Validation="@(new Func<string, Task<string>>(ValidateAcronym))"
-                          MaxLength="@MaxAcronymLength"/>
+                <MudTextField T="string"
+                              @bind-Value="_projectAcronym"
+                              Label="@Localizer["Workspace Acronym"]"
+                              AdornmentIcon="fa-light fa-arrows-rotate"
+                              HelperText="@Localizer["A unique alphanumeric acronym to identify the workspace. Click the icon to generate an acronym based on the title."]"
+                              Adornment="Adornment.End"
+                              OnAdornmentClick="GenerateAcronym"
+                              AdornmentAriaLabel="@Localizer["Generate Acronym"]"
+                              RequiredError="@Localizer["Workspace Acronym is required"]"
+                              Converter="_converter"
+                              @ref="_acronymField"
+                              alt=@Localizer["A unique alphanumeric acronym to identify the workspace. Click the icon to generate an acronym based on the title."]
+                              Required
+                              Validation="@(new Func<string, Task<string>>(ValidateAcronym))"
+                              MaxLength="@MaxAcronymLength"/>
 
-            <MudSelect T="string"
-                       Label="@Localizer["(Optional) Which features are of interest to you?"]"
-                       MultiSelection="true"
-                       HelperText="@Localizer["Please select all that apply"]"
-                       AnchorOrigin="Origin.BottomLeft"
-                       TransformOrigin="Origin.TopLeft"
-                       @bind-Value="@_interestedFeatures">
-                <MudSelectItem T="string" Value="@("Storage")">@Localizer["Storage"]</MudSelectItem>
-                <MudSelectItem T="string" Value="@("Analytics")">@Localizer["Analytics"]</MudSelectItem>
-                <MudSelectItem T="string" Value="@("Collaboration")">@Localizer["Collaboration"]</MudSelectItem>
-                <MudSelectItem T="string" Value="@("Other")">@Localizer["Other"]</MudSelectItem>
-            </MudSelect>
+                <MudSelect T="string"
+                           Label="@Localizer["(Optional) Which features are of interest to you?"]"
+                           MultiSelection="true"
+                           HelperText="@Localizer["Please select all that apply"]"
+                           AnchorOrigin="Origin.BottomLeft"
+                           TransformOrigin="Origin.TopLeft"
+                           @bind-Value="@_interestedFeatures">
+                    <MudSelectItem T="string" Value="@("Storage")">@Localizer["Storage"]</MudSelectItem>
+                    <MudSelectItem T="string" Value="@("Analytics")">@Localizer["Analytics"]</MudSelectItem>
+                    <MudSelectItem T="string" Value="@("Collaboration")">@Localizer["Collaboration"]</MudSelectItem>
+                    <MudSelectItem T="string" Value="@("Other")">@Localizer["Other"]</MudSelectItem>
+                </MudSelect>
 
-            @if (_portalConfiguration.Github.Enabled)
-            {
-                <MudStack Row Class="mt-4">
-                    <MudButton Href="https://github.com/apps/datahub-workspaces"
-                               OnClick="HandleIntegrateWithGit"
-                               Target="_blank"
-                               Variant="Variant.Filled"
-                               EndIcon="@Icons.Custom.Brands.GitHub"
-                               Color="Color.Primary">
-                        @Localizer["Link GitHub"]
-                    </MudButton>
-                    <MudCheckBox Value=@_createRepository
-                                 ValueChanged=@ToggleCreateRepo
-                                 Disabled="!_githubIntegration"
-                                 T="bool"
-                                 Label=@Localizer["Create Repository"] />
-                </MudStack>
-            }
-
-            @if (_errorMessage is not null)
-            {
-                <MudAlert Severity="Severity.Error" Dense="true" Class="my-2" ShowCloseIcon CloseIconClicked="CloseAlert">
-                    @_errorMessage
-                </MudAlert>
-            }
-        </MudForm>
-        <MudElement Class="pb-4">
-            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Href="@PageRoutes.Home" Class="mr-2">
-                @Localizer["Cancel"]
-            </MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_success" OnClick="CreateProject" Class="ml-2">
-                @if (_isCreating)
+                @if (_portalConfiguration.Github.Enabled)
                 {
-                    <MudProgressCircular Class="ms-n1 mr-2" Size="Size.Small" Indeterminate="true" />
+                    <MudStack Row Class="mt-4">
+                        <MudButton Href="https://github.com/apps/datahub-workspaces"
+                                   OnClick="HandleIntegrateWithGit"
+                                   Target="_blank"
+                                   Variant="Variant.Filled"
+                                   EndIcon="@Icons.Custom.Brands.GitHub"
+                                   Color="Color.Primary">
+                            @Localizer["Link GitHub"]
+                        </MudButton>
+                        <MudCheckBox Value=@_createRepository
+                                     ValueChanged=@ToggleCreateRepo
+                                     Disabled="!_githubIntegration"
+                                     T="bool"
+                                     Label=@Localizer["Create Repository"] />
+                    </MudStack>
                 }
-                @Localizer["Create Workspace"]
-            </MudButton>
-        </MudElement>
-    </MudStack>
+
+                @if (_errorMessage is not null)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="my-2" ShowCloseIcon CloseIconClicked="CloseAlert">
+                        @_errorMessage
+                    </MudAlert>
+                }
+            </MudForm>
+            <MudElement Class="pb-4">
+                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" Href="@PageRoutes.Home" Class="mr-2">
+                    @Localizer["Cancel"]
+                </MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_success" OnClick="CreateProject" Class="ml-2">
+                    @if (_isCreating)
+                    {
+                        <MudProgressCircular Class="ms-n1 mr-2" Size="Size.Small" Indeterminate="true" />
+                    }
+                    @Localizer["Create Workspace"]
+                </MudButton>
+            </MudElement>
+        </MudStack>
+    </Authorized>
+    <NotAuthorized>
+        <MudAlert Severity="Severity.Error" Dense="true" Class="my-2">
+            @Localizer["Workspace creation is unavailable in the production environment. To create a workspace, submit a support request or use the proof-of-concept environment."]
+        </MudAlert>
+    </NotAuthorized>
 </DatahubAuthView>
 
 @code {
@@ -108,11 +115,18 @@
     private string _interestedFeatures = string.Empty;
     private MudTextField<string>? _acronymField;
 
+    private DatahubAuthView.AuthLevels _authLevel;
     private bool _success;
     private bool _isCreating;
 
     private bool _githubIntegration;
     private bool _createRepository;
+
+    protected override void OnInitialized()
+    {
+        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
+    }
 
     private async Task GenerateAcronym()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/CreateWorkspacePage.razor
@@ -1,4 +1,5 @@
 ﻿@using Datahub.Application.Services
+@using static Datahub.Core.DevTools
 @inject IProjectCreationService _projectCreationService
 @inject NavigationManager _navigationManager
 @inject DatahubPortalConfiguration _portalConfiguration
@@ -124,8 +125,8 @@
 
     protected override void OnInitialized()
     {
-        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        _authLevel = env.Equals("prod") || env.Equals("prd") ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Authenticated;
+        var isProd = TopBarEnvironment() == TopBarEnvironments.Production || TopBarEnvironment() == TopBarEnvironments.ProductionProtected;
+        _authLevel = isProd ? DatahubAuthView.AuthLevels.DatahubSupport : DatahubAuthView.AuthLevels.Unauthorized;
     }
 
     private async Task GenerateAcronym()

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -469,7 +469,7 @@
   "Clear viewed alerts": "Effacer les alertes vues",
   "Click here for detailed instructions": "Cliquez ici pour des instructions détaillées",
   "Click here once the form is complete to register": "Cliquez ici une fois le formulaire rempli pour vous inscrire",
-  "Click here to access the proof-of-concept environment": "Cliquez ici pour accéder à l'environnement de preuve de concept",
+  "The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment": "Le DataHub scientifique fédéral sera lancé en mars. Pour prévisualiser la plateforme, veuillez vous inscrire dans l'environnement de preuve de concept",
   "Click here to add yourself to Databricks workspace admin group via REST API": "Click here to add yourself to Databricks workspace admin group via REST API",
   "Click here to edit the metadata.": "Cliquez ici pour modifier les métadonnées.",
   "Clicking the \\": "En cliquant sur le \\",

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -2537,6 +2537,7 @@
   "The lifeblood of the organization, your research and partnerships drive the business of NRCAN.": "L’élément vital de l’organisation, vos recherches et vos partenariats sont le moteur des activités de RNCan.",
   "The next few pages will show you how to use this layout and create your very own workspace!": "Les prochaines pages vous montreront comment utiliser cette mise en page et créer votre propre espace de travail!",
   "The picture for achievement {0}": "L'image de la réalisation {0}",
+  "The production environment is not available yet. Use the proof-of-concept environment instead.": "L'environnement de production n'est pas encore disponible. Utilisez plutôt l'environnement de preuve de concept.",
   "The project doesn\u0027t have a budget assigned. Contact a Datahub Administrator.": "Le projet n'a pas de budget attribué. Contactez un administrateur de Datahub.",
   "The second section of the sidebar is where you manage your workspace:": "La deuxième section de l'encadré est l'endroit où vous gérez votre espace de travail :",
   "The state of your request is currently unknown.": "L'état de votre demande est inconnu.",

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -2843,6 +2843,7 @@
   "Workspace Wayfarer": "Nomade de l'espace de travail",
   "Workspace admins": "Administrateurs de l'espace de travail",
   "Workspace admins can configure the web app using the link below.": "Les administrateurs de l'espace de travail peuvent configurer l'application web en utilisant le lien ci-dessous.",
+  "Workspace creation is unavailable in the production environment. To create a workspace, submit a support request or use the proof-of-concept environment.": "La création d'un espace de travail n'est pas disponible dans l'environnement de production. Pour créer un espace de travail, soumettez une demande de support ou utilisez l'environnement de preuve de concept.",
   "Workspace lead": "Responsable de l'espace de travail",
   "Workspace tools": "Outils de l'espace de travail",
   "Workspaces": "Espaces de travail",

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -469,6 +469,7 @@
   "Clear viewed alerts": "Effacer les alertes vues",
   "Click here for detailed instructions": "Cliquez ici pour des instructions détaillées",
   "Click here once the form is complete to register": "Cliquez ici une fois le formulaire rempli pour vous inscrire",
+  "Click here to access the proof-of-concept environment": "Cliquez ici pour accéder à l'environnement de preuve de concept",
   "Click here to add yourself to Databricks workspace admin group via REST API": "Click here to add yourself to Databricks workspace admin group via REST API",
   "Click here to edit the metadata.": "Cliquez ici pour modifier les métadonnées.",
   "Clicking the \\": "En cliquant sur le \\",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1947,6 +1947,7 @@
   "Workspace Wayfarer": "Workspace Wayfarer",
   "Workspace admins": "Workspace admins",
   "Workspace admins can configure the web app using the link below.": "Workspace admins can configure the web app using the link below.",
+  "Workspace creation is unavailable in the production environment. To create a workspace, submit a support request or use the proof-of-concept environment.": "Workspace creation is unavailable in the production environment. To create a workspace, submit a support request or use the proof-of-concept environment.",
   "Workspace lead": "Workspace lead",
   "Workspace tools": "Workspace tools",
   "Workspaces": "Workspaces",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -300,7 +300,7 @@
   "Clear viewed alerts": "Clear viewed alerts",
   "Click here for detailed instructions": "Click here for detailed instructions",
   "Click here once the form is complete to register": "Click here once the form is complete to register",
-  "Click here to access the proof-of-concept environment": "Click here to access the proof-of-concept environment",
+  "The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment": "The Federal Science DataHub is launching this March. To preview the platform, please register in the proof of concept environment",
   "Click here to add yourself to Databricks workspace admin group via REST API": "Click here to add yourself to Databricks workspace admin group via REST API",
   "Click here to edit the metadata.": "Click here to edit the metadata.",
   "Clicking the \\": "Clicking the \\",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -300,6 +300,7 @@
   "Clear viewed alerts": "Clear viewed alerts",
   "Click here for detailed instructions": "Click here for detailed instructions",
   "Click here once the form is complete to register": "Click here once the form is complete to register",
+  "Click here to access the proof-of-concept environment": "Click here to access the proof-of-concept environment",
   "Click here to add yourself to Databricks workspace admin group via REST API": "Click here to add yourself to Databricks workspace admin group via REST API",
   "Click here to edit the metadata.": "Click here to edit the metadata.",
   "Clicking the \\": "Clicking the \\",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1702,6 +1702,7 @@
   "The following web application has been uploaded by a user onto this data platform using their own code. Please be aware that the content and functionality of this application are entirely controlled by the user who uploaded it, and the platform provider takes no responsibility for its content, accuracy, or performance.": "The following web application has been uploaded by a user onto this data platform using their own code. Please be aware that the content and functionality of this application are entirely controlled by the user who uploaded it, and the platform provider takes no responsibility for its content, accuracy, or performance.",
   "The next few pages will show you how to use this layout and create your very own workspace!": "The next few pages will show you how to use this layout and create your very own workspace!",
   "The picture for achievement {0}": "The picture for achievement {0}",
+  "The production environment is not available yet. Use the proof-of-concept environment instead.": "The production environment is not available yet. Use the proof-of-concept environment instead.",
   "The project doesn\u0027t have a budget assigned. Contact a Datahub Administrator.": "The project doesn\u0027t have a budget assigned. Contact a Datahub Administrator.",
   "The second section of the sidebar is where you manage your workspace:": "The second section of the sidebar is where you manage your workspace:",
   "The state of your request is currently unknown.": "The state of your request is currently unknown.",


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Currently, any user can register for the production environment.

This PR disables new registration in the environment. It also disables workspace creation in the production environment to prevent these users from creating a new workspace.

If needed, our team can still manually create these workspaces and register users.

## Related Issues
<!-- List any related issues or tickets -->

## Changes
<!-- List the key changes in this PR -->

- Wrap registration and workspace creation pages in a check if the environment is production.
     - Displays a message in production environment, redirecting users.

![image](https://github.com/user-attachments/assets/3ead101c-3477-4307-b110-f65e3799a4e8)
![image](https://github.com/user-attachments/assets/6ad0ea1b-2f2c-4284-b063-7a052e0622f1)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
