### PR TITLE
fix: Empty workspaces can now be deleted

### DIFF
--- a/Portal/src/Datahub.Infrastructure/Services/ProjectDeletionService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/ProjectDeletionService.cs
@@ -40,17 +40,17 @@ namespace Datahub.Infrastructure.Services
                        .Where(r => r.Project.Project_Acronym_CD == acronym)
                        .ToListAsync(CancellationToken.None);
 
+                var project = await ctx.Projects
+                    .Where(p => p.Project_Acronym_CD == acronym)
+                    .FirstOrDefaultAsync(CancellationToken.None);
+
+                questionnaire.Project = project ?? throw new Exception($"Project not found for acronym - {acronym}");
+
                 var rgName = string.Empty;
                 var env = configuration.GetCurrentEnvironment();
                 foreach (var resource in resources)
                 {
-                    if (questionnaire.Project is null)
-                    {
-                        questionnaire.Project = resource.Project;
-                    }
-
                     resource.Status = resource.ResourceType == TerraformTemplate.GetTerraformServiceType(TerraformTemplate.NewProjectTemplate) ? TerraformStatus.DeleteRequested : TerraformStatus.Deleted;
-                    resource.Project.Deleted_DT = resource.Project.Deleted_DT ?? DateTime.Now;
                     if (resource.ResourceType == TerraformTemplate.GetTerraformServiceType(TerraformTemplate.NewProjectTemplate))
                     {
                         rgName = resource.Project.GetResourceGroupName();
@@ -65,7 +65,8 @@ namespace Datahub.Infrastructure.Services
                 
                 var currentUser = await userInformationService.GetCurrentPortalUserAsync();
                 questionnaire.DeletedDate = DateTime.Now;
-                questionnaire.DeletedBy = currentUser;
+                questionnaire.Project.Deleted_DT = questionnaire.DeletedDate;
+                questionnaire.DeletedBy = currentUser ?? throw new Exception("Current user not found");
 
                 ctx.Attach(currentUser);
                 ctx.Project_Delete_Questionnaires.Add(questionnaire);


### PR DESCRIPTION
# Pull Request

## Commit Title
<!-- Write your commit title following conventional commits. E.g., fix: Corrected login bug -->

fix: Empty workspaces can now be deleted

## Description
<!-- A brief description of what this PR does -->

Currently, it is impossible to delete a workspace that has no resources provisioned. This is due to the following code:

<img width="865" height="340" alt="image" src="https://github.com/user-attachments/assets/9895c52c-2d0d-4ac8-bf12-a8785de0559e" />

This code never assigns a foreign key to the questionnaire because there are no resources to iterate over.

This PR corrects this behaviour by directly loading the project and assigning it as the foreign key.

## Related Issues
<!-- List any related issues or tickets -->

[AB#2477](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/2477)

## Changes
<!-- List the key changes in this PR -->

- Updates `ProjectDeletionService` to properly assign the project as the deletion questionnaire's foreign key

## Testing
<!-- Describe the tests that were run or any QA steps that were taken -->

- Locally tested with workspace `DWT`

## Checklist
<!-- Ensure the following tasks are complete -->

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] ensured that my code follows coding standards
- [ ] written tests and theyre passing


### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage