### PR TITLE
fix: Improve announcement card on Home page to include button in article markup

### DIFF
--- a/Portal/src/Datahub.Core/Components/AnnouncementMarkdown.razor
+++ b/Portal/src/Datahub.Core/Components/AnnouncementMarkdown.razor
@@ -1,0 +1,69 @@
+﻿@using Markdig
+@using Microsoft.AspNetCore.Components
+
+@if (Content != null)
+{
+    <article @ref="_elementReference" @attributes=InputAttributes style="@Style" class="markdown-content">
+        @foreach (var part in Parts)
+        {
+            if (part.IsPlaceholder)
+            {
+                @ChildContent
+            }
+            else
+            {
+                @((MarkupString)part.Content)
+            }
+        }
+    </article>
+}
+
+@code {
+    private const string MARKDOWN_CONTAINER_CLASS = "markdown-container";
+    private ElementReference _elementReference;
+
+    [Parameter] public string Content { get; set; }
+    [Parameter] public string Style { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object> InputAttributes { get; set; }
+
+    private List<(bool IsPlaceholder, string Content)> Parts = new();
+
+    protected override void OnParametersSet()
+    {
+        if (InputAttributes == null)
+        {
+            InputAttributes = new()
+            {
+                {"class", MARKDOWN_CONTAINER_CLASS}
+            };
+        }
+        else
+        {
+            var existingClass = InputAttributes.GetValueOrDefault("class") ?? string.Empty;
+            InputAttributes["class"] = $"{MARKDOWN_CONTAINER_CLASS} {existingClass}";
+        }
+
+        if (string.IsNullOrEmpty(Content))
+        {
+            Parts.Clear();
+            return;
+        }
+
+        const string placeholder = "[Child]";
+        var html = Markdig.Markdown.ToHtml(Content);
+
+        Parts = new();
+        int last = 0;
+        int idx;
+        while ((idx = html.IndexOf(placeholder, last, StringComparison.Ordinal)) != -1)
+        {
+            if (idx > last)
+                Parts.Add((false, html.Substring(last, idx - last)));
+            Parts.Add((true, "")); // Placeholder
+            last = idx + placeholder.Length;
+        }
+        if (last < html.Length)
+            Parts.Add((false, html.Substring(last)));
+    }
+}

--- a/Portal/src/Datahub.Core/Components/DHMarkdown.razor
+++ b/Portal/src/Datahub.Core/Components/DHMarkdown.razor
@@ -1,4 +1,6 @@
 @using Markdig
+@using Datahub.Portal.Pages
+
 @inject IJSRuntime _jsRuntime;
 
 @if (Content != null)
@@ -45,12 +47,22 @@
                 {
                     _finalContent = Content;
                 }
+                _finalContent += ReadMoreLink();
+
                 _needsRefresh = false;
             }
             if (string.IsNullOrWhiteSpace(_finalContent)) return "Nothing to display";
 
             return _finalContent;
         }
+    }
+
+    private string ReadMoreLink()
+    {
+        var readMoreText = Localizer["Read more"];
+        var newsUrl = Localizer["/announcements"]; 
+        // Unicode for double right arrow: U + 00BB 
+        return $"\n\n[{readMoreText}]({newsUrl}) »";
     }
 
     private string OverrideLinkUrl(Markdig.Syntax.Inlines.LinkInline linkElement)

--- a/Portal/src/Datahub.Core/Components/DHMarkdown.razor
+++ b/Portal/src/Datahub.Core/Components/DHMarkdown.razor
@@ -1,6 +1,4 @@
 @using Markdig
-@using Datahub.Portal.Pages
-
 @inject IJSRuntime _jsRuntime;
 
 @if (Content != null)
@@ -47,22 +45,12 @@
                 {
                     _finalContent = Content;
                 }
-                _finalContent += ReadMoreLink();
-
                 _needsRefresh = false;
             }
             if (string.IsNullOrWhiteSpace(_finalContent)) return "Nothing to display";
 
             return _finalContent;
         }
-    }
-
-    private string ReadMoreLink()
-    {
-        var readMoreText = Localizer["Read more"];
-        var newsUrl = Localizer["/announcements"]; 
-        // Unicode for double right arrow: U + 00BB 
-        return $"\n\n[{readMoreText}]({newsUrl}) »";
     }
 
     private string OverrideLinkUrl(Markdig.Syntax.Inlines.LinkInline linkElement)

--- a/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
+++ b/Portal/src/Datahub.Portal/Components/Announcements/AnnouncementCarousel.razor
@@ -19,20 +19,17 @@
 
                     <MudPaper Elevation="0" Outlined Class="py-2 px-3">
                         <MudStack Justify="Justify.SpaceBetween" Style="height: 208px;" Spacing="1">
-                            <MudElement>
-                                <DHMarkdown Content="@preview.Preview" Style="@_descriptionTextStyle"/>
-                            </MudElement>
-                            <MudElement>
+                            <AnnouncementMarkdown Content="@($"{preview.Preview}<br/>[Child]")" Style="@_descriptionTextStyle">
                                 <DHButton Href="@Localizer[PageRoutes.News]"
                                           Color="@Color.Primary"
                                           Variant="@Variant.Text"
                                           EndIcon="@Icons.Material.Filled.KeyboardDoubleArrowRight"
-                                          Underline 
+                                          Underline
                                           NoWrap>
                                     <span class="sr-only">@preview.Preview</span>
                                     @Localizer["Read more"]
                                 </DHButton>
-                            </MudElement>
+                            </AnnouncementMarkdown>
                         </MudStack>
                     </MudPaper>
                 </li>


### PR DESCRIPTION
# Pull Request

## Commit Title
feat: Improve accessibility of announcement on home page

## Description
Created custom Markup component to ensure "Read More" button is rendered inside <article> DOM element

## Related Issues
https://dev.azure.com/DataSolutionsDonnees/FSDH%20SSC/_workitems/edit/6750

## Changes
- added new AnnouncementMarkup.razor component;
- updated AnnouncementCarousel to use new component instead of DHMarkup

## Testing
- tested manually (screenshot follows)

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [ ] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage