### PR TITLE
fix: Minor try/catch for better error message on costing refresh in production

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/Cost/WorkspaceCostManagementService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Cost/WorkspaceCostManagementService.cs
@@ -197,7 +197,7 @@ namespace Datahub.Infrastructure.Services.Cost
 
                 var result = response.Value;
                 queryResults.Add(result);
-                lastDate = granularity == QueryGranularity.Daily ? GetLastDate(result) : endDate;
+                lastDate = granularity == QueryGranularity.Daily ? (GetLastDate(result) ?? endDate) : endDate;
                 nextLink = result.NextLink;
             } while (!string.IsNullOrEmpty(nextLink));
 
@@ -587,14 +587,20 @@ namespace Datahub.Infrastructure.Services.Cost
         /// </summary>
         /// <param name="queryResult">A query result from a usage query</param>
         /// <returns>The datetime of the most recent date present in the query result</returns>
-        internal DateTime GetLastDate(QueryResult queryResult)
+        internal DateTime? GetLastDate(QueryResult queryResult)
         {
             var cols = queryResult.Columns.ToList().Select(c => c.Name).ToList();
             CultureInfo provider = CultureInfo.InvariantCulture;
+            var rowCount = queryResult.Rows.Count;
             var max = queryResult.Rows.MaxBy(r => DateTime.ParseExact(
                 r[cols.FindIndex(c => c == USAGE_DATE_COLUMN)].ToString(),
                 "yyyyMMdd",
                 provider));
+            if (max is null)
+            {
+                logger.LogWarning($"Could not find any dates in the query result - found {rowCount} rows");
+                return null;
+            }
             var maxDate = DateTime.ParseExact(max![cols.FindIndex(c => c == USAGE_DATE_COLUMN)].ToString(), "yyyyMMdd",
                 provider);
             return maxDate;

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Reports/WorkspaceCostingReport.razor
@@ -422,8 +422,15 @@
     {
         _refreshing = true;
         var beforeUpdate = _projectCredits.LastUpdate;
-
-        var success = await _costMgmt.RefreshWorkspaceCostsAsync(WorkspaceAcronym);
+        var success = false;
+        try {
+            success = await _costMgmt.RefreshWorkspaceCostsAsync(WorkspaceAcronym);
+            _logger.LogInformation("Refreshing cost data for workspace {WorkspaceAcronym}", WorkspaceAcronym);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error logging refresh for workspace {WorkspaceAcronym}", WorkspaceAcronym);
+        }
         await FetchDatabaseData();
         var afterUpdate = _projectCredits.LastUpdate;
 


### PR DESCRIPTION
# Pull Request

## Commit Title

- Too many calls to refresh in costing report can cause the page to crash because we run into the azure limits
- Added logging to identify edge case for workspace in prod

## Testing

- Local regression testing

### Author Checklist

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [X] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage