### PR TITLE
fix: Updating StorageHeading name so it appears in file explorer

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/FileExplorer.razor
@@ -2,7 +2,7 @@
 @using Datahub.Application.Services.Publishing
 @using Datahub.Core.Model.Users
 @using Datahub.Core.Storage;
-@using Datahub.Core.Components.FileUpload
+@using Datahub.Core.Components.FileUpload;
 @using Datahub.Core.Services.Storage;
 @using Datahub.Application.Services
 @using Datahub.Application.Services.UserManagement
@@ -22,265 +22,259 @@
 
 @if (!_failed)
 {
-    <CascadingValue Value="@StorageAccountMetadata" Name="StorageAccountMetadata">
-        <div class="file-explorer-layout">
-            <Heading
-                CurrentFolder="@_currentFolder"
-                SelectedItems="@_selectedItems"
-                Files="@_files"
-                Folders="@_folders"
-                MetadataSignature=@_metadataSignature
-                OnNewFolder="HandleNewFolder"
-                SetCurrentFolder="SetCurrentFolder"
-                OnFileDelete="HandleFilesDelete"
-                OnFileDownload="HandleFileDownload"
-                OnPublishFiles="HandlePublishFiles"
-                OnFileRename="HandleFileRename"
-                OnDeleteFolder="HandleDeleteFolder"
-                CanDeleteFolder="CanDeleteFolder" />
+  <CascadingValue Value="@StorageAccountMetadata" Name="StorageAccountMetadata">
+    <div class="file-explorer-layout">
+      <StorageHeading CurrentFolder="@_currentFolder"
+                      SelectedItems="@_selectedItems"
+                      Files="@_files"
+                      Folders="@_folders"
+                      MetadataSignature=@_metadataSignature
+                      OnNewFolder="HandleNewFolder"
+                      SetCurrentFolder="SetCurrentFolder"
+                      OnFileDelete="HandleFilesDelete"
+                      OnFileDownload="HandleFileDownload"
+                      OnPublishFiles="HandlePublishFiles"
+                      OnFileRename="HandleFileRename"
+                      OnDeleteFolder="HandleDeleteFolder"
+                      CanDeleteFolder="CanDeleteFolder" />
 
-            <div class="file-list">
-                <div class="file-list-header">
-                    <div>
-                        <span class="file-selection-icon" @onclick="ToggleSelectAllFiles">
-                            <i class="far fa-circle unchecked" style="display: @(!_allFilesSelected ? "inline" : "none")"></i>
-                            <i class="fas fa-check-circle checked" style="display: @(_allFilesSelected ? "inline" : "none")"></i>
-                        </span>
-                    </div>
-                    <MudText>
-                        @Localizer["Name"]
-                        @* <AeSearchInput *@
-                        @*     SearchIconFAClass="fas fa-search" *@
-                        @*     OnInputChangeWithLastKey="HandleSearch" *@
-                        @*     style="margin: 0 1rem;"/> *@
-                    </MudText>
-                    <MudText>@Localizer["Size"]</MudText>
-                    <MudText>@Localizer["Last Modified"]</MudText>
-                </div>
-
-                @if (_loading)
-                {
-                    <LoadingFileList/>
-                }
-                else
-                {
-                    <UploadSnackbar UploadingFiles="_uploadingFiles" BlockedFiles="_blockedFiles">
-                        <DropZone MaxHeight OnFilesDrop="UploadFiles">
-                            @if (_currentFolder != _root)
-                            {
-                                var parentFolder = GetDirectoryName(_currentFolder);
-                                <DropZone
-                                    OnFilesDrop="async (e) => await UploadFiles(e, parentFolder)"
-                                    OnFileItemDrop="async filename => await HandleFileItemDrop(parentFolder, filename)">
-                                    <FileItem
-                                        Name="[..]"
-                                        Folder
-                                        @onclick="@(() => _selectedItems = new HashSet<string> { parentFolder })"
-                                        @ondblclick="async () => await SetCurrentFolder(parentFolder)">
-                                        <Icon>
-                                            <i class="fas fa-folder"></i>
-                                        </Icon>
-                                    </FileItem>
-                                </DropZone>
-                            }
-                            @foreach (var folderName in _folders
-                                              .Where(f => f?.Contains(_filterValue) ?? false)
-                                              .OrderBy(f => f.ToLower()))
-                            {
-                                <DropZone
-                                    OnFilesDrop="async (e) => await UploadFiles(e, folderName)"
-                                    OnFileItemDrop="async filename => await HandleFileItemDrop(folderName, filename)">
-                                    <FileItem
-                                        Name="@GetFileName(folderName)"
-                                        Highlighted="_selectedItems.Contains(folderName)"
-                                        Folder
-                                        @onclick="@(() => _selectedItems = new HashSet<string> { folderName })"
-                                        @ondblclick="async () => await SetCurrentFolder(folderName)">
-                                        <Icon>
-                                            <i class="fas fa-folder"></i>
-                                        </Icon>
-                                    </FileItem>
-                                </DropZone>
-                            }
-                            @foreach (var file in _files
-                                              .Where(f => f?.name?.Contains(_filterValue) ?? false)
-                                              .OrderBy(f => f.name.ToLower()))
-                            {
-                                <FileItem
-                                    Name="@GetFileName(file.name)"
-                                    Modified="@file.Modified"
-                                    Size="@file.filesize"
-                                    @onclick="@(() => _selectedItems = new HashSet<string> { file.name })"
-                                    OnSelectionClick="() => HandleFileSelectionClick(file.name)"
-                                    Highlighted="_selectedItems.Contains(file.name)">
-                                    <Icon>
-                                        <i class="@DatahubTools.GetFileTypeIcon(file.fileformat)"></i>
-                                    </Icon>
-                                </FileItem>
-                            }
-                        </DropZone>
-                    </UploadSnackbar>
-                }
-            </div>
-            <div class="item-details">
-                <div class="details-sticky">
-                    <div class="details-container">
-                        @if (_loading || _folders.Contains(_selectedItem) || _currentFolder == _selectedItem)
-                        {
-                            <StorageProperties DisplayName="@GetFileName(_selectedItem)" Container="@Container"/>
-                        }
-                        else
-                        {
-                            var file = _files.FirstOrDefault(f => f.name.Equals(_selectedItem, StringComparison.OrdinalIgnoreCase));
-                            <FileProperties @key=@_selectedItem
-                                            ProjectId=@ProjectId
-                                            File=@file
-                                            Readonly="!OwnsFile(file)"
-                                            OnMetadataChanged=@HandleMetadataChanged/>
-                        }
-                    </div>
-                </div>
-            </div>
+      <div class="file-list">
+        <div class="file-list-header">
+          <div>
+            <span class="file-selection-icon" @onclick="ToggleSelectAllFiles">
+              <i class="far fa-circle unchecked" style="display: @(!_allFilesSelected ? "inline" : "none")"></i>
+              <i class="fas fa-check-circle checked" style="display: @(_allFilesSelected ? "inline" : "none")"></i>
+            </span>
+          </div>
+          <MudText>
+            @Localizer["Name"]
+            @* <AeSearchInput *@
+            @*     SearchIconFAClass="fas fa-search" *@
+            @*     OnInputChangeWithLastKey="HandleSearch" *@
+            @*     style="margin: 0 1rem;"/> *@
+          </MudText>
+          <MudText>@Localizer["Size"]</MudText>
+          <MudText>@Localizer["Last Modified"]</MudText>
         </div>
-    </CascadingValue>
+
+        @if (_loading)
+        {
+          <LoadingFileList />
+        }
+        else
+        {
+          <UploadSnackbar UploadingFiles="_uploadingFiles" BlockedFiles="_blockedFiles">
+            <DropZone MaxHeight OnFilesDrop="UploadFiles">
+              @if (_currentFolder != _root)
+              {
+                var parentFolder = GetDirectoryName(_currentFolder);
+                <DropZone OnFilesDrop="async (e) => await UploadFiles(e, parentFolder)"
+                          OnFileItemDrop="async filename => await HandleFileItemDrop(parentFolder, filename)">
+                  <FileItem Name="[..]"
+                            Folder
+                            @onclick="@(() => _selectedItems = new HashSet<string> { parentFolder })"
+                            @ondblclick="async () => await SetCurrentFolder(parentFolder)">
+                    <Icon>
+                      <i class="fas fa-folder"></i>
+                    </Icon>
+                  </FileItem>
+                </DropZone>
+              }
+              @foreach (var folderName in _folders
+                                   .Where(f => f?.Contains(_filterValue) ?? false)
+                                   .OrderBy(f => f.ToLower()))
+              {
+                <DropZone OnFilesDrop="async (e) => await UploadFiles(e, folderName)"
+                          OnFileItemDrop="async filename => await HandleFileItemDrop(folderName, filename)">
+                  <FileItem Name="@GetFileName(folderName)"
+                            Highlighted="_selectedItems.Contains(folderName)"
+                            Folder
+                            @onclick="@(() => _selectedItems = new HashSet<string> { folderName })"
+                            @ondblclick="async () => await SetCurrentFolder(folderName)">
+                    <Icon>
+                      <i class="fas fa-folder"></i>
+                    </Icon>
+                  </FileItem>
+                </DropZone>
+              }
+              @foreach (var file in _files
+                                   .Where(f => f?.name?.Contains(_filterValue) ?? false)
+                                   .OrderBy(f => f.name.ToLower()))
+              {
+                <FileItem Name="@GetFileName(file.name)"
+                          Modified="@file.Modified"
+                          Size="@file.filesize"
+                          @onclick="@(() => _selectedItems = new HashSet<string> { file.name })"
+                          OnSelectionClick="() => HandleFileSelectionClick(file.name)"
+                          Highlighted="_selectedItems.Contains(file.name)">
+                  <Icon>
+                    <i class="@DatahubTools.GetFileTypeIcon(file.fileformat)"></i>
+                  </Icon>
+                </FileItem>
+              }
+            </DropZone>
+          </UploadSnackbar>
+        }
+      </div>
+      <div class="item-details">
+        <div class="details-sticky">
+          <div class="details-container">
+            @if (_loading || _folders.Contains(_selectedItem) || _currentFolder == _selectedItem)
+            {
+              <StorageProperties DisplayName="@GetFileName(_selectedItem)" Container="@Container" />
+            }
+            else
+            {
+              var file = _files.FirstOrDefault(f => f.name.Equals(_selectedItem, StringComparison.OrdinalIgnoreCase));
+              <FileProperties @key=@_selectedItem
+                              ProjectId=@ProjectId
+                              File=@file
+                              Readonly="!OwnsFile(file)"
+                              OnMetadataChanged=@HandleMetadataChanged />
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+  </CascadingValue>
 }
 else
 {
-    <MudPaper Class="pa-4" Outlined Elevation="0">
-        <MudText>
-            @Localizer["Failed to load file explorer"]
-        </MudText>
-    </MudPaper>
+  <MudPaper Class="pa-4" Outlined Elevation="0">
+    <MudText>
+      @Localizer["Failed to load file explorer"]
+    </MudText>
+  </MudPaper>
 }
 
 @code {
 
-    [CascadingParameter(Name = "ProjectAcronym")]
-    public string ProjectAcronym { get; set; }
+  [CascadingParameter(Name = "ProjectAcronym")]
+  public string ProjectAcronym { get; set; }
 
-    [CascadingParameter(Name = "PortalUser")]
-    public PortalUser PortalUser { get; set; }
+  [CascadingParameter(Name = "PortalUser")]
+  public PortalUser PortalUser { get; set; }
 
-    [Parameter] public int? ProjectId { get; set; }
+  [Parameter] public int? ProjectId { get; set; }
 
-    [Parameter] public CloudStorageContainer Container { get; set; }
+  [Parameter] public CloudStorageContainer Container { get; set; }
 
-    public StorageMetadata StorageAccountMetadata { get; set; }
+  public StorageMetadata StorageAccountMetadata { get; set; }
 
-    private bool _allFilesSelected = false;
+  private bool _allFilesSelected = false;
 
-    private CloudStorageContainer _lastContainer = default;
+  private CloudStorageContainer _lastContainer = default;
 
-    private string ContainerName => Container?.Name;
+  private string ContainerName => Container?.Name;
 
-    private ICloudStorageManager StorageManager => Container?.StorageManager;
+  private ICloudStorageManager StorageManager => Container?.StorageManager;
 
-    private string? _userId;
+  private string? _userId;
 
-    private bool _loading = true;
-    private bool _failed = false;
-    private List<FileMetaData> _uploadingFiles = [];
-    private List<string> _blockedFiles = [];
-    private string _continuationToken;
+  private bool _loading = true;
+  private bool _failed = false;
+  private List<FileMetaData> _uploadingFiles = [];
+  private List<string> _blockedFiles = [];
+  private string _continuationToken;
 
-    private readonly string _root = "/";
-    private string _currentFolder = "/";
-    private string _selectedItem => _selectedItems.FirstOrDefault("/");
+  private readonly string _root = "/";
+  private string _currentFolder = "/";
+  private string _selectedItem => _selectedItems.FirstOrDefault("/");
 
-    private HashSet<string> _selectedItems = new();
+  private HashSet<string> _selectedItems = new();
 
-    private List<string> _folders = new();
-    private List<FileMetaData> _files = new();
-    private string _filterValue = string.Empty;
+  private List<string> _folders = new();
+  private List<FileMetaData> _files = new();
+  private string _filterValue = string.Empty;
 
-    private IJSObjectReference _module;
+  private IJSObjectReference _module;
 
-    private Dictionary<string, int> _folderList;
+  private Dictionary<string, int> _folderList;
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    await base.OnAfterRenderAsync(firstRender);
+    if (firstRender)
     {
-        await base.OnAfterRenderAsync(firstRender);
-        if (firstRender)
-        {
-            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Workspace/Storage/FileExplorer.razor.js");
-            if (StorageManager != null)
-            {
-                StorageAccountMetadata = await StorageManager.GetStorageMetadataAsync(ContainerName);
-                _folderList = await GetFileCountAsync(_currentFolder);
-                StateHasChanged();
-            }
-        }
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-
-        await using var projectContext = await _dbFactoryProject.CreateDbContextAsync();
-
-        _userId = await _userInformationService.GetCurrentUserEntraId();
-
-        _uploadingFiles = new List<FileMetaData>();
-    }
-
-    private bool OwnsFile(FileMetaData file) => (file?.ownedby ?? "").Equals(_userId, StringComparison.InvariantCulture);
-
-    private Guid _metadataSignature = Guid.NewGuid();
-
-    private void HandleMetadataChanged()
-    {
-        _metadataSignature = Guid.NewGuid();
-    }
-
-    private async Task<Dictionary<string, int>> GetFileCountAsync(string folderPath)
-    {
-        Dictionary<string, int> folders = new();
-        if (StorageManager != null)
-        {
-            folders = await StorageManager.ListFoldersAsync(ContainerName, folderPath);
-        }
-        return folders;
-    }
-    private async Task ToggleSelectAllFiles()
-    {
-        _allFilesSelected = !_allFilesSelected;
-
-        if (_allFilesSelected)
-        {
-            _selectedItems = _files.Select(f => f.name).ToHashSet();
-        }
-        else
-        {
-            _selectedItems.Clear();
-        }
-    }
-    private bool CanDeleteFolder(string folderName)
-    {
-        if (_folders.Contains(folderName) && _folderList != null)
-        {
-            return _folderList.TryGetValue($"{folderName}/", out int fileCount) && fileCount == 0;
-        }
-        return false;
-    }
-
-    private void SelectItem(string item)
-    {
-        _selectedItems = new HashSet<string> { item };
+      _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Workspace/Storage/FileExplorer.razor.js");
+      if (StorageManager != null)
+      {
+        StorageAccountMetadata = await StorageManager.GetStorageMetadataAsync(ContainerName);
+        _folderList = await GetFileCountAsync(_currentFolder);
         StateHasChanged();
+      }
     }
+  }
 
-    public async ValueTask DisposeAsync()
+  protected override async Task OnInitializedAsync()
+  {
+    await base.OnInitializedAsync();
+
+    await using var projectContext = await _dbFactoryProject.CreateDbContextAsync();
+
+    _userId = await _userInformationService.GetCurrentUserEntraId();
+
+    _uploadingFiles = new List<FileMetaData>();
+  }
+
+  private bool OwnsFile(FileMetaData file) => (file?.ownedby ?? "").Equals(_userId, StringComparison.InvariantCulture);
+
+  private Guid _metadataSignature = Guid.NewGuid();
+
+  private void HandleMetadataChanged()
+  {
+    _metadataSignature = Guid.NewGuid();
+  }
+
+  private async Task<Dictionary<string, int>> GetFileCountAsync(string folderPath)
+  {
+    Dictionary<string, int> folders = new();
+    if (StorageManager != null)
     {
-        try
-        {
-            if (_module != null)
-            {
-                await _module.DisposeAsync();
-            }
-        }
-        catch (Exception)
-        {
-            // ignored
-        }
+      folders = await StorageManager.ListFoldersAsync(ContainerName, folderPath);
     }
+    return folders;
+  }
+  private async Task ToggleSelectAllFiles()
+  {
+    _allFilesSelected = !_allFilesSelected;
+
+    if (_allFilesSelected)
+    {
+      _selectedItems = _files.Select(f => f.name).ToHashSet();
+    }
+    else
+    {
+      _selectedItems.Clear();
+    }
+  }
+  private bool CanDeleteFolder(string folderName)
+  {
+    if (_folders.Contains(folderName) && _folderList != null)
+    {
+      return _folderList.TryGetValue($"{folderName}/", out int fileCount) && fileCount == 0;
+    }
+    return false;
+  }
+
+  private void SelectItem(string item)
+  {
+    _selectedItems = new HashSet<string> { item };
+    StateHasChanged();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    try
+    {
+      if (_module != null)
+      {
+        await _module.DisposeAsync();
+      }
+    }
+    catch (Exception)
+    {
+      // ignored
+    }
+  }
 }

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor
@@ -142,7 +142,7 @@
         if (firstRender)
         {
             _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import",
-                "./Pages/Workspace/Storage/Heading.razor.js");
+                "./Pages/Workspace/Storage/StorageHeading.razor.js");
             _dotNetHelper = DotNetObjectReference.Create(this);
         }
     }


### PR DESCRIPTION
# Pull Request

## Commit Title
<!-- Write your commit title following conventional commits. E.g., fix: Corrected login bug -->

fix: Updating StorageHeading name so it appears in file explorer

## Description
<!-- A brief description of what this PR does -->

Heading.razor was renamed to StorageHeading.razor, this PR applies that change to the file explorer

## Related Issues
<!-- List any related issues or tickets -->

n/a

## Changes
<!-- List the key changes in this PR -->

- Updates references to original name of StorageHeading

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [ ] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage