### PR TITLE
🔒 Removing authentication from the media endpoints

### DIFF
--- a/Portal/src/Datahub.Portal/Controllers/MediaController.cs
+++ b/Portal/src/Datahub.Portal/Controllers/MediaController.cs
@@ -31,7 +31,6 @@ public class MediaController : Controller
     /// </summary>
     /// <returns></returns>
     [HttpGet("api/media/{**filePath}")]
-    [Authorize]
     public IActionResult GetMedia(string filePath)
     {
         if (_datahubPortalConfiguration?.Media?.StorageConnectionString is null)
@@ -58,7 +57,6 @@ public class MediaController : Controller
     /// </summary>
     /// <returns></returns>
     [HttpGet("api/docs/{**filePath}")]
-    [Authorize]
     public IActionResult GetDocs(string filePath)
     {
         if (_datahubPortalConfiguration?.Media?.StorageConnectionString is null)


### PR DESCRIPTION
# Pull Request

## Description
<!-- A brief description of what this PR does -->

Currently, signed out users cannot see the images in our registration docs due to authentication on the media endpoint.

![image](https://github.com/user-attachments/assets/8078dfba-6886-445e-a896-1c8642840908)

The media is all stored publicly on GitHub, so removing the authentication on the media endpoints should not pose an issue.

## Related Issues
<!-- List any related issues or tickets -->

n/a

## Changes
<!-- List the key changes in this PR -->

- Removing authentication on the media endpoints

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

- [x] Code follows dotnet coding standards
- [x] Tests added/updated to cover changes
