### PR TITLE
removed sql retry for migratrion issue

### DIFF
--- a/Portal/src/Datahub.Core/Data/EFTools.cs
+++ b/Portal/src/Datahub.Core/Data/EFTools.cs
@@ -97,8 +97,8 @@ public static class EFTools
             case DbDriver.SqlServer:
             case DbDriver.SqlLocalDB:
             case DbDriver.Azure:
-                services.AddPooledDbContextFactory<T>(options => options.UseSqlServer(connectionString, providerOptions => providerOptions.EnableRetryOnFailure()));
-                services.AddDbContextPool<T>(options => options.UseSqlServer(connectionString, providerOptions => providerOptions.EnableRetryOnFailure()));
+                services.AddPooledDbContextFactory<T>(options => options.UseSqlServer(connectionString));
+                services.AddDbContextPool<T>(options => options.UseSqlServer(connectionString));
                 break;
             case DbDriver.Sqlite:
                 services.AddPooledDbContextFactory<T>(options => options.UseSqlite(connectionString));


### PR DESCRIPTION
# Pull Request

## Description
I added a sql retry option as a fix for the migrations, but its causing some issues, so I will remove it. it was an extra layer of protection to make sure the migrations run, but its not necessary.

- [ y] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
