### PR TITLE
 refactor: Replacing AeTypography with MudText in the storage explorer properties

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileProperties.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileProperties.razor
@@ -16,34 +16,34 @@
     <div class="storage-properties">
         <div class="title-container">
             <i class="@DatahubTools.GetFileTypeIcon(File.fileformat)"></i>
-            <AeTypography Variant="h3" class="details-title-text">
+            <MudText Typo="Typo.h3" class="details-title-text">
                 @Path.GetFileName(File.name)
-            </AeTypography>
+            </MudText>
         </div>
 
         <div class="access-container">
-            <AeTypography Variant="h4">@Localizer["Who has access"]</AeTypography>
+            <MudText Typo="Typo.h4">@Localizer["Who has access"]</MudText>
             <span class="circle-item">
                 <ProfileCircle FullName="@ProjectAcronym"/>
-                <AeTypography>@ProjectAcronym</AeTypography>
+                <MudText>@ProjectAcronym</MudText>
             </span>
         </div>
 
         <div class="properties">
-            <AeTypography class="properties-title" Variant="h4">@Localizer["Storage Properties"]</AeTypography>
+            <MudText class="properties-title" Typo="Typo.h4">@Localizer["Storage Properties"]</MudText>
             @foreach (var (key, value) in _properties)
             {
                 if (!string.IsNullOrEmpty(value) && value != "[]")
                 {
-                    <AeTypography class="label">@Localizer[key]</AeTypography>
-                    <AeTypography class="text">@value</AeTypography>
+                    <MudText class="label">@Localizer[key]</MudText>
+                    <MudText class="text">@value</MudText>
                 }
             }
 
-            <AeTypography class="label">@Localizer["Power BI URL"]</AeTypography>
+            <MudText class="label">@Localizer["Power BI URL"]</MudText>
             <InlineCodeWithCopy>@_powerBiPasteText</InlineCodeWithCopy>
             
-            <AeTypography class="label">@Localizer["File URL"]</AeTypography>
+            <MudText class="label">@Localizer["File URL"]</MudText>
             <InlineCodeWithCopy>@_fileLinkUrl</InlineCodeWithCopy>
 
         </div>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageProperties.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageProperties.razor
@@ -20,31 +20,31 @@ else
     <div class="storage-properties">
         <div class="title-container">
             <i class="fas fa-folder"></i>
-            <AeTypography Variant="h3" class="details-title-text">
+            <MudText Typo="Typo.h3" class="details-title-text">
                 @DisplayName
-            </AeTypography>
+            </MudText>
         </div>
 
         <div class="access-container">
-            <AeTypography Variant="h4">@Localizer["Who has access"]</AeTypography>
+            <MudText Typo="Typo.h4">@Localizer["Who has access"]</MudText>
             <span class="circle-item">
                 <ProfileCircle FullName="@ProjectAcronym"/>
-                <AeTypography>@ProjectAcronym</AeTypography>
+                <MudText>@ProjectAcronym</MudText>
             </span>
         </div>
 
         <div class="properties">
-            <AeTypography class="properties-title" Variant="h4">@Localizer["Storage Properties"]</AeTypography>
+            <MudText class="properties-title" Typo="Typo.h4">@Localizer["Storage Properties"]</MudText>
             @foreach (var (key, (value, fragment)) in _properties)
             {
-                <AeTypography class="label">@Localizer[key]</AeTypography>
+                <MudText class="label">@Localizer[key]</MudText>
                 @if (fragment != null)
                 {
                     @fragment
                 }
                 else
                 {
-                    <AeTypography class="text">@value</AeTypography>
+                    <MudText class="text">@value</MudText>
                 }
             }
         </div>


### PR DESCRIPTION
# Pull Request

## Commit Title
<!-- Write your commit title following conventional commits. E.g., fix: Corrected login bug -->

 refactor: Replacing AeTypography with MudText in the storage explorer properties

## Description
<!-- A brief description of what this PR does -->

This PR replaces several AeTypography components with MudText in the properties section of the storage explorer:

## Related Issues
<!-- List any related issues or tickets -->

https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/10549

## Changes
<!-- List the key changes in this PR -->

- Removes and replaces several AeTypography components with MudText

Before:
![image](https://github.com/user-attachments/assets/829dde8b-9f6d-40d6-8721-e7dfb41b9f63)

After:
![image](https://github.com/user-attachments/assets/c30de0b0-b0a4-4b1c-b92e-dfee8748233d)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [x] written tests and theyre passing
    - not applicable


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage