### PR TITLE
fix: removed ResponseType to fall back to default

### DIFF
--- a/Portal/src/Datahub.Portal/Services/Auth/ConfigureAuthServices.cs
+++ b/Portal/src/Datahub.Portal/Services/Auth/ConfigureAuthServices.cs
@@ -94,7 +94,6 @@ public static class ConfigureAuthServices
                     }
                     options.ClientId = configuration["GccfOidc:ClientId"] ?? throw new ArgumentNullException("GCCF ClientID"); // From configuration
                     options.ClientSecret = configuration["GccfOidc:ClientSecret"] ?? throw new ArgumentNullException("GCCF ClientSecret"); // From configuration
-                    options.ResponseType = OpenIdConnectResponseType.Code;
 
                     options.CallbackPath = GccfSigninURL;
                     options.SaveTokens = true;


### PR DESCRIPTION
# Pull Request

## Commit Title

## Description
<!-- A brief description of what this PR does -->

## Related Issues
<!-- List any related issues or tickets -->

## Changes

- Tentative fix for GCCF configuration - changed response to default id token

## Testing

- To be tested with GCCF in dev

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [X] written tests and theyre passing

