### PR TITLE
fix: Removed the ability to set a user's role as disabled and removed the ability to set a new user as a removed user

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/AddNewUsersToProjectDialog.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/AddNewUsersToProjectDialog.razor
@@ -51,7 +51,7 @@
                         <td>@GetListText(user)</td>
                         <td>
                             <MudSelect T="int" Label="@Localizer["Role"]" @bind-Value="user.RoleId" Class="role-dropdown">
-                                @foreach (var role in _projectRoles)
+                                @foreach (var role in _projectRoles.Where(r => r.Id is not ((int)Project_Role.RoleNames.Remove or (int)Project_Role.RoleNames.WorkspaceLead or (int)Project_Role.RoleNames.DisabledUser)))
                                 {
                                     <MudSelectItem T="int" Value="@role.Id">@Localizer[role.Name]</MudSelectItem>
                                 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/ProjectMembersRoleSelect.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/ProjectMembersRoleSelect.razor
@@ -42,15 +42,6 @@
             </MudMenuItem>
         }
         <MudDivider />
-        @{
-            var disabledRole = _projectRoles.First(r => r.Id == (int)Project_Role.RoleNames.DisabledUser);
-        }
-        <MudMenuItem Disabled Style="max-width: 400px;">
-            <MudAlert Style="margin-bottom: 12px;" Dense Severity="Severity.Info">@Localizer["Disabled users cannot interact with the workspace."]</MudAlert>
-            <MudText Typo="Typo.h6">@Localizer[disabledRole.Name]</MudText>
-            <MudText>@Localizer[disabledRole.Description]</MudText>
-        </MudMenuItem>
-        <MudDivider />
         <MudMenuItem OnClick="@(() => RoleChanged(_removeRole.Id))" Style="max-width: 400px;">
             <MudText Color="Color.Error" Typo="Typo.h6">@Localizer[_removeRole.Name]</MudText>
             <MudText Color="Color.Error">@Localizer[_removeRole.Description]</MudText>


### PR DESCRIPTION
# Pull Request

## Commit Title
<!-- Write your commit title following conventional commits. E.g., fix: Corrected login bug -->

## Description
<!-- A brief description of what this PR does -->

Currently, when adding a new user, you can select "Removed User" or "Disabled" as their role. Neither of these roles should be assigned to a new user. This PR corrects this issue.

Also, this PR removes the "Disabled" option from the role selection list for existing workspace users.

## Related Issues
<!-- List any related issues or tickets -->

[BUG 11204](https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/11204)

## Changes
<!-- List the key changes in this PR -->

- Adds filter to the role list for new users to remove Workspace Lead, Removed User, or Disabled User.
    - If admins need to switch a Workspace Lead, we can do so from the role selection page.
- Removes the disabled user option from the role selection list

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [x] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage