### PR TITLE
feat: bilingual URL in external user invitation email

### DIFF
--- a/Portal/src/Datahub.Application/Services/Notification/IGCNotifyService.cs
+++ b/Portal/src/Datahub.Application/Services/Notification/IGCNotifyService.cs
@@ -14,7 +14,7 @@ public interface IGCNotifyService
     Task SendDatahubResourceDeletedNotification(string email, string resource, string resource_fr, string acro);
     Task SendWelcomePackageNotification(string email);
     Task SendWorkspaceInactiveNotification(string email, string daysSince);
-    Task SendExternalUserInviteNotification(string email, string externalUserName, string workspace, string inviterName, string invitationURL);
+    Task SendExternalUserInviteNotification(string email, string externalUserName, string workspace, string inviterName, string invitationURL_en, string invitationURL_fr);
     Task SendBugReportNotification(string id, string title, string body, string email = "datasolutions-solutiondedonnees@ssc-spc.gc.ca");
     Task SendInfectedFileNotification(string email, string fileName, string workspace, string date);
     Task SendStorageScanSuccessEmailAsync(StorageScanNotificationHelper.StorageScanSuccessEventPayload payload, string? recipientEmail = null, CancellationToken cancellationToken = default);

--- a/Portal/src/Datahub.Application/Services/UserManagement/IExternalUserInvitationService.cs
+++ b/Portal/src/Datahub.Application/Services/UserManagement/IExternalUserInvitationService.cs
@@ -29,7 +29,7 @@ public interface IExternalUserInvitationService
         string invitationRationale,
         int projectRoleId,
         PortalUser inviter,
-        Func<WorkspaceInvitation, string> GetCodeAcceptancePageUrl,
+        Func<WorkspaceInvitation, (string enURL, string frURL)> GetCodeAcceptancePageUrl,
         DateTimeOffset? invitationExpiry = null,
         CancellationToken cancellationToken = default);
 
@@ -70,7 +70,7 @@ public interface IExternalUserInvitationService
         string projectAcronym,
         string invitedEmail,
         int projectRoleId,
-        Func<WorkspaceInvitation, string> GetCodeAcceptancePageUrl,
+        Func<WorkspaceInvitation, (string enURL, string frURL)> GetCodeAcceptancePageUrl,
         PortalUser inviter,
         CancellationToken cancellationToken = default);
 

--- a/Portal/src/Datahub.Infrastructure/Services/Notification/GCNotifyService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/Notification/GCNotifyService.cs
@@ -246,7 +246,7 @@ public class GCNotifyService : IGCNotifyService
         await SendNotification(postDataJson);
     }
 
-    public async Task SendExternalUserInviteNotification(string email, string externalUserName, string workspace, string inviterName, string invitationURL)
+    public async Task SendExternalUserInviteNotification(string email, string externalUserName, string workspace, string inviterName, string invitationURL_en, string invitationURL_fr)
     {
         using var _ = _logger.BeginScope("ExternalUserInviteNotification {Email}", MaskEmail(email));
         _logger.LogInformation("Composing external user invite notification. externalUserName={ExternalUserName}, workspace={Workspace}, inviterName={InviterName}", externalUserName, workspace, inviterName);
@@ -255,7 +255,7 @@ public class GCNotifyService : IGCNotifyService
         {
             email_address = email,
             template_id = templateId,
-            personalisation = new { externalUserName, workspace, inviterName, invitationURL }
+            personalisation = new { externalUserName, workspace, inviterName, invitationURL_en, invitationURL_fr }
         };
         _logger.LogDebug("Dispatching external user invite notification with template {TemplateId}", templateId);
         string postDataJson = JsonSerializer.Serialize(postData);

--- a/Portal/src/Datahub.Infrastructure/Services/UserManagement/ExternalUserInvitationService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/UserManagement/ExternalUserInvitationService.cs
@@ -6,6 +6,7 @@ using Datahub.Core.Model.Projects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Datahub.Application.Services.Notification;
+using System.Reflection.Metadata;
 
 namespace Datahub.Infrastructure.Services.UserManagement;
 
@@ -59,7 +60,7 @@ public class ExternalUserInvitationService : IExternalUserInvitationService
         string invitationRationale,
         int projectRoleId,
         PortalUser inviter,
-        Func<WorkspaceInvitation, string> GetCodeAcceptancePageUrl,
+        Func<WorkspaceInvitation, (string enURL, string frURL)> GetCodeAcceptancePageUrl,
         DateTimeOffset? invitationExpiry = null,
         CancellationToken cancellationToken = default)
     {
@@ -118,7 +119,7 @@ public class ExternalUserInvitationService : IExternalUserInvitationService
         string projectAcronym,
         string invitedEmail,
         int projectRoleId,
-        Func<WorkspaceInvitation,string> GetCodeAcceptancePageUrl,
+        Func<WorkspaceInvitation, (string enURL, string frURL)> GetCodeAcceptancePageUrl,
         PortalUser inviter,
         CancellationToken cancellationToken = default)
     {
@@ -252,7 +253,7 @@ public class ExternalUserInvitationService : IExternalUserInvitationService
         int projectRoleId,
         PortalUser inviter,
         DateTimeOffset? invitationExpiry,
-        Func<WorkspaceInvitation, string> GetCodeAcceptancePageUrl,
+        Func<WorkspaceInvitation, (string enURL, string frURL)> GetCodeAcceptancePageUrl,
         CancellationToken cancellationToken)
     {
         // attach inviter to context to avoid duplicate key error if inviter is also the user being invited
@@ -301,13 +302,14 @@ public class ExternalUserInvitationService : IExternalUserInvitationService
             externalUserId,
             projectAcronym);
 
-        var invitationURL = GetCodeAcceptancePageUrl(invitation);
+        var invitationUrl = GetCodeAcceptancePageUrl(invitation);
         await _gcNotifyService.SendExternalUserInviteNotification(
             invitation.InvitedEmail,
             externalUser.PortalUser.DisplayName ?? "<user>",
             project.ProjectName ?? "Workspace",
             inviter.DisplayName ?? "Inviter",
-            invitationURL);
+            invitationUrl.enURL,
+            invitationUrl.frURL);
 
         return invitation;
     }

--- a/Portal/src/Datahub.Portal/Pages/Public/ExternalInvitationSetupPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Public/ExternalInvitationSetupPage.razor
@@ -91,7 +91,7 @@ else
         if (externalUserOid is null && _gccfEnabled)
         {
             _snackbar.Add(Localizer["Please sign in with your account to access this invitation."], Severity.Warning);
-            _navigationManager.NavigateTo($"{PageRoutes.GCCF_Login}?locale={CultureInfo.CurrentCulture.Name}&returnUrl={_navigationManager.Uri}", forceLoad: true);
+            _navigationManager.NavigateTo($"{PageRoutes.GCCF_Login}?locale={Uri.EscapeDataString(CultureInfo.CurrentCulture.Name)}&returnUrl={Uri.EscapeDataString(_navigationManager.Uri)}", forceLoad: true);
             return;
         }
 

--- a/Portal/src/Datahub.Portal/Pages/Tools/Email/ComposeEmailPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Tools/Email/ComposeEmailPage.razor
@@ -303,7 +303,7 @@ await _userInformationService.GetUserEmail());
   {
     var email = await _userInformationService.GetUserEmail();
     await _gcNotifyService.SendExternalUserInviteNotification(email, "external-user-name-test", "workspace-name-test",
-    "inviter-test", "https://dev.fsdh-dhsf.science.cloud-nuage.canada.ca/");
+        "inviter-test", "https://dev.fsdh-dhsf.science.cloud-nuage.canada.ca/?locale=en","https://dev.fsdh-dhsf.science.cloud-nuage.canada.ca/?locale=fr");
   }
 
   private async Task TestStorageScanSuccessEmail()

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/AddNewExternalUsersToProjectDialog.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/AddNewExternalUsersToProjectDialog.razor
@@ -11,7 +11,6 @@
 @inject IUserEnrollmentService _userEnrollmentService
 @inject IUserInformationService _userInformationService
 @inject IExternalUserInvitationService _externalUserInvitationService
-@inject IProjectUserManagementService _projectUserManagementService
 @inject ISnackbar _snackbar
 @inject IDbContextFactory<DatahubProjectDBContext> _dbContextFactory
 
@@ -203,7 +202,7 @@
     public PortalUser Inviter { get; set; } = null!;
 
     [Parameter]
-    public Func<WorkspaceInvitation, string> GetGcInvitationLink { get; set; } = null!;
+    public Func<WorkspaceInvitation, (string enURL, string frURL)> GetGcInvitationLink { get; set; } = null!;
 
     private int _page = 1;
     private bool[] _successes = { false, false, false };

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceExternalUsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceExternalUsersPage.razor
@@ -1,6 +1,7 @@
 @using Datahub.Application.Services
 @using Datahub.Core.Model.Projects
 @using Datahub.Core.Model.Users
+@using Datahub.Infrastructure.Services.UserManagement
 @using Datahub.Portal.Pages.Tools.Users
 @using MudBlazor.Utilities
 @using Datahub.Portal.Components.User
@@ -26,134 +27,134 @@
 }
 else
 {
-  <MudStack>
-      <MudStack Row Class="mt-6 mb-4">
-          <DHMainContentTitle Title="@Localizer["External Workspace Members"]" />
-          <MudSpacer />
-          <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
-              <DHButton OnClick="OpenInviteUserDialog" Variant="Variant.Outlined" Color="Color.Primary" EndIcon="@Icons.Material.Outlined.PersonAdd">
-                  @Localizer["Add user"]
-              </DHButton>
-          </DatahubAuthView>
-      </MudStack>
-      @if (_externalProjectUsers.Any())
-      {
-          <MudTable Items="@_externalProjectUsers" Striped Filter="@(new Func<ExternalWorkspaceUserRow, bool>(CombinedFilter))">
-              <ToolBarContent>
-                  <MudTextField @bind-Value="_filterString"
-                                Placeholder="@Localizer["Search"]"
-                                Immediate
-                                Adornment="Adornment.Start"
-                                AdornmentIcon="@Icons.Material.Filled.Search"
-                                Label="@Localizer["Search"]"
-                                IconSize="Size.Medium" />
-              </ToolBarContent>
-              <HeaderContent>
-                  <MudTh>@Localizer["Name"]</MudTh>
-                  <MudTh>@Localizer["Email"]</MudTh>
-                  <MudTh>@Localizer["Organization"]</MudTh>
-                  <MudTh>@Localizer["Status"]</MudTh>
-                  <MudTh>@Localizer["Last Login"]</MudTh>
-                  <MudTh>@Localizer["Account Expiry"]</MudTh>
-                  <MudTh>@Localizer["Activation Code"]</MudTh>
-                  <MudTh>@Localizer["Code Acceptance Page"]</MudTh>
-                  <MudTh>@Localizer["Actions"]</MudTh>
-              </HeaderContent>
-              <RowTemplate Context="rowContext">
-                  <MudTd>
-                      <MudStack Row AlignItems="AlignItems.Center">
-                          <MudText>
-                              <strong>@rowContext.PortalUser.DisplayName</strong>
-                          </MudText>
-                      </MudStack>
-                  </MudTd>
-                  <MudTd>
-                      <MudStack Row AlignItems="AlignItems.Center">
-                          <MudText>@rowContext.PortalUser.Email</MudText>
-                      </MudStack>
-                  </MudTd>
-                  <MudTd>
-                      <MudStack Row AlignItems="AlignItems.Center">
-                          <MudText>@rowContext.ExternalUser.Organization</MudText>
-                      </MudStack>
-                  </MudTd>
-                  <MudTd>
-                      <MudStack Row AlignItems="AlignItems.Center">
-                          <MudText>
-                              @if (rowContext.ExternalUser.UserDeactivatedAt is not null)
-                              {
-                                  <MudChip T="string" Color="Color.Error">@Localizer["Deactivated"]</MudChip>
-                              }
-                              else if (rowContext.ExternalUser.UserExpiryDate < DateTimeOffset.UtcNow)
-                              {
-                                  <MudChip T="string" Color="Color.Error">@Localizer["Expired"]</MudChip>
-                              }
-                              else if (rowContext.ExternalUser.FirstLoginDateTime is null)
-                              {
-                                  <MudChip T="string" Color="Color.Warning">@Localizer["Pending Invite"]</MudChip>
-                              }
-                              else
-                              {
-                                  <MudChip T="string" Color="Color.Success">@Localizer["Active"]</MudChip>
-                              }
-                          </MudText>
-                      </MudStack>
-                  </MudTd>
+    <MudStack>
+        <MudStack Row Class="mt-6 mb-4">
+            <DHMainContentTitle Title="@Localizer["External Workspace Members"]" />
+            <MudSpacer />
+            <DatahubAuthView AuthLevel="DatahubAuthView.AuthLevels.WorkspaceAdmin" ProjectAcronym="@WorkspaceAcronym" ElevatedWorkspaceAccessEnabled="@ElevatedWorkspaceAccessEnabled">
+                <DHButton OnClick="OpenInviteUserDialog" Variant="Variant.Outlined" Color="Color.Primary" EndIcon="@Icons.Material.Outlined.PersonAdd">
+                    @Localizer["Add user"]
+                </DHButton>
+            </DatahubAuthView>
+        </MudStack>
+        @if (_externalProjectUsers.Any())
+        {
+            <MudTable Items="@_externalProjectUsers" Striped Filter="@(new Func<ExternalWorkspaceUserRow, bool>(CombinedFilter))">
+                <ToolBarContent>
+                    <MudTextField @bind-Value="_filterString"
+                                  Placeholder="@Localizer["Search"]"
+                                  Immediate
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Filled.Search"
+                                  Label="@Localizer["Search"]"
+                                  IconSize="Size.Medium" />
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh>@Localizer["Name"]</MudTh>
+                    <MudTh>@Localizer["Email"]</MudTh>
+                    <MudTh>@Localizer["Organization"]</MudTh>
+                    <MudTh>@Localizer["Status"]</MudTh>
+                    <MudTh>@Localizer["Last Login"]</MudTh>
+                    <MudTh>@Localizer["Account Expiry"]</MudTh>
+                    <MudTh>@Localizer["Activation Code"]</MudTh>
+                    <MudTh>@Localizer["Code Acceptance Page"]</MudTh>
+                    <MudTh>@Localizer["Actions"]</MudTh>
+                </HeaderContent>
+                <RowTemplate Context="rowContext">
+                    <MudTd>
+                        <MudStack Row AlignItems="AlignItems.Center">
+                            <MudText>
+                                <strong>@rowContext.PortalUser.DisplayName</strong>
+                            </MudText>
+                        </MudStack>
+                    </MudTd>
+                    <MudTd>
+                        <MudStack Row AlignItems="AlignItems.Center">
+                            <MudText>@rowContext.PortalUser.Email</MudText>
+                        </MudStack>
+                    </MudTd>
+                    <MudTd>
+                        <MudStack Row AlignItems="AlignItems.Center">
+                            <MudText>@rowContext.ExternalUser.Organization</MudText>
+                        </MudStack>
+                    </MudTd>
+                    <MudTd>
+                        <MudStack Row AlignItems="AlignItems.Center">
+                            <MudText>
+                                @if (rowContext.ExternalUser.UserDeactivatedAt is not null)
+                                {
+                                    <MudChip T="string" Color="Color.Error">@Localizer["Deactivated"]</MudChip>
+                                }
+                                else if (rowContext.ExternalUser.UserExpiryDate < DateTimeOffset.UtcNow)
+                                {
+                                    <MudChip T="string" Color="Color.Error">@Localizer["Expired"]</MudChip>
+                                }
+                                else if (rowContext.ExternalUser.FirstLoginDateTime is null)
+                                {
+                                    <MudChip T="string" Color="Color.Warning">@Localizer["Pending Invite"]</MudChip>
+                                }
+                                else
+                                {
+                                    <MudChip T="string" Color="Color.Success">@Localizer["Active"]</MudChip>
+                                }
+                            </MudText>
+                        </MudStack>
+                    </MudTd>
                     <MudTd>
                         <MudStack Row AlignItems="AlignItems.Center">
                             <MudText>@(rowContext.PortalUser.LastLoginDateTime?.ToString("yyyy-MM-dd") ?? "-")</MudText>
                         </MudStack>
                     </MudTd>
-                  <MudTd>
-                      <MudStack Row AlignItems="AlignItems.Center">
-                          <MudText>@rowContext.ExternalUser.UserExpiryDate.ToString("yyyy-MM-dd")</MudText>
-                      </MudStack>
-                  </MudTd>
-                  <MudTd>
-                      <MudText>@GetInvitationCode(rowContext)</MudText>
-                  </MudTd>
-                  <MudTd>
-                      @if (ShouldShowInvitationDetails(rowContext))
-                      {
-                          <MudButton Variant="Variant.Text"
-                                     Color="Color.Primary"
-                                     StartIcon="@Icons.Material.Outlined.ContentCopy"
-                                     OnClick="@(() => CopyInvitationLinkAsync(rowContext.LatestInvitation))">
-                              @Localizer["Copy link"]
-                          </MudButton>
-                      }
-                      else
-                      {
-                          <MudText>-</MudText>
-                      }
-                  </MudTd>
-                  <MudTd>
-                      <MudStack Row AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
-                          @if (rowContext.UserRoleLink is not null)
-                          {
+                    <MudTd>
+                        <MudStack Row AlignItems="AlignItems.Center">
+                            <MudText>@rowContext.ExternalUser.UserExpiryDate.ToString("yyyy-MM-dd")</MudText>
+                        </MudStack>
+                    </MudTd>
+                    <MudTd>
+                        <MudText>@GetInvitationCode(rowContext)</MudText>
+                    </MudTd>
+                    <MudTd>
+                        @if (ShouldShowInvitationDetails(rowContext))
+                        {
+                            <MudButton Variant="Variant.Text"
+                                       Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Outlined.ContentCopy"
+                                       OnClick="@(() => CopyInvitationLinkAsync(rowContext.LatestInvitation))">
+                                @Localizer["Copy link"]
+                            </MudButton>
+                        }
+                        else
+                        {
+                            <MudText>-</MudText>
+                        }
+                    </MudTd>
+                    <MudTd>
+                        <MudStack Row AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                            @if (rowContext.UserRoleLink is not null)
+                            {
                                 <DHButton Variant="Variant.Filled" OnClick="() => OpenManageUserDialog(rowContext.UserRoleLink!)">@Localizer["View/Edit"]</DHButton>
-                          }
-                          @if (CanDisableUser(rowContext))
-                          {
+                            }
+                            @if (CanDisableUser(rowContext))
+                            {
                                 <DHButton Variant="Variant.Filled" OnClick="() => OpenDeactivateUserDialog(rowContext.UserRoleLink!)">@Localizer["Disable user"]</DHButton>
-                          }
-                          @if (CanCancelInvitation(rowContext))
-                          {
-                              <DHButton Variant="Variant.Filled" OnClick="() => CancelInvitationAsync(rowContext)">@Localizer["Cancel invite"]</DHButton>
-                          }
-                          @if (CanResendInvitation(rowContext))
-                          {
-                              <DHButton Variant="Variant.Filled" OnClick="() => ResendInvitationAsync(rowContext)">@Localizer["Resend invitation"]</DHButton>
-                          }
-                      </MudStack>
-                  </MudTd>
-              </RowTemplate>
-              <PagerContent>
-                  <MudTablePager />
-              </PagerContent>
-          </MudTable>
-      }
-  </MudStack>
+                            }
+                            @if (CanCancelInvitation(rowContext))
+                            {
+                                <DHButton Variant="Variant.Filled" OnClick="() => CancelInvitationAsync(rowContext)">@Localizer["Cancel invite"]</DHButton>
+                            }
+                            @if (CanResendInvitation(rowContext))
+                            {
+                                <DHButton Variant="Variant.Filled" OnClick="() => ResendInvitationAsync(rowContext)">@Localizer["Resend invitation"]</DHButton>
+                            }
+                        </MudStack>
+                    </MudTd>
+                </RowTemplate>
+                <PagerContent>
+                    <MudTablePager />
+                </PagerContent>
+            </MudTable>
+        }
+    </MudStack>
 }
 
 
@@ -270,10 +271,26 @@ else
 
 
 
-    private string GetCodeAcceptancePageUrl(WorkspaceInvitation invitation)
+    private (string enURL, string frURL) GetCodeAcceptancePageUrl(WorkspaceInvitation invitation)
     {
-        var relativeUrl = $"{Localizer[PageRoutes.ExternalInvitationSetup]}/{invitation.InvitationToken}";
-        return _navigationManager.ToAbsoluteUri(relativeUrl).ToString();
+        // Force French (fr) for this lookup
+        CultureInfo.CurrentUICulture = new CultureInfo("fr");
+        try
+        {
+            CultureInfo.CurrentUICulture = new CultureInfo("fr");
+            string frenchURL = Localizer[PageRoutes.ExternalInvitationSetup];
+
+            var relativeUrlEn = $"{PageRoutes.ExternalInvitationSetup}/{invitation.InvitationToken}";
+            var relativeUrlFr = $"{frenchURL}/{invitation.InvitationToken}";
+            var setLocaleUrlEN = UserSettingsService.GetCultureControllerRedirect(ICultureService.CanadaEnglish, relativeUrlEn);
+            var setLocaleUrlFR = UserSettingsService.GetCultureControllerRedirect(ICultureService.CanadaFrench, relativeUrlFr);
+            return (_navigationManager.ToAbsoluteUri(setLocaleUrlEN).ToString(), _navigationManager.ToAbsoluteUri(setLocaleUrlFR).ToString());
+        }
+        finally
+        {
+            // Reset to the original culture after generating the URL
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        }
     }
 
     private async Task CopyInvitationLinkAsync(WorkspaceInvitation? invitation)
@@ -415,7 +432,7 @@ else
     {
         return projectUser.LatestInvitation!.InvitationCodeAccepted is null
             ? projectUser.LatestInvitation!.InvitationCode
-            : (projectUser.LatestInvitation is null)?"-": $"{Localizer["Accepted on"]} {projectUser.LatestInvitation.InvitationCodeAccepted.Value.ToString("yyyy-MM-dd")}";
+            : (projectUser.LatestInvitation is null) ? "-" : $"{Localizer["Accepted on"]} {projectUser.LatestInvitation.InvitationCodeAccepted.Value.ToString("yyyy-MM-dd")}";
     }
 
     private bool CanDisableUser(ExternalWorkspaceUserRow projectUser)

--- a/Portal/test/Datahub.SpecflowTests/Hooks/ExternalUserInvitationHook.cs
+++ b/Portal/test/Datahub.SpecflowTests/Hooks/ExternalUserInvitationHook.cs
@@ -29,6 +29,7 @@ public class ExternalUserInvitationHook
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
+                Arg.Any<string>(),
                 Arg.Any<string>())
             .Returns(Task.CompletedTask);
         objectContainer.RegisterInstanceAs(gcNotifyService);

--- a/Portal/test/Datahub.SpecflowTests/Steps/UserManagement/ExternalUserInvitationServiceSteps.cs
+++ b/Portal/test/Datahub.SpecflowTests/Steps/UserManagement/ExternalUserInvitationServiceSteps.cs
@@ -160,7 +160,7 @@ public class ExternalUserInvitationServiceSteps(
                 invitationRationale: "Test invitation",
                 projectRoleId: (int)Project_Role.RoleNames.Guest,
                 inviter: inviter,
-                GetCodeAcceptancePageUrl: _ => "https://test.example.com/accept",
+                GetCodeAcceptancePageUrl: _ => ("https://test.example.com/accept", "https://test.example.com/accept"),
                 invitationExpiry: DateTimeOffset.UtcNow.AddDays(7));
             scenarioContext[InvitationKey] = invitation;
         }
@@ -183,7 +183,7 @@ public class ExternalUserInvitationServiceSteps(
                 invitationRationale: "Test",
                 projectRoleId: (int)Project_Role.RoleNames.Guest,
                 inviter: inviter,
-                GetCodeAcceptancePageUrl: _ => "https://test.example.com/accept");
+                GetCodeAcceptancePageUrl: _ => ("https://test.example.com/accept", "https://test.example.com/accept"));
         }
         catch (Exception ex)
         {
@@ -223,7 +223,7 @@ public class ExternalUserInvitationServiceSteps(
             projectAcronym: projectAcronym,
             invitedEmail: "external1@example.com",
             projectRoleId: (int)Project_Role.RoleNames.Guest,
-            GetCodeAcceptancePageUrl: _ => "https://test.example.com/accept",
+            GetCodeAcceptancePageUrl: _ => ("https://test.example.com/accept", "https://test.example.com/accept"),
             inviter: inviter);
         scenarioContext["newInvitation"] = newInvitation;
     }
@@ -298,6 +298,7 @@ public class ExternalUserInvitationServiceSteps(
     public async Task ThenANotificationEmailShouldBeSent()
     {
         await gcNotifyService.Received(1).SendExternalUserInviteNotification(
+            Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),


### PR DESCRIPTION
# Pull Request

## Commit Title

- update invitation emails with both English and French URLs
- added better redirects to force locale

## Related Work Items

[AB#2587](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/2587)

## Testing

- Tested email locally


### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [X] written tests and they're passing

