### PR TITLE
🐛 Fixing when Workspace.Credits is null in the new budget bar

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Home/HomeWorkspaceCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeWorkspaceCard.razor
@@ -67,19 +67,23 @@
             </ul>
         </nav>
     </MudStack>
-    @if (ShowCost)
+    @if (ShowCost && Workspace.Credits != null)
     {
         <MudProgressLinear
             Color=@CostBarColor()
             Size="Size.Large"
             Style=@CostBarStyle
-            Value=@Workspace.Credits.Current
+            Value=@(Workspace.Credits == null ? 0 : Workspace.Credits.Current)
             Max=@((double)Workspace.Project_Budget!)
             title=@CostBarTitle()>
             <ProjectPreviewCardIconDetails
                 WorkspaceUsage=@WorkspaceUsage
             />
         </MudProgressLinear>
+    }
+    else if (ShowCost && Workspace.Credits == null)
+    {
+        <MudText Typo="Typo.body1">@CostBarTitle()</MudText>
     }
 </MudPaper>
 
@@ -158,6 +162,10 @@
     // Utils
     private Color CostBarColor()
     {
+        if (Workspace == null || Workspace.Project_Budget == null || Workspace.Credits == null)
+        {
+            return Color.Primary;
+        }
         return (Workspace.Credits.Current / (double)Workspace.Project_Budget! * 100) switch
         {
             >= 90 and < 100 => Color.Warning,
@@ -168,6 +176,10 @@
 
     private string CostBarTitle()
     {
+        if (Workspace.Credits == null)
+        {
+            return Localizer["No budget information available yet. Check again later!"];
+        }
         var defaultTitle = @Localizer["{0:C2} spent of {1:C2} budget for workspace {2}.", Workspace.Credits.Current, Workspace.Project_Budget!, Workspace.Project_Acronym_CD];
         return (Workspace.Credits.Current / (double)Workspace.Project_Budget * 100) switch
         {

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -1751,6 +1751,7 @@
   "Nickname": "Surnom",
   "No": "Non",
   "No announcements yet!": "Pas encore d'annonces!",
+  "No budget information available yet. Check again later!": "Aucune information budgétaire n'est disponible pour le moment. Vérifiez à nouveau plus tard!",
   "No catalog records found, try different keyword and filters.": "Aucun enregistrement de catalogue trouvé, essayez des mots-clés et des filtres différents.",
   "No changes to save": "Aucun changement à enregistrer",
   "No cost data available, please check back later": "Aucune donnée de coût disponible, veuillez revenir plus tard",

--- a/Portal/src/Datahub.Portal/i18n/localization.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.json
@@ -1098,6 +1098,7 @@
   "Nickname": "Nickname",
   "No": "No",
   "No announcements yet!": "No announcements yet!",
+  "No budget information available yet. Check again later!": "No budget information available yet. Check again later!",
   "No catalog records found, try different keyword and filters.": "No catalog records found, try different keyword and filters.",
   "No changes to save": "No changes to save",
   "No cost data available, please check back later": "No cost data available, please check back later",


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Currently, the new workspace costing bars on the home page cannot handle new workspaces prior to the budgets being processed.

This PR handles that case and displays a message when Workspace.Credits is null

![image](https://github.com/user-attachments/assets/bd2eed35-4e13-4f71-b5ad-e440f71ad3de)

## Related Issues
<!-- List any related issues or tickets -->

n/a

## Changes
<!-- List the key changes in this PR -->

- Adds a bunch of handling to make sure stuff isn't null

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
