### PR TITLE
🔧 Adding a topic to support requests to request extended storage tokens

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
@@ -227,9 +227,11 @@
         { "Databricks", false },
         { "Storage", false },
         { "PostgreSQL", false },
+        { "Web App", false },
         { "User Management", false },
         { "Documentation", false },
         { "Tool Requesting", false },
+        { "Extended Storage Token", false },
         { "Other", false },
     };
 

--- a/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
@@ -70,7 +70,14 @@
                         }
                         else if (_currentStep == Steps.Description)
                         {
-                            <MudText Typo="@Typo.body1" Class="py-3">@Localizer["Please provide additional information that we can use to investigate this issue."]</MudText>
+                            if (_ticketTopics["Extended Storage Token"])
+                            {
+                                <MudText Typo="@Typo.body1" Class="py-3">@Localizer["Please describe why you need an extended storage token and any additional information for your request."]</MudText>
+                            }
+                            else
+                            {
+                                <MudText Typo="@Typo.body1" Class="py-3">@Localizer["Please provide additional information that we can use to investigate this issue."]</MudText>
+                            }
                             <MudTextField T="string"
                                           @bind-Value="@_ticketDescription"
                                           Label=@(Localizer["Detailed description"])

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -1913,6 +1913,7 @@
   "Please contact the workspace administrators for access or to share repositories.": "Veuillez contacter les administrateurs de l'espace de travail pour accéder à l'espace de travail ou pour partager des dépôts.",
   "Please enter a valid GC email address": "Veuillez entrer une adresse électronique GC valide",
   "Please enter a workspace acronym.": "Veuillez entrer un acronyme d'espace de travail.",
+  "Please describe why you need an extended storage token and any additional information for your request.": "Veuillez décrire pourquoi vous avez besoin d'un jeton de stockage prolongé et toute information supplémentaire pour votre demande.",
   "Please indicate which language you would like to be contacted in.": "Veuillez indiquer la langue dans laquelle vous aimeriez être contacté(e).",
   "Please indicate which workspaces you have this issue in. (Please select all that apply)": "Veuillez indiquer les espaces de travail dans lesquels vous rencontrez ce problème. (Veuillez sélectionner tous ceux qui s'appliquent)",
   "Please login to continue": "Veuillez vous connecter pour continuer",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1224,6 +1224,7 @@
   "Please press the button below to generate the IMSO approval form.": "Please press the button below to generate the IMSO approval form.",
   "Please press the button below to publish your submission on the Open Data Registry.": "Please press the button below to publish your submission on the Open Data Registry.",
   "Please provide additional information that we can use to investigate this issue.": "Please provide additional information that we can use to investigate this issue.",
+  "Please describe why you need an extended storage token and any additional information for your request.": "Please describe why you need an extended storage token and any additional information for your request.",
   "Please read before configuration to ensure that you do not run into any issues!": "Please read before configuration to ensure that you do not run into any issues!",
   "Please read the Additional Information section before proceeding to ensure that you do not run into any issues!": "Please read the Additional Information section before proceeding to ensure that you do not run into any issues!",
   "Please select all that apply": "Please select all that apply",


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Currently, tokens expire after 30 minutes. This PR allows users to submit a support request that requests an extended token and provide justification for this request.

A corresponding PR in `datahub-docs` is updating the storage token terms & conditions.

## Related Issues
<!-- List any related issues or tickets -->

[As a user, I need to request a longer expiration period for my storage token](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/9774)

## Changes
<!-- List the key changes in this PR -->

- Adds "Web App" and "Extended Storage Token" to support requests as topics.
- Updates text for description when an extended token is requested
- Adds i18n

![image](https://github.com/user-attachments/assets/974949e5-678b-4359-973e-ec3aab719588)

![image](https://github.com/user-attachments/assets/c560530c-ad71-4837-a5d9-11d6d909a238)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested submitting a ticket

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
