### PR TITLE
fix: Terrafom output handler fails on pre-resource run

### DIFF
--- a/ServerlessOperations/src/Datahub.Functions/TerraformOutputHandler.cs
+++ b/ServerlessOperations/src/Datahub.Functions/TerraformOutputHandler.cs
@@ -44,7 +44,8 @@ public class TerraformOutputHandler(
         // if (await pongService.Pong(message.Body.ToString()))
         // return;
 
-        var output = await message.DeserializeAndUnwrapMessageAsync<Dictionary<string, TerraformOutputVariable>>();
+        // Try to deserialize with wrapper first, then without
+        var output = await TryDeserializeMessage(message);
 
         _logger.LogInformation("C# Queue trigger function processing: {OutputCount} items", output?.Count);
 
@@ -74,6 +75,46 @@ public class TerraformOutputHandler(
         await ProcessPostTerraformTriggers(output);
 
         _logger.LogInformation("C# Queue trigger function finished");
+    }
+
+    private async Task<Dictionary<string, TerraformOutputVariable>?> TryDeserializeMessage(ServiceBusReceivedMessage message)
+    {
+        try
+        {
+            var messageBody = message.Body.ToString();
+            var deserializeOptions = new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            };
+
+            // Check if the message has the wrapper
+            var messageDoc = System.Text.Json.JsonDocument.Parse(messageBody);
+            var hasMessageWrapper = messageDoc.RootElement.TryGetProperty("message", out _);
+
+            string messageToDeserialize;
+            if (hasMessageWrapper)
+            {
+                // Already has wrapper, use as-is
+                messageToDeserialize = messageBody;
+            }
+            else
+            {
+                // Add the wrapper
+                messageToDeserialize = $"{{\"message\":{messageBody}}}";
+                _logger.LogInformation("Message did not have wrapper, added wrapper before deserialization");
+            }
+
+            // Parse and deserialize
+            var messageEnvelope = System.Text.Json.JsonDocument.Parse(messageToDeserialize);
+            messageEnvelope.RootElement.TryGetProperty("message", out var messageContent);
+
+            return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, TerraformOutputVariable>>(messageContent.GetRawText(), deserializeOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize message body");
+            return null;
+        }
     }
 
     internal async Task ProcessTerraformInputVariables(Dictionary<string, TerraformOutputVariable> output)

--- a/ServerlessOperations/src/Datahub.Functions/host.json
+++ b/ServerlessOperations/src/Datahub.Functions/host.json
@@ -16,8 +16,5 @@
             "maxAutoLockRenewalDuration": "00:30:00",
             "transportType": "amqpWebSockets"
         }
-    },
-    "functions": [
-        "TerraformOutputHandler"
-    ]
+    }
 }

--- a/ServerlessOperations/src/Datahub.Functions/host.json
+++ b/ServerlessOperations/src/Datahub.Functions/host.json
@@ -16,5 +16,8 @@
             "maxAutoLockRenewalDuration": "00:30:00",
             "transportType": "amqpWebSockets"
         }
-    }
+    },
+    "functions": [
+        "TerraformOutputHandler"
+    ]
 }

--- a/ServerlessOperations/test/Datahub.Functions.UnitTests/Functions/TerraformOutputHandlerTests.cs
+++ b/ServerlessOperations/test/Datahub.Functions.UnitTests/Functions/TerraformOutputHandlerTests.cs
@@ -517,4 +517,91 @@ public class TerraformOutputHandlerTests
         // Assert
         await act.Should().ThrowAsync<Exception>().WithMessage("The given key 'project_cd' was not present in the dictionary.");
     }
