### PR TITLE
improved X-Frame-Options to avoid iframe issues with web apps

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/ReverseProxy/ReverseProxyConfigService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/ReverseProxy/ReverseProxyConfigService.cs
@@ -75,6 +75,7 @@ internal class ReverseProxyConfigService : IReverseProxyConfigService
         };
 
         var finalRoute = route.
+            WithTransformResponseHeader("X-Frame-Options", "SAMEORIGIN", append: false).
             WithTransformForwarded().
             WithTransformXForwarded().
             WithTransform(transform => {

--- a/Portal/src/Datahub.Portal/Startup.cs
+++ b/Portal/src/Datahub.Portal/Startup.cs
@@ -292,7 +292,8 @@ public class Startup
         
         app.Use(async (context, next) =>
         {
-            context.Response.Headers.Append("X-Frame-Options", "SAMEORIGIN");
+            context.Response.Headers.Append("X-Frame-Options", "DENY");
+            //context.Response.Headers.Append("Content-Security-Policy", "frame-ancestors 'self';");
             await next();
         });
 

--- a/Portal/src/Datahub.Portal/Startup.cs
+++ b/Portal/src/Datahub.Portal/Startup.cs
@@ -108,9 +108,19 @@ public class Startup
         {
             // This lambda determines whether user consent for non-essential cookies is needed for a given request.
             options.CheckConsentNeeded = context => true;
-            options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+            options.MinimumSameSitePolicy = SameSiteMode.Strict;
+            options.HttpOnly = Microsoft.AspNetCore.CookiePolicy.HttpOnlyPolicy.Always;
             // Handling SameSite cookie according to https://docs.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-3.1
             options.HandleSameSiteCookieCompatibility();
+        });
+
+        services.AddSession(options =>
+        {
+            options.Cookie.HttpOnly = true;
+            options.Cookie.IsEssential = true;
+            options.Cookie.SameSite = SameSiteMode.Strict;
+            options.Cookie.Name = ".FSDH.Session";
+            options.IdleTimeout = TimeSpan.FromMinutes(30);
         });
 
         //required to access existing headers


### PR DESCRIPTION
# Pull Request

- Updated `X-Frame-Options` will not allow any app to iframe pages from fsdh, but proxy setting will allow inserting proxied web apps inside fsdh
- Updated cookie policy with `HttpOnly` for all sessions cookies to prevent iframes from accessing them

## Checklist
<!-- Ensure the following tasks are complete -->

- [X] Code follows dotnet coding standards
- [X] Tests added/updated to cover changes
