### PR TITLE
fix: added signouturl to show page after GCCF signout

### DIFF
--- a/Portal/src/Datahub.Portal/Services/Auth/ConfigureAuthenticationServices.cs
+++ b/Portal/src/Datahub.Portal/Services/Auth/ConfigureAuthenticationServices.cs
@@ -153,6 +153,7 @@ public static class ConfigureAuthenticationServices
                     options.ClientSecret = configuration["GccfOidc:ClientSecret"] ?? throw new ArgumentNullException("GCCF ClientSecret");
                     options.ResponseType = OpenIdConnectResponseType.Code;
                     options.CallbackPath = GccfSigninURL;
+                    options.SignedOutRedirectUri = "/home";
                     options.SaveTokens = true;
                     options.Scope.Add("openid");
                     options.Scope.Add("profile");


### PR DESCRIPTION
# Pull Request

## Commit Title

This tentatively completes the GCCF signout and sends the user back to the login page after they logout from GCCF
[AB#2650](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/2650)

## Testing

- To be validated in dev

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [X] written tests and they're passing

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
