### PR TITLE
fix: Sensitivity level name change and topbar fix

### DIFF
--- a/Portal/src/Datahub.Metadata/Model/ClassificationType.cs
+++ b/Portal/src/Datahub.Metadata/Model/ClassificationType.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using System;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace Datahub.Metadata.Model;
@@ -9,6 +10,22 @@ public enum ClassificationType : byte
     Unclassified,
     ProtectedA,
     ProtectedB
+}
+
+public static class ClassificationTypeExtension
+{
+    public static string ToSpacedString(this ClassificationType me)
+    {
+        switch (me)
+        {
+            case ClassificationType.ProtectedB:
+                return "Protected B";
+            case ClassificationType.ProtectedA:
+                return "Protected A";
+            default:
+                return "Unclassified";
+        }
+    }
 }
 
 public partial class SecurityClassificationStringConverter : ValueConverter<ClassificationType, string>

--- a/Portal/src/Datahub.Portal/Layout/Topbar/EnvironmentTopBar.razor
+++ b/Portal/src/Datahub.Portal/Layout/Topbar/EnvironmentTopBar.razor
@@ -1,5 +1,6 @@
 @using Datahub.Core
 @using Datahub.Core.Model.Projects
+@using Datahub.Metadata.Model
 @using MudBlazor.Utilities
 
     <h2 class="sr-only">
@@ -10,9 +11,7 @@
     </p>
 
 @code {
-    [Parameter] public int SecurityLevel { get; set; }
-
-    [Parameter] public string? ChildContent { get; set; }
+    [Parameter] public ClassificationType SecurityLevel { get; set; }
 
     private string _styles = null!;
 
@@ -36,26 +35,26 @@
             .Build();
     }
 
-    private string GetSecurityColor(int securityLevel)
+    private string GetSecurityColor(ClassificationType securityLevel)
     {
         switch (securityLevel)
         {
-            case 2:
+            case ClassificationType.ProtectedB:
                 return "rgb(244, 67, 54)";
-            case 1:
+            case ClassificationType.ProtectedA:
                 return "rgb(255,152,0)";
             default:
                 return "rgb(89, 74, 226)";
         }
     }
 
-    private string GetSecurityLabel(int securityLevel)
+    private string GetSecurityLabel(ClassificationType securityLevel)
     {
         switch (securityLevel)
         {
-            case 2:
+            case ClassificationType.ProtectedB:
                 return Localizer["Protected B"];
-            case 1:
+            case ClassificationType.ProtectedA:
                 return Localizer["Protected A"];
             default:
                 return Localizer["Unclassified"];

--- a/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
+++ b/Portal/src/Datahub.Portal/Layout/WorkspaceSidebar.razor
@@ -50,14 +50,18 @@
                                 <MudSpacer/>
                                 <MudChip T="string" Color="@GetSecurityColor(project.Data_Sensitivity)" Size="Size.Small" title="@Localizer[GetSecurityTitle(project.Data_Sensitivity)]">
                                     <DHIcon Icon=@(project.Data_Sensitivity == ClassificationType.Unclassified ? Icons.Material.Outlined.LockOpen : Icons.Material.Outlined.Lock) />
-                                    @if (!(project.Data_Sensitivity == ClassificationType.Unclassified))
-                                    {
                                         <MudText Typo="Typo.body1">
                                             <strong>
-                                                @Localizer[(project.Data_Sensitivity == ClassificationType.ProtectedA ? "A" : "B")]
-                                            </strong>
+                                              @if (!(project.Data_Sensitivity == ClassificationType.Unclassified))
+                                              {
+                                                  @Localizer[(project.Data_Sensitivity == ClassificationType.ProtectedA ? "A" : "B")]
+                                              }
+                                              else
+                                              {
+                                                  @Localizer["Uc"]
+                                              }
+                                          </strong>
                                         </MudText>
-                                    }
                                     <span class="sr-only">@Localizer[GetSecurityTitle(project.Data_Sensitivity)]</span>
                                 </MudChip>
                             </MudStack>

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeWorkspaceCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeWorkspaceCard.razor
@@ -1,4 +1,4 @@
-﻿@using Datahub.Application.Services
+@using Datahub.Application.Services
 @using Datahub.Application.Services.Notification
 @using Datahub.Core.Model.Projects
 @using Datahub.Core.Services.Projects
@@ -32,17 +32,11 @@
             <FeaturedProjectToggle Project="@Workspace" />
             <MudSpacer />
             <MudChip T="string" Color="@GetSecurityColor(Workspace.Data_Sensitivity)" Size="Size.Small" title="@Localizer[GetSecurityTitle(Workspace.Data_Sensitivity)]">
-
                 <DHIcon Icon=@(Workspace.Data_Sensitivity == ClassificationType.Unclassified ? Icons.Material.Outlined.LockOpen : Icons.Material.Outlined.Lock)/>
-                @if (!(Workspace.Data_Sensitivity == ClassificationType.Unclassified))
-                    {
-                        <MudText Typo="Typo.body1">
-                            <strong>
-                            @Localizer[(Workspace.Data_Sensitivity == ClassificationType.ProtectedA ? "A" : "B")]
-                            </strong>
-                        </MudText>
-                    }
-                    <span class="sr-only">@Localizer[GetSecurityTitle(Workspace.Data_Sensitivity)]</span>
+                <MudText Typo="Typo.body1">
+                    @Localizer[(Workspace.Data_Sensitivity.ToString())]
+                </MudText>
+                <span class="sr-only">@Localizer[GetSecurityTitle(Workspace.Data_Sensitivity)]</span>
             </MudChip>
         </MudStack>
         <MudStack Row>

--- a/Portal/src/Datahub.Portal/Pages/Home/HomeWorkspaceCard.razor
+++ b/Portal/src/Datahub.Portal/Pages/Home/HomeWorkspaceCard.razor
@@ -34,7 +34,7 @@
             <MudChip T="string" Color="@GetSecurityColor(Workspace.Data_Sensitivity)" Size="Size.Small" title="@Localizer[GetSecurityTitle(Workspace.Data_Sensitivity)]">
                 <DHIcon Icon=@(Workspace.Data_Sensitivity == ClassificationType.Unclassified ? Icons.Material.Outlined.LockOpen : Icons.Material.Outlined.Lock)/>
                 <MudText Typo="Typo.body1">
-                    @Localizer[(Workspace.Data_Sensitivity.ToString())]
+                    @Localizer[(Workspace.Data_Sensitivity.ToSpacedString())]
                 </MudText>
                 <span class="sr-only">@Localizer[GetSecurityTitle(Workspace.Data_Sensitivity)]</span>
             </MudChip>

--- a/Portal/src/Datahub.Portal/Pages/Workspace/WorkspacePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/WorkspacePage.razor
@@ -29,7 +29,7 @@
 <PageTitle>
     @Localizer["{0} - Workspace - Federal Science DataHub", WorkspaceAcronymParam ?? ""]
 </PageTitle>
-<EnvironmentTopBar ChildContent="@_project.Data_Sensitivity.ToString()"/>
+<EnvironmentTopBar SecurityLevel="@_project.Data_Sensitivity"/>
 
 <DHSidebarDrawer>
     <WorkspaceSidebar WorkspaceAcronym="@WorkspaceAcronymParam" ElevatedWorkspaceAccessEnabled="@_showToDatahubAdmins" />


### PR DESCRIPTION
# Pull Request

## Commit Title
fix: Sensitivity level name change and topbar fix

## Description
Adds full name to sensitivity level in workspace card, abbreviated name in workspace dropdown, and fixes topbar naming.

## Related Issues
12343 & 12347

## Changes
<!-- List the key changes in this PR -->

- Full name to sens level in workspace card
- Abbreviated name in workspace dropdown
- Fixes topbar issue where it only displays "unclassified"

## Testing
Visual
<img width="470" height="764" alt="image" src="https://github.com/user-attachments/assets/41048edd-8c06-4ddd-8b1e-73cc25bb0a82" />


## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [ ] written tests and they're passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage