### PR TITLE
Rework the source url in the terraform files

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner.Application/Config/ResourceProvisionerConfiguration.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Application/Config/ResourceProvisionerConfiguration.cs
@@ -30,7 +30,7 @@ public class InfrastructureRepositoryConfiguration
 
 public class ModuleRepositoryConfiguration
 {
-    public const string DefaultBranch = "dev";
+    public const string DefaultBranch = "main";
     public string Url { get; set; }
     public string LocalPath { get; set; }
 
@@ -38,7 +38,7 @@ public class ModuleRepositoryConfiguration
     public string TemplatePathPrefix { get; set; }
     public string ModulePathPrefix { get; set; } = "modules/";
 
-    public string Branch { get; set; } = "dev";
+    public string Branch { get; set; } = "main";
 }
 
 public class ResourceProvisionerConfiguration

--- a/ResourceProvisioner/src/ResourceProvisioner.Application/Config/ResourceProvisionerConfiguration.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Application/Config/ResourceProvisionerConfiguration.cs
@@ -30,7 +30,7 @@ public class InfrastructureRepositoryConfiguration
 
 public class ModuleRepositoryConfiguration
 {
-    public const string DefaultBranch = "main";
+    public const string DefaultBranch = "dev";
     public string Url { get; set; }
     public string LocalPath { get; set; }
 
@@ -38,7 +38,7 @@ public class ModuleRepositoryConfiguration
     public string TemplatePathPrefix { get; set; }
     public string ModulePathPrefix { get; set; } = "modules/";
 
-    public string Branch { get; set; } = "main";
+    public string Branch { get; set; } = "dev";
 }
 
 public class ResourceProvisionerConfiguration

--- a/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/TerraformService.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/TerraformService.cs
@@ -19,8 +19,9 @@ public class TerraformService(
     IConfiguration configuration)
     : ITerraformService
 {
-    public const string TerraformVersionToken = "{{version}}";
-    public const string TerraformBranchToken = "{{branch}}";
+    //public const string TerraformVersionToken = "{{version}}";
+    //public const string TerraformBranchToken = "{{branch}}";
+    public const string TerraformTagToken = "{{tag}}";
 
     internal static readonly List<string> EXCLUDED_FILE_EXTENSIONS = new(new[] { ".md" });
 
@@ -63,9 +64,9 @@ public class TerraformService(
             var destinationFilename = Path.Combine(projectPath, sourceFilename);
 
             var fileContent = await File.ReadAllTextAsync(file);
-            fileContent = fileContent.Replace(TerraformVersionToken, terraformWorkspace.Version);
-            fileContent = fileContent.Replace(TerraformBranchToken,
-                $"?ref={resourceProvisionerConfiguration.ModuleRepository.Branch}");
+            
+            fileContent = fileContent.Replace(TerraformTagToken,
+                $"?ref={resourceProvisionerConfiguration.ModuleRepository.Branch}-{terraformWorkspace.Version}");
             await File.WriteAllTextAsync(destinationFilename, fileContent);
         }
     }

--- a/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/AzureAppServiceTemplateTests.cs
+++ b/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/AzureAppServiceTemplateTests.cs
@@ -69,9 +69,7 @@ public class AzureAppServiceTemplateTests
         foreach (var file in expectedFiles)
         {
             var sourceFileContent = await File.ReadAllTextAsync(file);
-            var expectedContent = sourceFileContent
-                .Replace(TerraformService.TerraformVersionToken, workspace.Version)
-                .Replace(TerraformService.TerraformBranchToken, $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}");
+            var expectedContent = sourceFileContent.Replace(TerraformService.TerraformTagToken, $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}-{workspace.Version}");
             var destinationFileContent =
                 await File.ReadAllTextAsync(Path.Join(moduleDestinationPath, Path.GetFileName(file)));
             Assert.That(destinationFileContent, Is.EqualTo(expectedContent));

--- a/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/AzureDatabricksTemplateTests.cs
+++ b/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/AzureDatabricksTemplateTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Datahub.Shared.Entities;
 using Datahub.Shared.Enums;
+using Microsoft.TeamFoundation.SourceControl.WebApi.Legacy;
+using ResourceProvisioner.Application.Config;
 using ResourceProvisioner.Domain.Exceptions;
 using ResourceProvisioner.Infrastructure.Common;
 using ResourceProvisioner.Infrastructure.Services;
@@ -73,8 +75,8 @@ public class AzureDatabricksTemplateTests
         {
             var sourceFileContent = await File.ReadAllTextAsync(file);
             var expectedContent = sourceFileContent
-                .Replace(TerraformService.TerraformVersionToken, workspace.Version)
-                .Replace(TerraformService.TerraformBranchToken, $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}");
+                .Replace(TerraformService.TerraformTagToken,
+               $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}-{workspace.Version}");
             var destinationFileContent =
                 await File.ReadAllTextAsync(Path.Join(moduleDestinationPath, Path.GetFileName(file)));
             Assert.That(destinationFileContent, Is.EqualTo(expectedContent));

--- a/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/AzureStorageBlobTemplateTests.cs
+++ b/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/AzureStorageBlobTemplateTests.cs
@@ -66,10 +66,9 @@ public class AzureStorageBlobTemplateTests
         foreach (var file in expectedFiles)
         {
             var sourceFileContent = await File.ReadAllTextAsync(file);
-            var expectedContent = sourceFileContent
-                .Replace(TerraformService.TerraformVersionToken, workspace.Version)
-                .Replace(TerraformService.TerraformBranchToken, $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}");
-            
+            var expectedContent = sourceFileContent.Replace(TerraformService.TerraformTagToken,
+               $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}-{workspace.Version}");
+
             var destinationFileContent =
                 await File.ReadAllTextAsync(Path.Join(moduleDestinationPath, Path.GetFileName(file)));
             Assert.That(destinationFileContent, Is.EqualTo(expectedContent));

--- a/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/NewProjectTemplateTests.cs
+++ b/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Templates/NewProjectTemplateTests.cs
@@ -51,9 +51,7 @@ public class NewProjectTemplateTests
         foreach (var file in expectedFiles)
         {
             var sourceFileContent = await File.ReadAllTextAsync(file);
-            var expectedContent = sourceFileContent
-                .Replace(TerraformService.TerraformVersionToken, workspace.Version)
-                .Replace(TerraformService.TerraformBranchToken, $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}");
+            var expectedContent = sourceFileContent.Replace(TerraformService.TerraformTagToken, $"?ref={_resourceProvisionerConfiguration.ModuleRepository.Branch}-{workspace.Version}");
             var destinationFileContent =
                 await File.ReadAllTextAsync(Path.Join(moduleDestinationPath, Path.GetFileName(file)));
             Assert.That(destinationFileContent, Is.EqualTo(expectedContent));
@@ -289,7 +287,7 @@ public class NewProjectTemplateTests
         // verify that the file main.tf does not contain "{{version}}" or "{{branch}}"
         var mainTfPath = Path.Join(moduleDestinationPath, "main.tf");
         var mainTfContent = await File.ReadAllTextAsync(mainTfPath);
-        Assert.That(mainTfContent, Does.Not.Contain(TerraformService.TerraformVersionToken));
-        Assert.That(mainTfContent, Does.Not.Contain(TerraformService.TerraformBranchToken));
+        Assert.That(mainTfContent, Does.Not.Contain(TerraformService.TerraformTagToken));
+        
     }
 }


### PR DESCRIPTION
# Pull Request

## Description
The terraform templates updated the source url for the git repo, this needed to be reflected in the code that pulls the templates to update tags in the url

## Related Issues
10374 - Once Terraform source updated, validate the need for application changes

## Changes

Chanted the url to use {{tag}} which is replaced by - env-version, instead of the previous method


## Testing
tested locally, will need to test flow once deployed to the serverless on dev

## Checklist

- [✔️ ] Code follows dotnet coding standards
- [ ] Tests added/updated to cover changes
