### PR TITLE
💻 Removing extra column in storage explorer and replacing AeTypography

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor
@@ -37,16 +37,15 @@
         <div class="file-list">
             <div class="file-list-header">
                 <div></div>
-                <AeTypography>
+                <MudText>
                     @Localizer["Name"]
                     @* <AeSearchInput *@
                     @*     SearchIconFAClass="fas fa-search" *@
                     @*     OnInputChangeWithLastKey="HandleSearch" *@
                     @*     style="margin: 0 1rem;"/> *@
-                </AeTypography>
-                <AeTypography>@Localizer["Size"]</AeTypography>
-                <AeTypography>@Localizer["Last Modified"]</AeTypography>
-                <i class="fas fa-sort-alpha-down"></i>
+                </MudText>
+                <MudText>@Localizer["Size"]</MudText>
+                <MudText>@Localizer["Last Modified"]</MudText>
             </div>
 
             @if (_loading)

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileItem.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileItem.razor
@@ -22,7 +22,7 @@
             <i class="fas fa-check-circle checked"></i>
         </span>
     }
-    <AeTypography class="file-item-name">
+    <MudText class="file-item-name">
         <span class="file-item-icon">
             @if (Icon != null)
             {
@@ -34,12 +34,9 @@
             }
         </span>
         @Name
-    </AeTypography>
-    <AeTypography class="file-item-size">@(ByteSize ?? "")</AeTypography>
-    <AeTypography class="file-item-modified">@(Modified?.ToString("r") ?? "")</AeTypography>
-    <span class="more-actions">
-        <i class="fas fa-ellipsis-h"></i>
-    </span>
+    </MudText>
+    <MudText class="file-item-size">@(ByteSize ?? "")</MudText>
+    <MudText class="file-item-modified">@(Modified?.ToString("r") ?? "")</MudText>
 </div>
 
     @code {


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

In UAT, a question was raised about the right column (with elipses) in the storage explorer. The buttons  in this column seem to be non-functional. This PR removes them.

This PR also replaces a few AeTypography lines with MudText

## Related Issues
<!-- List any related issues or tickets -->

https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/9867

## Changes
<!-- List the key changes in this PR -->

- Removes the non-functional right column from the storage explorer
- Removes `AeTypography` and replaces with `MudText`

### Before

![image](https://github.com/user-attachments/assets/2d929af8-1f18-4e05-a8c1-c2a819b18e1c)

### After

![image](https://github.com/user-attachments/assets/517ef574-96d4-4fd0-9481-2d899705b490)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
