### PR TITLE
💻 Re-adding the personal sidebar to many pages

### DIFF
--- a/Portal/src/Datahub.Portal/Layout/PersonalSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/PersonalSidebar.razor
@@ -20,8 +20,8 @@
 }
 
 <MudStack Class="px-4 mt-6" id="nav">
-    <MudDrawerHeader Dense Style="padding: 0">
-        <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.FlexStart">
+    <MudDrawerHeader Style="padding: 0">
+        <MudStack Row AlignItems="AlignItems.Center">
             <SkipLink Type="SkipLinkType.Navigation" Anchor>
                 <p class="sr-only">@Localizer["Toggle sidebar open or closed."]</p>
                 <MudIconButton title="@Localizer["Toggle sidebar open or closed."]" Icon="@Icons.Material.Filled.Menu"
@@ -39,7 +39,64 @@
     <MudDrawerContainer Style="overflow: hidden auto">
         @if (Drawer.Open)
         {
-            <MudStack Spacing="2">
+            <MudStack Spacing="2" Class="ml-2">
+                @{
+                    var userRoles = GetWorkspaces();
+                }
+                <MudStack Row AlignItems="AlignItems.Center">
+                    <MudText Typo="Typo.h2" Class="ml-2" Style="font-size: 1rem">
+                        <b>
+                            @Localizer["My workspaces"]
+                        </b>
+                    </MudText>
+                    <MudSpacer />
+                    @if (userRoles.Any())
+                    {
+                        <DHButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" Href="@Localizer[PageRoutes.CreateWorkspace]" Disabled="@_canNotCreateWorkspace">
+                            <DHIcon Icon="@SidebarIcons.CreateNew" Size="Size.Small" Class="mr-2" Style="font-size: 0.75rem;" />
+                            @Localizer["New"]
+                            <span class="sr-only">@Localizer["Workspace"]</span>
+                        </DHButton>
+                    }
+                </MudStack>
+
+                @if (userRoles.Any())
+                {
+                    <MudNavMenu Color="Color.Primary" role="navigation">
+                        <ul>
+
+                            @foreach (var userRole in userRoles)
+                            {
+                                <li>
+                                    <MudNavLink Href="@($"/w/{userRole.Project.Project_Acronym_CD}")">
+                                        <MudStack Row AlignItems="AlignItems.Center">
+                                            <DHIcon Icon="@SidebarIcons.Workspace" Size="Size.Small" Class="mr-2 ml-n2" Style="font-size: 1rem;" />
+                                            <MudText Style="@_workspaceLinkStyle">
+                                                @userRole.Project.ProjectName
+                                            </MudText>
+                                        </MudStack>
+                                    </MudNavLink>
+                                </li>
+                            }
+                        </ul>
+                        @if (_showAllWorkspaces == false && _userRoles.Count > _maxWorkspacesToShow)
+                        {
+                            <MudLink OnClick="@(() => _showAllWorkspaces = true)" Typo="Typo.body2" Color="Color.Default" Class="ml-4" Style="font-size: 0.75rem;">
+                                @Localizer["Show more"]
+                            </MudLink>
+                        }
+                    </MudNavMenu>
+                }
+                else
+                {
+                    <DHButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small" Class="ml-2 mt-2 mb-4" Href="@PageRoutes.CreateWorkspace">
+                        <DHIcon Icon="@SidebarIcons.CreateNew" Size="Size.Small" Class="mr-5" Style="font-size: 0.85rem;" />
+                        @Localizer["Create new"]
+                        <MudSpacer />
+                    </DHButton>
+                }
+            </MudStack>
+            <MudStack Spacing="2" Class="ml-2">
                 <MudText Typo="Typo.h2" Class="ml-2" Style="font-size: 1rem; text-wrap: nowrap">
                     <strong>
                         @Localizer["My account"]
@@ -67,7 +124,7 @@
                 </MudNavMenu>
             </MudStack>
             <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.DatahubSupport">
-                <MudStack Spacing="2">
+                <MudStack Spacing="2" Class="ml-2">
                     <MudText Typo="Typo.h2" Class="ml-2" Style="font-size: 1rem; text-wrap: nowrap">
                         <strong>
                             @Localizer["Datahub Admin"]
@@ -185,6 +242,7 @@
         .AddStyle("white-space", "nowrap")
         .AddStyle("overflow", "hidden")
         .AddStyle("text-overflow", "ellipsis")
+        .AddStyle("font-size", "1rem")
         .Build();
 
     protected override async Task OnInitializedAsync()

--- a/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementsPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Announcements/AnnouncementsPage.razor
@@ -1,5 +1,6 @@
 ﻿@using Datahub.Core.Model.Announcements
 @using Datahub.Application.Services.Announcements
+@using Datahub.Portal.Components.Sidebar
 
 
 @inject IAnnouncementService _announcementService
@@ -10,6 +11,10 @@
 <PageTitle>
     @Localizer["Announcements - Federal Science DataHub"]
 </PageTitle>
+
+<DHSidebarDrawer>
+    <PersonalSidebar/>
+</DHSidebarDrawer>
 
 <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.Authenticated">
     <MudStack Spacing="6">

--- a/Portal/src/Datahub.Portal/Pages/Explore/DataProjects.razor
+++ b/Portal/src/Datahub.Portal/Pages/Explore/DataProjects.razor
@@ -2,6 +2,7 @@
 @using Datahub.Core.Model.Projects
 @using Datahub.Portal.Pages.Tools.Users
 @using Datahub.Core.Model.Achievements
+@using Datahub.Portal.Components.Sidebar
 
 @inject IDbContextFactory<DatahubProjectDBContext> _dbFactory
 @inject DatahubPortalConfiguration _datahubPortalConfiguration
@@ -13,6 +14,10 @@
 <PageTitle>
     @Localizer["Explore - Federal Science DataHub"]
 </PageTitle>
+
+<DHSidebarDrawer>
+    <PersonalSidebar/>
+</DHSidebarDrawer>
 
 @if (!_allProjects.Any())
 {

--- a/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Help/HelpPage.razor
@@ -17,6 +17,7 @@
 @using Datahub.Core.Model.Projects;
 @using Datahub.Application.Configuration
 @using Datahub.Portal.Components.User
+@using Datahub.Portal.Components.Sidebar
 @using Datahub.Portal.Pages.Account
 @using Datahub.Portal.Pages.Project
 @using Datahub.Portal.Pages.Workspace.Settings;
@@ -46,6 +47,10 @@
 <PageTitle>
     @Localizer["Help - Federal Science DataHub"]
 </PageTitle>
+
+<DHSidebarDrawer>
+    <PersonalSidebar/>
+</DHSidebarDrawer>
 
 <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.Authenticated">
     <MudStack Spacing="6">

--- a/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
@@ -3,6 +3,7 @@
 @using Datahub.Core.Model.Achievements
 @using Datahub.Portal.Views.Dialogs
 @using Microsoft.Graph.Models
+@using Datahub.Portal.Components.Sidebar
 
 @inherits ViewUserBase<HomePage>
 
@@ -21,6 +22,10 @@
     <DHLoadingInitializer Message="@Localizer["Initializing profile..."]"/>
     return;
 }
+
+<DHSidebarDrawer>
+    <PersonalSidebar/>
+</DHSidebarDrawer>
 
 <MudStack>
     <DHMainContentTitle Title="@Localizer["MainTitle"]" />


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Following our discussion on navigation in FSDH, where broad consensus was around making both changes, this PR re-introduces the personal sidebar to make workspace navigation easy from any page.

## Related Issues
<!-- List any related issues or tickets -->

## Changes
<!-- List the key changes in this PR -->

- Re-introduces the PersonalSidebar to home, announcements, and a few other pages.
- Changes formatting in PersonalSidebar to match the current version of workspace sidebar.

![image](https://github.com/user-attachments/assets/3fb54f3f-e919-4c25-842c-5e2899106636)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
