### PR TITLE
feat: Remove disabled button for external users

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Public/LoginChoicePage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/LoginChoicePage.razor
@@ -42,15 +42,6 @@
                     </span>
                 </DHButton>
             }
-            else
-            {
-                <DHButton Class="px-16 my-2" Variant="Variant.Filled" Style="width:50%;" Disabled="true">
-                    <span>
-                        @Localizer["External user (coming soon)"]
-                        <span class="sr-only"></span>
-                    </span>
-                </DHButton>
-            }
         </MudStack>
         <DHFooter />
     </MudPaper>


### PR DESCRIPTION
# Pull Request


## Description
I think it makes more logical sense to have no button presented when the feature is disabled. This allows a platform owner the ability to remove/hide the feature and also not set user expectations that External Login will soon be available.

## Related Issues
Users may expect external login being available when platform owner never intends to enable it 

## Changes
Remove else, no placeholder button

## Testing
verified locally 

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [x] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage