### PR TITLE
Update SEARCH_API_URL for geo.ca

### DIFF
--- a/Portal/test/Datahub.Tests/ExternalSearchTest.cs
+++ b/Portal/test/Datahub.Tests/ExternalSearchTest.cs
@@ -39,7 +39,7 @@ public class ExternalSearchFixture : IDisposable
 
 public class ExternalSearchTest : IClassFixture<ExternalSearchFixture>
 {
-    private static readonly string SEARCH_API_URL = "https://hqdatl0f6d.execute-api.ca-central-1.amazonaws.com/dev/geo";
+    private static readonly string SEARCH_API_URL = "https://geocore.api.geo.ca/geo";
 
     private ExternalSearchFixture _fixture;
 


### PR DESCRIPTION
# Pull Request

## Description
Updates SEARCH_API_URL which is the search API for GEO.ca

## Related Issues
Previous URL was a temporary search API endpoint

## Testing
Discussed with John Bain that the new production endpoint works

## Checklist
Not needed I think
- [ ] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
