### PR TITLE
fix: Announcement section is now hidden on the home page when there's nothing to announce

### DIFF
--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -4,6 +4,10 @@
 @inject NavigationManager _navigationManager
 
 <ul class="my-4 d-flex" style="gap: 25px; flex-wrap: wrap">
+    @if (_previewCount > 0)
+    {
+        <MudText Typo="Typo.h2">@Localizer["Announcements"]</MudText>
+    }
     @foreach (var index in _announcementIndices)
     {
         if (index != -1)
@@ -61,26 +65,6 @@
         base.OnInitialized();
 
         var hasBackgroundUrl = !string.IsNullOrEmpty(BackgroundUrl);
-
-        // _carouselStyle = new StyleBuilder()
-        //     .AddStyle("height", $"{CarouselHeight}px")
-        //     .Build();
-
-        // _backgroundImageStyle = new StyleBuilder()
-        //     .AddStyle("height", $"{CarouselHeight}px")
-        //     .AddStyle("background", $"linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, black 100%), url('{BackgroundUrl}') no-repeat", when: hasBackgroundUrl)
-        //     .AddStyle("background-size", "cover", when: hasBackgroundUrl)
-        //     .AddStyle("margin-bottom", "1rem")
-        //     .Build();
-
-        // _glassStyle = new StyleBuilder()
-        //     .AddStyle("height", $"{CarouselHeight}px")
-        //     .AddStyle("background", "rgba(0, 0, 0, 0.5)", when: hasBackgroundUrl)
-        //     .AddStyle("color", "white", when: hasBackgroundUrl)
-        //     .AddStyle("backdrop-filter", "blur(5px)", when: hasBackgroundUrl)
-        //     .AddStyle("--mud-palette-text-primary", "white", when: hasBackgroundUrl)
-        //     .AddStyle("--mud-palette-primary", Colors.Purple.Accent2, when: hasBackgroundUrl)
-        //     .Build();
 
         _descriptionTextStyle = new StyleBuilder()
             .AddStyle("overflow", "hidden")

--- a/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomePage.razor
@@ -17,12 +17,11 @@
 }
 
 <MudStack>
-    <DHMainContentTitle Title="@Localizer["Home"]"/>
     @if (_viewedPortalUser.GraphGuid == _currentUser.GraphGuid)
     {
         <div role="group">
             <MudStack Row AlignItems="AlignItems.End">
-                <MudText Typo="Typo.h2">@Localizer["Announcements"]</MudText>
+                <DHMainContentTitle Title="@Localizer["Home"]" />
                 <MudSpacer/>
                 <UserCard ViewedUserGraphId="@_viewedPortalUser.GraphGuid" RightAvatar ShowLoginTime/>
             </MudStack>

--- a/Portal/src/Datahub.Portal/Pages/Home/WelcomeBanner.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/WelcomeBanner.razor
@@ -17,12 +17,6 @@
 {
     <DHLoadingInitializer />
 }
-else if (_previews.Count == 0)
-{
-    <MudPaper Class="welcome-banner" Style="@_personalBackgroundStyle" >
-        <MudText Typo="Typo.h2" class="greeting">@_greeting</MudText>
-    </MudPaper>
-}
 else
 {
    <AnnouncementCarousel Previews="_previews" BackgroundUrl="@_userBackgroundUrl" />


### PR DESCRIPTION
# Pull Request

## Commit Title
<!-- Write your commit title following conventional commits. E.g., fix: Corrected login bug -->

fix: Announcement section is now hidden on the home page when there's nothing to announce

## Description
<!-- A brief description of what this PR does -->

Currently, the announcement section displays some art when no announcements are available. This PR instead hides the section entirely in that case.

## Related Issues
<!-- List any related issues or tickets -->

n/a

## Changes
<!-- List the key changes in this PR -->

- Hides the announcement section entirely when no announcements are available

![image](https://github.com/user-attachments/assets/8f3d8653-0300-4c76-8c9e-9342dfcc79c4)

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [ ] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage