### PR TITLE
fix: updated rules to allow only single workspace lead

### DIFF
--- a/Datahub.sln
+++ b/Datahub.sln
@@ -95,6 +95,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{A8C7
 		scripts\appsettings.psm1 = scripts\appsettings.psm1
 		bleach.ps1 = bleach.ps1
 		scripts\ConfigureAZCert.ps1 = scripts\ConfigureAZCert.ps1
+		dotnet-upgrade.ps1 = dotnet-upgrade.ps1
 		scripts\find-translations.ps1 = scripts\find-translations.ps1
 		scripts\fix_CS8981.ps1 = scripts\fix_CS8981.ps1
 		scripts\initLocalDev.ps1 = scripts\initLocalDev.ps1
@@ -363,12 +364,11 @@ Global
 		{12002871-163E-49CD-93DE-FBED9F5573E1} = {0A20EC69-1E3C-498F-B989-89CAF316CE06}
 		{53C2E55C-7BF1-477E-B12A-05A3CAD9B39A} = {12002871-163E-49CD-93DE-FBED9F5573E1}
 		{DB462B58-CFC4-4AEE-920E-AA308F14029C} = {8620F501-1D36-439E-9BF0-3BBEFB84DC56}
-		{1B44BC52-6E9A-4FF1-84EE-D2A67D8CDD2B} = {73AC16BF-F514-4081-8C74-63C6399260E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_ConfirmAddLanguageFile = True
-		RESX_AutoCreateNewLanguageFiles = True
 		SolutionGuid = {9DC4B901-16FF-4FF2-9ED6-B286EA17048E}
+		RESX_AutoCreateNewLanguageFiles = True
+		RESX_ConfirmAddLanguageFile = True
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Shared\src\Datahub.Shared\Datahub.Shared.projitems*{57703cec-08b9-40b8-b5e2-064a196b1587}*SharedItemsImports = 5

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor.cs
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor.cs
@@ -100,9 +100,9 @@ namespace Datahub.Portal.Pages.Workspace.Users
             var allWorkspaceLeads = _usersToUpdate.Select(_usersToUpdate => _usersToUpdate.ProjectUser).Where(x => x.RoleId == (int)Project_Role.RoleNames.WorkspaceLead).Count();
             var existingWorkspaceLeads = _projectUsers.Except(_usersToUpdate.Select(p => p.ProjectUser)).Where(x => x.RoleId == (int)Project_Role.RoleNames.WorkspaceLead).Count();
             var newLeads = _usersToAdd.Count(x => x.RoleId == (int)Project_Role.RoleNames.WorkspaceLead);
-            if (allWorkspaceLeads + newLeads + existingWorkspaceLeads > 2)
+            if (allWorkspaceLeads + newLeads + existingWorkspaceLeads > 1)
             {
-                _validationErrorMessage = Localizer["You cannot have more than 2 workspace leads."];
+                _validationErrorMessage = Localizer["You cannot have more than one workspace lead."];
             }
         }
 

--- a/Portal/src/Datahub.Portal/i18n/localization.fr.json
+++ b/Portal/src/Datahub.Portal/i18n/localization.fr.json
@@ -3207,7 +3207,7 @@
   "You can edit your selection in the select step.": "Vous pouvez modifier votre sélection à l'étape de sélection.",
   "You can explore existing projects and users on the platform using the Explore page": "Vous pouvez explorer les projets et les utilisateurs existants sur la plateforme en utilisant la page Explorer",
   "You can request workspace tools from the \u0027Toolbox\u0027 tab.": "Vous pouvez demander des outils d'espace de travail à partir de l'onglet \u0027Boîte à outils\u0027.",
-  "You cannot have more than 2 workspace leads.": "Vous ne pouvez pas avoir plus de 2 responsables d'un espace de travail.",
+  "You cannot have more than one workspace lead.": "Vous ne pouvez pas avoir plus d'un responsable d'un espace de travail.",
   "You currently do not have access to this project": "Vous n’avez actuellement pas accès à ce projet",
   "You currently do not have access to this project.": "Vous n’avez actuellement pas accès à ce projet.",
   "You do not have a lot of time to create and configure environments if you are to remain flexible and focused on the task at hand.": "Vous n’avez pas beaucoup de temps pour créer et configurer des environnements si vous souhaitez rester souple et concentré sur la tâche à accomplir.",

--- a/Portal/test/Datahub.SpecflowTests/Features/Workspace/WorkspaceUsersPage.feature
+++ b/Portal/test/Datahub.SpecflowTests/Features/Workspace/WorkspaceUsersPage.feature
@@ -66,3 +66,8 @@ The Workspace Users page should list users, support changing user roles, and all
         And the Data Steward checkbox is disabled for user "guest@example.com"
         When the user updates the role of user with email "guest@example.com" to Collaborator
         Then the Data Steward checkbox should be enabled for user "guest@example.com"
+
+    Scenario: Adding a second workspace lead
+        Given I have an existing workspace lead
+        When I add another lead
+        Then a validation error is shown preventing multiple leads

--- a/Portal/test/Datahub.SpecflowTests/Steps/Workspace/WorkspaceUsersPageSteps.cs
+++ b/Portal/test/Datahub.SpecflowTests/Steps/Workspace/WorkspaceUsersPageSteps.cs
@@ -1,5 +1,6 @@
 ﻿using Bunit;
 using Bunit.TestDoubles;
+using Datahub.Application.Commands;
 using Datahub.Application.Configuration;
 using Datahub.Application.Services;
 using Datahub.Application.Services.UserManagement;
@@ -14,6 +15,7 @@ using Datahub.Portal.Pages.Workspace.Users;
 using Datahub.SpecflowTests.Utils;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +24,8 @@ using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
 using Reqnroll;
+using System.Reflection;
+using Xunit;
 
 namespace Datahub.SpecflowTests.Steps
 {
@@ -356,6 +360,72 @@ namespace Datahub.SpecflowTests.Steps
         public async Task WhenTheUserUpdatesSomeonesRoleToCollaborator(string email)
         {
             await UpdateGivenUsersRole(email, (int)Project_Role.RoleNames.Collaborator);
+        }
+
+        [Given(@"I have an existing workspace lead")]
+        public async Task GivenIHaveAnExistingWorkspaceLead()
+        {
+
+            await GivenTheUserIsOnTheWorkspaceUsersPage();
+            // Retrieve the already-registered NSubstitute mock from DI
+            // (Set up previously in GivenTheUserIsOnTheWorkspaceUsersPage() or wherever you configure your services.)
+            var projectUserManagementService = Services.GetService<IProjectUserManagementService>();
+
+            var page = GetWorkspaceUserPageFromContext();
+            // Substitute behavior: return a user who is a Workspace Lead
+            projectUserManagementService!.GetProjectUsersAsync(Arg.Any<string>())
+                .Returns(new List<Datahub_Project_User>
+                {
+            new Datahub_Project_User
+            {
+                RoleId = (int)Project_Role.RoleNames.WorkspaceLead,
+                PortalUser = new PortalUser { GraphGuid = Guid.NewGuid().ToString() }
+            }
+                });            
+        }
+
+        [When(@"I add another lead")]
+        public void WhenIAddAnotherLead()
+        {
+            var page = GetWorkspaceUserPageFromContext();
+            
+            // Get the instance itself, not the type
+            var instance = page.Instance;
+            
+            // Access the field from the instance
+            var fieldUsersToAdd = instance.GetType().GetField("_usersToAdd", BindingFlags.NonPublic | BindingFlags.Instance);
+            fieldUsersToAdd.Should().NotBeNull("The _usersToAdd field should exist in the component");
+            
+            var usersToAdd = (List<ProjectUserAddUserCommand>)fieldUsersToAdd.GetValue(instance);
+            usersToAdd.Should().NotBeNull("The _usersToAdd list should be initialized");
+
+            usersToAdd.Add(new ProjectUserAddUserCommand
+            {
+                Email = "second_lead@test.com",
+                RoleId = (int)Project_Role.RoleNames.WorkspaceLead
+            });
+
+            // Run validation
+            var validateMethod = instance.GetType().GetMethod("ValidateWorkspaceRules", BindingFlags.NonPublic | BindingFlags.Instance);
+            validateMethod.Should().NotBeNull("The ValidateWorkspaceRules method should exist");
+            validateMethod.Invoke(instance, null);
+        }
+
+        [Then(@"a validation error is shown preventing multiple leads")]
+        public void ThenAValidationErrorIsShownPreventingMultipleLeads()
+        {
+            var page = GetWorkspaceUserPageFromContext();
+            
+            // Get the instance itself, not the type
+            var instance = page.Instance;
+            
+            // Check the private field for error message
+            var errorMessageField = instance.GetType().GetField("_validationErrorMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+            errorMessageField.Should().NotBeNull("The _validationErrorMessage field should exist in the component");
+            
+            var validationMessage = (string)errorMessageField.GetValue(instance);
+            validationMessage.Should().NotBeNull("There should be a validation error message");
+            validationMessage.Should().Contain("You cannot have more than one workspace lead.");
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Description
- updated rule in workspace members to change from two to one lead max
- updated translation

## Testing

- New unit test for validation clauses and message

## Checklist

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [X] written tests and they re passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage