### PR TITLE
fix: Keeping external users out of workspace members list

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor.cs
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceUsersPage.razor.cs
@@ -38,7 +38,8 @@ namespace Datahub.Portal.Pages.Workspace.Users
 
         private async Task InitializedProjectMembers()
         {
-            _projectUsers = await _projectUserManagementService.GetProjectUsersAsync(WorkspaceAcronym);
+            var allProjectUsers = await _projectUserManagementService.GetProjectUsersAsync(WorkspaceAcronym);
+            _projectUsers = allProjectUsers.Where(x => x.PortalUser.ExternalUserId is null).ToList();
             _originalUserInfo = _projectUsers.Select(u => new WorkspaceUserInfo(u.PortalUserId, u.RoleId, u.IsDataSteward)).ToList();
             ProjectMemberRoleFilter(_currentRoleFilter);
         }


### PR DESCRIPTION
# Pull Request

## Commit Title

fix: Keeping external users out of workspace members list

## Description

Keeps external users out of workspace members list since they have a separate list.

## Related Work Items

[AB#2652](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/2652)

## Changes

<!-- List the key changes in this PR -->

- keeps external users out of workspace members list

## Testing


## Checklist

<!-- Ensure the following tasks are complete -->

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Added `!` to the type prefix if change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] ensured that my code follows coding standards
- [ ] written tests and they're passing

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
