### PR TITLE
Azure function healthcheck cannot use default subscription

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Helpers/HealthCheckHelper.cs
@@ -2,6 +2,7 @@
 using Azure.Messaging.ServiceBus;
 using Azure.ResourceManager;
 using Azure.ResourceManager.AppService;
+using Azure.ResourceManager.Resources;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Storage.Queues;
@@ -67,6 +68,7 @@ namespace Datahub.Infrastructure.Services.Helpers
         private string AzureTenantId => portalConfiguration.AzureAd.TenantId;
         private string DevopsClientId => portalConfiguration.AzureAd.InfraClientId;
         private string DevopsClientSecret => portalConfiguration.AzureAd.InfraClientSecret;
+        private string SubscriptionId => portalConfiguration.AzureAd.SubscriptionId;
 
         private AzureDevOpsConfiguration BuildDevopsConfig() => new()
         {
@@ -454,7 +456,11 @@ namespace Datahub.Infrastructure.Services.Helpers
                 var credential = new ClientSecretCredential(AzureTenantId, DevopsClientId, DevopsClientSecret);
 
                 var armClient = new ArmClient(credential);
-                var subscription = await armClient.GetDefaultSubscriptionAsync();
+                // [VB] Datahub SP has different default subscription: we have explicitely select correct one 
+                //var subscription = await armClient.GetDefaultSubscriptionAsync();
+                var subscriptionResourceId = SubscriptionResource.CreateResourceIdentifier(SubscriptionId);
+                var subscription = armClient.GetSubscriptionResource(subscriptionResourceId); 
+                
                 var resourceGroup = await subscription.GetResourceGroupAsync($"fsdh-{CurrentEnvironment}-rg");
                 var functionApp = await resourceGroup.Value.GetWebSiteAsync($"{InfrastructureHealthCheckConstants.FSDHFunctionPrefix}-{CurrentEnvironment}");
                 var hostKeys = await functionApp.Value.GetHostKeysAsync();

--- a/ServerlessOperations/test/Datahub.Functions.UnitTests/HealthCheckFunctionTests.cs
+++ b/ServerlessOperations/test/Datahub.Functions.UnitTests/HealthCheckFunctionTests.cs
@@ -35,6 +35,14 @@ namespace Datahub.Functions.UnitTests
         public async Task Setup()
         {
             var datahubConfig = new DatahubPortalConfiguration();
+            datahubConfig.AzureAd = new AzureAd
+            {
+                SubscriptionId = Guid.NewGuid().ToString(),
+                TenantId = Guid.NewGuid().ToString(),
+                InfraClientId = Guid.NewGuid().ToString(),
+                InfraClientSecret = Guid.NewGuid().ToString()
+            };
+
             Testing._configuration.Bind(datahubConfig);
 
             var projectStorageConfigurationService = new ProjectStorageConfigurationService(datahubConfig);
@@ -162,6 +170,19 @@ namespace Datahub.Functions.UnitTests
         }
 
         [Test]
+        public async Task TestWorkspaceAzureFunctionHealthCheck()
+        {
+            var request = new InfrastructureHealthCheckMessage(Core.Model.Health.InfrastructureHealthResourceType.AzureFunction,
+                InfrastructureHealthCheckConstants.WorkspacesRequestGroup, TEST_PROJECT_ACRONYM);
+            var response = await _checkInfrastructureStatusFunction.ProcessRequest(request);
+
+            var results = GetHealthCheckResults(response);
+            var firstResult = results.FirstOrDefault();
+            var expectedError = "Error while checking Azure Function health: ClientSecretCredential authentication failed";
+            VerifyUnhealthyResult(firstResult, expectedError);
+        }
+
+        [Test]
         public async Task TestInvalidWorkspaceSQLDatabaseHealthCheck()
         {
             var request = new InfrastructureHealthCheckMessage(Core.Model.Health.InfrastructureHealthResourceType.AzureSqlDatabase, 
@@ -239,7 +260,15 @@ namespace Datahub.Functions.UnitTests
             result.Check.Status.Should().Be(Core.Model.Health.InfrastructureHealthStatus.Healthy);
             result.Errors.Should().BeEmpty();
         }
-
+        
+        private static void VerifyUnhealthyResult(InfrastructureHealthCheckResponse? result, string expectedError)
+        {
+            result.Should().NotBeNull();
+            result.Check.Should().NotBeNull();
+            result.Check.Status.Should().Be(Core.Model.Health.InfrastructureHealthStatus.Unhealthy);
+            result.Errors?.Count().Should().BeGreaterThan(0);
+            result.Errors?[0].Should().Contain(expectedError);
+        }
         [OneTimeTearDown]
         public void TearDown() 
         { 


### PR DESCRIPTION
# Pull Request

## Description
Fix permission error in Azure function health check

## Related Issues
[<!-- List any related issues or tickets -->](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/9981/)

## Changes
- using correct subscription instead of default subscription for the Service Account

## Testing
- tested locally 

## Checklist
- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
