### PR TITLE
🔧 Hotfix registration

### DIFF
--- a/Portal/src/Datahub.Application/Services/UserManagement/IUserInformationService.cs
+++ b/Portal/src/Datahub.Application/Services/UserManagement/IUserInformationService.cs
@@ -47,6 +47,7 @@ public interface IUserInformationService
     Task<bool> UpdatePortalUserAsync(PortalUser updatedUser);
     public event EventHandler<PortalUserUpdatedEventArgs> PortalUserUpdated;
     Task<bool> IsDailyLogin();
+    Task<bool> CheckUserInTenant(string email);
 }
 
 public static class UserInformationServiceConstants

--- a/Portal/src/Datahub.Infrastructure.Offline/OfflineUserInformationService.cs
+++ b/Portal/src/Datahub.Infrastructure.Offline/OfflineUserInformationService.cs
@@ -238,4 +238,9 @@ public class OfflineUserInformationService : IUserInformationService
     {
         return Task.FromResult(false);
     }
+
+    public Task<bool> CheckUserInTenant(string email)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/Portal/src/Datahub.Infrastructure/Services/UserManagement/UserInformationService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/UserManagement/UserInformationService.cs
@@ -562,4 +562,13 @@ public class UserInformationService(
 
         return portalUser;
     }
+
+    public async Task<bool> CheckUserInTenant(string email)
+    {
+        PrepareAuthenticatedClient();
+        var users = await graphServiceClient.Users.GetAsync(
+            test => test.QueryParameters.Filter = $"mail eq '{email}'");
+        if (users?.Value != null) return users.Value.Count > 0;
+        return false;
+    }
 }

--- a/Portal/src/Datahub.Portal/Pages/Public/Login.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/Login.razor
@@ -60,22 +60,34 @@
         _loggingIn = true;
         var loginHint = loginModel.Email;
         var existingUser = await _userInformationService.GetPortalUserByEmailAsync(loginHint);
+        
+        // If user is deleted, redirect to register page with deleted flag
         if (existingUser is { IsDeleted: true })
         {
             _navigationManager.NavigateTo($"{Localizer["/register"]}?email={loginHint}&s=d");
             return;
         }
 
+        // If user is locked, redirect to locked page
         if (existingUser is { IsLocked: true })
         {
             _navigationManager.NavigateTo(Localizer["/locked"]);
             return;
         }
-        
+
+        // If there is no portal user associated with the email, then:
         if (existingUser is null)
         {
-            _navigationManager.NavigateTo($"{Localizer["/register"]}?email={loginHint}&s=n");
-            return; 
+            // - first check if the user is registered in the tenant (that means they have registered but not logged in yet)
+            var registered = await _userInformationService.CheckUserInTenant(loginHint);
+            
+            // - if not registered, redirect to register page with new flag
+            if (!registered)
+            {
+                _navigationManager.NavigateTo($"{Localizer["/register"]}?email={loginHint}&s=n");
+                return;
+            }
+            // - if they are registered, proceed with the normal login flow
         }
 
         if (string.IsNullOrWhiteSpace(redirectUri))


### PR DESCRIPTION
There was an issue that prevented users from logging in the first time after registering. After registering, the user account exists in the tenant, but there is no portal user created for them just yet. Because of that, the current flow for checking if a user needs to register first when they attempt to login was redirecting them to the registration page upon their first login.

This PR adds an extra step that checks if their user account exists in the tenant, and if it does, proceeds to normal login flow.

Here's the flow:

```mermaid
flowchart TD
    A[User attempts to login] --> B{Check if associated PortalUser exists}
    B -->|Exists and Locked| C[Redirect to locked page]
    B -->|Exists and Deleted| D[Redirect to registration page with deleted state]
    B -->|Exists| E[Redirect to Microsoft login]
    B -->|Does not exist| F{NEW: Check if Entra ID account exists in the tenant}
    F-->|Exists| E
    F-->|Does not exist| H[Redirect to registration page with new user state]
```