+
+    [Test]
+    public async Task TryDeserializeMessage_ShouldDeserializeMessageWithWrapper()
+    {
+        // Arrange - Terraform output message with wrapper (first JSON example)
+        var terraformOutputMessage = new Dictionary<string, TerraformOutputVariable>
+        {
+            { "azure_databricks_module_status", new TerraformOutputVariable { Value = "completed" } },
+            { "azure_databricks_workspace_id", new TerraformOutputVariable { Value = "test-workspace-id" } },
+            { "azure_databricks_workspace_name", new TerraformOutputVariable { Value = "test-workspace-name" } },
+            { "azure_databricks_workspace_url", new TerraformOutputVariable { Value = "test-workspace-url.azuredatabricks.net" } },
+            { "azure_resource_group_name", new TerraformOutputVariable { Value = "test-resource-group" } },
+            { "azure_storage_account_name", new TerraformOutputVariable { Value = "teststorageaccount" } },
+            { "azure_storage_blob_status", new TerraformOutputVariable { Value = "completed" } },
+            { "azure_storage_container_name", new TerraformOutputVariable { Value = "test-container" } },
+            { "new_project_template", new TerraformOutputVariable { Value = "completed" } },
+            { "project_cd", new TerraformOutputVariable { Value = "TD1" } },
+            { "workspace_version", new TerraformOutputVariable { Value = "v5.2.1" } }
+        };
+
+        var messageEnvelope = new { message = terraformOutputMessage };
+        var messageBody = JsonSerializer.Serialize(messageEnvelope);
+        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: new BinaryData(messageBody));
+
+        // Act - Use reflection to call the private method
+        var method = typeof(TerraformOutputHandler).GetMethod("TryDeserializeMessage", 
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var result = await (Task<Dictionary<string, TerraformOutputVariable>?>)method!.Invoke(
+            _terraformOutputHandler, new object[] { serviceBusReceivedMessage })!;
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Count, Is.EqualTo(11));
+        Assert.That(result["project_cd"].Value, Is.EqualTo("TD1"));
+        Assert.That(result["azure_databricks_module_status"].Value, Is.EqualTo("completed"));
+        Assert.That(result["workspace_version"].Value, Is.EqualTo("v5.2.1"));
+    }
+
+    [Test]
+    public async Task TryDeserializeMessage_ShouldDeserializeMessageWithoutWrapper()
+    {
+        // Arrange - Terraform input message without wrapper (second JSON example)
+        var pipelineMessage = new Dictionary<string, TerraformOutputVariable>
+        {
+            { "pipeline_run_id", new TerraformOutputVariable { Value = "12345" } },
+            { "pipeline_run_url", new TerraformOutputVariable { Value = "https://test.example.com/build/12345" } },
+            { "project_cd", new TerraformOutputVariable { Value = "TD1" } }
+        };
+
+        // Serialize WITHOUT the message wrapper
+        var messageBody = JsonSerializer.Serialize(pipelineMessage);
+        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: new BinaryData(messageBody));
+
+        // Act - Use reflection to call the private method
+        var method = typeof(TerraformOutputHandler).GetMethod("TryDeserializeMessage", 
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var result = await (Task<Dictionary<string, TerraformOutputVariable>?>)method!.Invoke(
+            _terraformOutputHandler, new object[] { serviceBusReceivedMessage })!;
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Count, Is.EqualTo(3));
+        Assert.That(result["pipeline_run_id"].Value, Is.EqualTo("12345"));
+        Assert.That(result["pipeline_run_url"].Value, Is.EqualTo("https://test.example.com/build/12345"));
+        Assert.That(result["project_cd"].Value, Is.EqualTo("TD1"));
+    }
+
+    [Test]
+    public async Task TryDeserializeMessage_ShouldReturnNullForInvalidJson()
+    {
+        // Arrange - Invalid JSON
+        var invalidJson = "{ this is not valid json }";
+        var serviceBusReceivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: new BinaryData(invalidJson));
+
+        // Act - Use reflection to call the private method
+        var method = typeof(TerraformOutputHandler).GetMethod("TryDeserializeMessage", 
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var result = await (Task<Dictionary<string, TerraformOutputVariable>?>)method!.Invoke(
+            _terraformOutputHandler, new object[] { serviceBusReceivedMessage })!;
+
+        // Assert - Should return null for invalid JSON
+        Assert.That(result, Is.Null);
+    }
 }


### PR DESCRIPTION
# Pull Request

## Commit Title
fix: Terrafom output handler fails on pre-resource run

## Description
The terraform output handler runs twice when resources are being deployed. Once to track the pipeline id and the next to complete the resource deployment. The first run was failing because the terraform message was not formed correctly. While this should be a fix in the actual terraform run, I added a message wrapper to fix the json received and continue the provisioning process.

## Related Issues
12271: Terrafom output handler fails on pre-resource run

## Changes
- Added a message wrapper to incomplete json inputs
- Added test cases to verify new code

## Testing
- Added test cases for new method
- Tested function locally
- Will test on dev once deployed

## Checklist

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [x] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage