### PR TITLE
fix: missing migration for external user access and 404 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ TestResults/
 /Portal/src/Datahub.Portal/MissingTranslations-en.json
 /Portal/src/Datahub.Portal/MissingTranslations-fr.json
 /data
+/Portal/src/Datahub.Portal/MissingTranslations-en-CA.json

--- a/Portal/src/Datahub.Application/Authentication/DevelopmentAuthStateProvider.cs
+++ b/Portal/src/Datahub.Application/Authentication/DevelopmentAuthStateProvider.cs
@@ -29,7 +29,7 @@ namespace Datahub.Application.Authentication
 
         private ClaimsIdentity CreateGccfUser()
         {
-            var email = _configuration["GccfOidc:DevAuth:UserEmail"] ?? "dev.user@example.com";
+            var email = _configuration["GccfOidc:DevAuth:UserEmail"];
             var name = _configuration["GccfOidc:DevAuth:UserName"] ?? email;
 
             var identity = new ClaimsIdentity(new[]

--- a/Portal/src/Datahub.Core/Migrations/20260623184002_ExternalEntities.Designer.cs
+++ b/Portal/src/Datahub.Core/Migrations/20260623184002_ExternalEntities.Designer.cs
@@ -3,41 +3,49 @@ using System;
 using Datahub.Core.Model.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Datahub.Core.Migrations.SqliteDatahub
+namespace Datahub.Core.Migrations
 {
-    [DbContext(typeof(SqliteDatahubContext))]
-    partial class SqliteDatahubContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(SqlServerDatahubContext))]
+    [Migration("20260623184002_ExternalEntities")]
+    partial class ExternalEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.9");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.9")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("Datahub.Core.Model.Achievements.Achievement", b =>
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(8)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(8)");
 
                     b.Property<string>("ConcatenatedRules")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("Points")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -226,17 +234,19 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("EventDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("EventName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -249,21 +259,23 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AchievementId")
                         .IsRequired()
                         .HasMaxLength(8)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(8)");
 
                     b.Property<int>("Count")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("UnlockedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -278,50 +290,52 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("BodyEn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("BodyFr")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("EndDateTime")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("ForceHidden")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("PreviewEn")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PreviewFr")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Severity")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("StartDateTime")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -335,32 +349,34 @@ namespace Datahub.Core.Migrations.SqliteDatahub
             modelBuilder.Entity("Datahub.Core.Model.Catalog.CatalogObject", b =>
                 {
                     b.Property<int>("ObjectType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Desc_English")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Desc_French")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Location")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name_English")
                         .HasMaxLength(160)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(160)");
 
                     b.Property<string>("Name_French")
                         .HasMaxLength(160)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(160)");
 
                     b.HasKey("ObjectType", "ObjectId");
 
@@ -371,26 +387,28 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("ConnectionData")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Provider")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(16)
-                        .HasColumnType("TEXT")
+                        .HasColumnType("nvarchar(16)")
                         .HasDefaultValue("Azure");
 
                     b.HasKey("Id");
@@ -404,34 +422,36 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
                     b.Property<string>("ContainerName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FileId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FileName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FilePurpose")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FolderPath")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("ProjectStorageId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<long>("SubmissionId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<string>("UploadMessage")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("UploadStatus")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -446,32 +466,34 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
                     b.Property<string>("DatasetTitle")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("OpenForAttachingFiles")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int>("ProcessType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("RequestDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("RequestingUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Status")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("UniqueId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
 
@@ -491,34 +513,36 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("AddedByUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("DateAdded")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DateRemoved")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("DepartmentName")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(500)");
 
                     b.Property<string>("EmailHostname")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Notes")
                         .HasMaxLength(2000)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(2000)");
 
                     b.Property<int?>("RemovedByUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Status")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -539,52 +563,54 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<long>("SharedDataFile_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("SharedDataFile_ID"));
 
                     b.Property<DateTime?>("ApprovedDate_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ApprovingUser_ID")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime?>("ExpirationDate_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<Guid>("File_ID")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Filename_TXT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FolderPath_TXT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsOpenDataRequest_FLAG")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("MetadataCompleted_FLAG")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ProjectCode_CD")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime?>("PublicationDate_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("RequestedDate_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("RequestingUser_ID")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime?>("SubmittedDate_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("UnpublishDate_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("SharedDataFile_ID");
 
@@ -600,34 +626,36 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<long>("Notification_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Notification_ID"));
 
                     b.Property<string>("ActionLink_Key")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ActionLink_URL")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(512)");
 
                     b.Property<DateTime>("Generated_TS")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("NotificationTextEn_TXT")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("NotificationTextFr_TXT")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("Read_FLAG")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ReceivingUser_ID")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.HasKey("Notification_ID");
 
@@ -638,32 +666,34 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("VersionTagId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("VersionTagId"));
 
                     b.Property<bool>("AnnouncementCreated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsActive")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Tag")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("VersionDescription")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("VersionDescriptionFr")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("VersionTagId");
 
@@ -674,13 +704,13 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<int>("Hits")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("LastUpdated")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -691,19 +721,19 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<Guid>("GeneratedId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Id")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("JsonContent")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TypeName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("GeneratedId");
 
@@ -716,108 +746,110 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CBRID")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("CBRName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DepartmentName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("FinancialAuthorityCommitmentIsOrg")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("FinancialAuthorityCommitmentIsRef")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("FinancialAuthorityEmail")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("FinancialAuthorityFirstName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("FinancialAuthorityLastName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("GcHostingId")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("GeneratesInfoBusinessValue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Keywords")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("LeadEmail")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("LeadFirstName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("LeadLastName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("ProjectDescription")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ProjectTitle")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime>("RetentionPeriodStartDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("RetentionPeriodYears")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("RetentionValue")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("SecurityClassification")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Subject")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal>("WorkspaceBudget")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<string>("WorkspaceDescription")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("WorkspaceName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.HasKey("Id");
 
@@ -828,20 +860,22 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("CreatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("InterestedFeatures")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -856,18 +890,20 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Comment")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -878,128 +914,130 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Project_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Project_ID"));
 
                     b.Property<DateTime>("AllowDatahubSupport")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Contact_List")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("Created_DT")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("GETUTCDATE()");
 
                     b.Property<string>("DB_Type")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Data_Sensitivity")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("DatahubAzureSubscriptionId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("Deleted_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("ExpiryDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("GitRepo_URL")
                         .HasMaxLength(150)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(150)");
 
                     b.Property<string>("HashedAPIToken")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsVersionUpdateRequested")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("Is_Featured")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("Is_Private")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime>("Last_Updated_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Last_Updated_UserId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool?>("MetadataAdded")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime?>("OperationalWindow")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("ParentGCHostingBudgetId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<bool>("PreventAutoDelete")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Project_Acronym_CD")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.Property<string>("Project_Admin")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<decimal?>("Project_Budget")
                         .HasColumnType("decimal(18,2)");
 
                     b.Property<string>("Project_Icon")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Project_Name")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Project_Name_Fr")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Project_Phase")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("Project_Status")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Project_Status_Desc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Project_Summary_Desc")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Project_Summary_Desc_Fr")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<byte[]>("Timestamp")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("rowversion");
 
                     b.Property<string>("Version")
                         .HasMaxLength(16)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(16)");
 
                     b.Property<bool?>("WebAppEnabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("WebAppUrlRewritingEnabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(true);
 
                     b.Property<string>("WebApp_URL")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("Project_ID");
 
@@ -1017,28 +1055,28 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<Guid>("ProjectApiUser_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Client_Name_TXT")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("Email_Contact_TXT")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime?>("Expiration_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Project_Acronym_CD")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.HasKey("ProjectApiUser_ID");
 
@@ -1049,21 +1087,23 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("ProjectCosts_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ProjectCosts_ID"));
 
                     b.Property<double>("CadCost")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("Project_ID")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("ServiceName")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("ProjectCosts_ID");
 
@@ -1075,17 +1115,17 @@ namespace Datahub.Core.Migrations.SqliteDatahub
             modelBuilder.Entity("Datahub.Core.Model.Projects.ProjectInactivityNotifications", b =>
                 {
                     b.Property<int>("Project_ID")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("DaysBeforeDeletion")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("NotificationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("SentTo")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Project_ID");
 
@@ -1096,40 +1136,42 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<double>("BudgetCurrentSpent")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<double>("Current")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<string>("CurrentPerDay")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("CurrentPerService")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime?>("LastNotified")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("LastRollover")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("LastUpdate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("PercNotified")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<double>("YesterdayCredits")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<string>("YesterdayPerService")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
@@ -1143,31 +1185,33 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("DeletedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("DeletedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("DoesDataNotHaveArchivalValue")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsDataMigrated")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsDataNotSubjectToLitigation")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsDeletionConfirmed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsWorkspaceNotRequired")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int>("Project_ID")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1182,47 +1226,47 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<Guid>("ResourceId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ClassName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("InputJsonContent")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("JsonContent")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("PipelineId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("RequestedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("RequestedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("ResourceType")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Status")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int?>("UpdatedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("ResourceId");
 
@@ -1239,20 +1283,22 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<bool>("IsExternalRole")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(32)");
 
                     b.HasKey("Id");
 
@@ -1328,21 +1374,23 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<double>("AverageCapacity")
-                        .HasColumnType("REAL");
+                        .HasColumnType("float");
 
                     b.Property<string>("CloudProvider")
                         .IsRequired()
                         .HasMaxLength(16)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(16)");
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1355,25 +1403,27 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AdminLastUpdated_ID")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("AdminLastUpdated_UserName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("AllowDatabricks")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("AllowStorage")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime>("LastUpdated")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1387,33 +1437,35 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("ProjectUser_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ProjectUser_ID"));
 
                     b.Property<int?>("ApprovedPortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("Approved_DT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ExternalUserNotes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsDataSteward")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Project_ID")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<byte[]>("Timestamp")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("rowversion");
 
                     b.HasKey("ProjectUser_ID");
 
@@ -1424,7 +1476,8 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                     b.HasIndex("RoleId");
 
                     b.HasIndex("Project_ID", "PortalUserId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[PortalUserId] IS NOT NULL");
 
                     b.ToTable("Project_Users", (string)null);
                 });
@@ -1433,38 +1486,40 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Branch")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("HeadCommitId")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<bool>("IsPublic")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Path")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Provider")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<string>("RepositoryUrl")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -1477,26 +1532,28 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Nickname")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("SubscriptionId")
                         .IsRequired()
                         .HasMaxLength(36)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(36)");
 
                     b.Property<string>("SubscriptionName")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("TenantId")
                         .IsRequired()
                         .HasMaxLength(36)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(36)");
 
                     b.HasKey("Id");
 
@@ -1507,22 +1564,24 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AddressPrefix")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int>("SubnetGroup")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SubnetName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<int>("VNetId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1535,20 +1594,22 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("SubscriptionId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("VNetId")
                         .IsRequired()
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(500)");
 
                     b.Property<string>("VNetName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.HasKey("Id");
 
@@ -1561,13 +1622,15 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("ProjectId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("SubnetId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1583,20 +1646,22 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("GraphGuid")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int?>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<byte[]>("Timestamp")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("rowversion");
 
                     b.HasKey("Id");
 
@@ -1604,7 +1669,8 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                         .IsUnique();
 
                     b.HasIndex("PortalUserId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[PortalUserId] IS NOT NULL");
 
                     b.ToTable("EntraUsers");
                 });
@@ -1613,66 +1679,69 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
-                    b.Property<long?>("CreatedAt")
-                        .HasColumnType("INTEGER");
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTimeOffset?>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int?>("DeactivatedByUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("DeactivationReason")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(500)");
 
                     b.Property<string>("ExternalSubject")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
-                    b.Property<long?>("FirstLoginDateTime")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("FirstLoginDateTime")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
-                    b.Property<long?>("LastLoginDateTime")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("LastLoginDateTime")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Organization")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(255)");
 
                     b.Property<int>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<byte[]>("Timestamp")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("rowversion");
 
-                    b.Property<long?>("UpdatedAt")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("datetimeoffset");
 
-                    b.Property<long?>("UserDeactivatedAt")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("UserDeactivatedAt")
+                        .HasColumnType("datetimeoffset");
 
-                    b.Property<long>("UserExpiryDate")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset>("UserExpiryDate")
+                        .HasColumnType("datetimeoffset");
 
                     b.HasKey("Id");
 
                     b.HasIndex("DeactivatedByUserId");
 
                     b.HasIndex("ExternalSubject")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ExternalSubject] IS NOT NULL");
 
                     b.HasIndex("PortalUserId");
 
@@ -1683,35 +1752,37 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
-                    b.Property<long?>("AppliedExpiryDate")
-                        .HasColumnType("INTEGER");
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTimeOffset?>("AppliedExpiryDate")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTime>("EventDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("EventType")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("EvidenceUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("PerformedByUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
-                    b.Property<long?>("PreviousExpiryDate")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("PreviousExpiryDate")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Reason")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
@@ -1728,41 +1799,44 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("BannerPictureUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayName")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<int?>("ExternalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("FirstLoginDateTime")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("LastLoginDateTime")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ProfilePictureUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<byte[]>("Timestamp")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("rowversion");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ExternalUserId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ExternalUserId] IS NOT NULL");
 
                     b.ToTable("PortalUsers", (string)null);
                 });
@@ -1771,16 +1845,18 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime>("ChangeDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -1791,19 +1867,21 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("User_ID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("User_ID"));
 
                     b.Property<int>("DaysBeforeDeleted")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("DaysBeforeLocked")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("NotificationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("User_ID");
 
@@ -1816,52 +1894,54 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
-                    b.Property<long>("AccessedTime")
-                        .HasColumnType("INTEGER");
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTimeOffset>("AccessedTime")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("AzureWebAppUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DataProject")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DatabricksURL")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ExternalUrl")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("LinkType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PBIReportId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PBIWorkspaceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PowerBIURL")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ResourceArticleId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ResourceArticleTitle")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Variant")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("WebFormsURL")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
@@ -1873,40 +1953,40 @@ namespace Datahub.Core.Migrations.SqliteDatahub
             modelBuilder.Entity("Datahub.Core.Model.Users.UserSettings", b =>
                 {
                     b.Property<int>("PortalUserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("AcceptedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("HiddenAlerts")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("HideAchievements")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<bool>("HideAlerts")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<string>("Language")
                         .HasMaxLength(5)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(5)");
 
                     b.Property<bool>("NotificationsEnabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(true);
 
                     b.Property<string>("Theme")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("UserName")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(128)");
 
                     b.HasKey("PortalUserId");
 
@@ -1917,58 +1997,60 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("RequestID")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("RequestID"));
 
                     b.Property<string>("ExternalSubjectInvited")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("InvitationCode")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
-                    b.Property<long?>("InvitationCodeAccepted")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("InvitationCodeAccepted")
+                        .HasColumnType("datetimeoffset");
 
-                    b.Property<long>("InvitationExpiry")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset>("InvitationExpiry")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("InvitationRationale_EN")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<Guid>("InvitationToken")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uniqueidentifier");
 
-                    b.Property<long?>("InvitationTokenAccepted")
-                        .HasColumnType("INTEGER");
+                    b.Property<DateTimeOffset?>("InvitationTokenAccepted")
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int>("InvitedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("InvitedEmail")
                         .IsRequired()
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<int>("Project_ID")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
-                    b.Property<long>("Request_DT")
+                    b.Property<DateTimeOffset>("Request_DT")
                         .HasColumnType("datetimeoffset");
 
                     b.Property<int>("Requested_RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<byte[]>("Timestamp")
                         .IsConcurrencyToken()
                         .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("rowversion");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("RequestID");
 
@@ -1990,35 +2072,37 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Group")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTime>("HealthCheckTimeUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("GETUTCDATE()");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("ResourceType")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("Status")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Url")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -2030,34 +2114,34 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                     b.HasBaseType("Datahub.Core.Model.Datahub.OpenDataSubmission");
 
                     b.Property<DateTime?>("ImsoApprovalRequestDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("ImsoApprovedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("InitialOpenGovSubmissionDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("LocalDQCheckPassed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("LocalDQCheckStarted")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("MetadataComplete")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("OpenGovCriteriaFormId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime?>("OpenGovCriteriaMetDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("OpenGovDQCheckPassed")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime?>("OpenGovPublicationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.ToTable("TbsOpenGovSubmissions");
                 });
@@ -2067,28 +2151,28 @@ namespace Datahub.Core.Migrations.SqliteDatahub
                     b.HasBaseType("Datahub.Core.Model.Datahub.SharedDataFile");
 
                     b.Property<bool>("ApprovalFormEdited_FLAG")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("ApprovalFormRead_FLAG")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("ApprovalForm_ID")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("FileStorage_CD")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("FileUrl_TXT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("SignedApprovalForm_URL")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("UploadError_TXT")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("UploadStatus_CD")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.ToTable("OpenDataSharedFile");
                 });

--- a/Portal/src/Datahub.Core/Migrations/20260623184002_ExternalEntities.cs
+++ b/Portal/src/Datahub.Core/Migrations/20260623184002_ExternalEntities.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Datahub.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExternalEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserWorkspaceLocks");
+
+            migrationBuilder.CreateTable(
+                name: "ExternalUserLockAuditEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PortalUserId = table.Column<int>(type: "int", nullable: false),
+                    EventType = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EventDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Reason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    EvidenceUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PreviousExpiryDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    AppliedExpiryDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    PerformedByUserId = table.Column<int>(type: "int", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalUserLockAuditEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExternalUserLockAuditEvents_PortalUsers_PerformedByUserId",
+                        column: x => x.PerformedByUserId,
+                        principalTable: "PortalUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ExternalUserLockAuditEvents_PortalUsers_PortalUserId",
+                        column: x => x.PortalUserId,
+                        principalTable: "PortalUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalUserLockAuditEvents_EventType",
+                table: "ExternalUserLockAuditEvents",
+                column: "EventType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalUserLockAuditEvents_PerformedByUserId",
+                table: "ExternalUserLockAuditEvents",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalUserLockAuditEvents_PortalUserId_EventDate",
+                table: "ExternalUserLockAuditEvents",
+                columns: new[] { "PortalUserId", "EventDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalUserLockAuditEvents");
+
+            migrationBuilder.CreateTable(
+                name: "UserWorkspaceLocks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PerformedByUserId = table.Column<int>(type: "int", nullable: true),
+                    PortalUserId = table.Column<int>(type: "int", nullable: false),
+                    EventDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EventType = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EvidenceUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Reason = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserWorkspaceLocks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserWorkspaceLocks_PortalUsers_PerformedByUserId",
+                        column: x => x.PerformedByUserId,
+                        principalTable: "PortalUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserWorkspaceLocks_PortalUsers_PortalUserId",
+                        column: x => x.PortalUserId,
+                        principalTable: "PortalUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserWorkspaceLocks_EventType",
+                table: "UserWorkspaceLocks",
+                column: "EventType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserWorkspaceLocks_PerformedByUserId",
+                table: "UserWorkspaceLocks",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserWorkspaceLocks_PortalUserId_EventDate",
+                table: "UserWorkspaceLocks",
+                columns: new[] { "PortalUserId", "EventDate" });
+        }
+    }
+}

--- a/Portal/src/Datahub.Core/Migrations/SqlServerDatahubContextModelSnapshot.cs
+++ b/Portal/src/Datahub.Core/Migrations/SqlServerDatahubContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace Datahub.Core.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.7")
+                .HasAnnotation("ProductVersion", "10.0.9")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -1745,6 +1745,53 @@ namespace Datahub.Core.Migrations
                     b.ToTable("ExternalUsers", (string)null);
                 });
 
+            modelBuilder.Entity("Datahub.Core.Model.Users.ExternalUserLockAuditEvent", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTimeOffset?>("AppliedExpiryDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<DateTime>("EventDate")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("EventType")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("EvidenceUrl")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Notes")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int?>("PerformedByUserId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("PortalUserId")
+                        .HasColumnType("int");
+
+                    b.Property<DateTimeOffset?>("PreviousExpiryDate")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Reason")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventType");
+
+                    b.HasIndex("PerformedByUserId");
+
+                    b.HasIndex("PortalUserId", "EventDate");
+
+                    b.ToTable("ExternalUserLockAuditEvents", (string)null);
+                });
+
             modelBuilder.Entity("Datahub.Core.Model.Users.PortalUser", b =>
                 {
                     b.Property<int>("Id")
@@ -1941,47 +1988,6 @@ namespace Datahub.Core.Migrations
                     b.HasKey("PortalUserId");
 
                     b.ToTable("UserSettings", (string)null);
-                });
-
-            modelBuilder.Entity("Datahub.Core.Model.Users.UserWorkspaceLock", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("EventDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("EventType")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<string>("EvidenceUrl")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Notes")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int?>("PerformedByUserId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("PortalUserId")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Reason")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("EventType");
-
-                    b.HasIndex("PerformedByUserId");
-
-                    b.HasIndex("PortalUserId", "EventDate");
-
-                    b.ToTable("UserWorkspaceLocks");
                 });
 
             modelBuilder.Entity("Datahub.Core.Model.Users.WorkspaceInvitation", b =>
@@ -2506,6 +2512,24 @@ namespace Datahub.Core.Migrations
                     b.Navigation("PortalUser");
                 });
 
+            modelBuilder.Entity("Datahub.Core.Model.Users.ExternalUserLockAuditEvent", b =>
+                {
+                    b.HasOne("Datahub.Core.Model.Users.PortalUser", "PerformedByUser")
+                        .WithMany()
+                        .HasForeignKey("PerformedByUserId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("Datahub.Core.Model.Users.PortalUser", "User")
+                        .WithMany()
+                        .HasForeignKey("PortalUserId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("PerformedByUser");
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("Datahub.Core.Model.Users.PortalUser", b =>
                 {
                     b.HasOne("Datahub.Core.Model.Users.ExternalUser", "ExternalUser")
@@ -2545,24 +2569,6 @@ namespace Datahub.Core.Migrations
                         .HasForeignKey("Datahub.Core.Model.Users.UserSettings", "PortalUserId")
                         .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
-
-                    b.Navigation("User");
-                });
-
-            modelBuilder.Entity("Datahub.Core.Model.Users.UserWorkspaceLock", b =>
-                {
-                    b.HasOne("Datahub.Core.Model.Users.PortalUser", "PerformedByUser")
-                        .WithMany()
-                        .HasForeignKey("PerformedByUserId")
-                        .OnDelete(DeleteBehavior.Restrict);
-
-                    b.HasOne("Datahub.Core.Model.Users.PortalUser", "User")
-                        .WithMany()
-                        .HasForeignKey("PortalUserId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("PerformedByUser");
 
                     b.Navigation("User");
                 });

--- a/Portal/src/Datahub.Core/Migrations/SqliteDatahub/20260623184011_ExternalEntities.Designer.cs
+++ b/Portal/src/Datahub.Core/Migrations/SqliteDatahub/20260623184011_ExternalEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Datahub.Core.Model.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Datahub.Core.Migrations.SqliteDatahub
 {
     [DbContext(typeof(SqliteDatahubContext))]
-    partial class SqliteDatahubContextModelSnapshot : ModelSnapshot
+    [Migration("20260623184011_ExternalEntities")]
+    partial class ExternalEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.9");

--- a/Portal/src/Datahub.Core/Migrations/SqliteDatahub/20260623184011_ExternalEntities.cs
+++ b/Portal/src/Datahub.Core/Migrations/SqliteDatahub/20260623184011_ExternalEntities.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Datahub.Core.Migrations.SqliteDatahub
+{
+    /// <inheritdoc />
+    public partial class ExternalEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExternalUserLockAuditEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    PortalUserId = table.Column<int>(type: "INTEGER", nullable: false),
+                    EventType = table.Column<string>(type: "TEXT", nullable: false),
+                    EventDate = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", nullable: true),
+                    EvidenceUrl = table.Column<string>(type: "TEXT", nullable: true),
+                    PreviousExpiryDate = table.Column<long>(type: "INTEGER", nullable: true),
+                    AppliedExpiryDate = table.Column<long>(type: "INTEGER", nullable: true),
+                    PerformedByUserId = table.Column<int>(type: "INTEGER", nullable: true),
+                    Notes = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalUserLockAuditEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExternalUserLockAuditEvents_PortalUsers_PerformedByUserId",
+                        column: x => x.PerformedByUserId,
+                        principalTable: "PortalUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ExternalUserLockAuditEvents_PortalUsers_PortalUserId",
+                        column: x => x.PortalUserId,
+                        principalTable: "PortalUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalUserLockAuditEvents_EventType",
+                table: "ExternalUserLockAuditEvents",
+                column: "EventType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalUserLockAuditEvents_PerformedByUserId",
+                table: "ExternalUserLockAuditEvents",
+                column: "PerformedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalUserLockAuditEvents_PortalUserId_EventDate",
+                table: "ExternalUserLockAuditEvents",
+                columns: new[] { "PortalUserId", "EventDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalUserLockAuditEvents");
+        }
+    }
+}

--- a/Portal/src/Datahub.Infrastructure/Services/UserManagement/UserInformationService.cs
+++ b/Portal/src/Datahub.Infrastructure/Services/UserManagement/UserInformationService.cs
@@ -295,7 +295,9 @@ public class UserInformationService(
 
     public async Task<bool> IsAdminModeEnabled()
     {
-        var userId = (await GetCurrentGraphUserAsync()).Id ?? throw new InvalidOperationException("Cannot access graph user Id");
+        if (await IsExternalUser())
+            return false;
+        var userId = (await GetCurrentGraphUserAsync())?.Id ?? throw new InvalidOperationException("Cannot access graph user Id");
         return serviceAuthManager.IsAdminModeEnabled(userId);
     }
 

--- a/Portal/src/Datahub.Portal/Components/DHMainContentTitle.razor
+++ b/Portal/src/Datahub.Portal/Components/DHMainContentTitle.razor
@@ -9,14 +9,10 @@
     }
 </SkipLink>
 
-@code {
+    @code {
 
-    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; set; } = null!;
 
-    [Parameter] public string Title { get; set; }
+    [Parameter] public string Title { get; set; } = null!;
 
-    protected override void OnParametersSet()
-    {
-        base.OnParametersSet();
-    }
 }

--- a/Portal/src/Datahub.Portal/Components/User/UserCard.razor
+++ b/Portal/src/Datahub.Portal/Components/User/UserCard.razor
@@ -11,6 +11,7 @@
 @inject IPortalUserTelemetryService _telemetryService;
 @inject IJSRuntime _jsRuntime;
 @inject ILocalTimeZone _localTz;
+@inject NavigationManager _navigationManager;
 @implements IDisposable
 
 @if (_viewedUser is null)
@@ -86,9 +87,17 @@
     DateTime? lastLoginDt = null;
     if ((lastLoginDt ??= await _telemetryService.GetUserLastLoginAsync()) is not null)
     {
-      var localTz = await _localTz.GetLocalTimeZoneAsync(null);
-      _timezone = LocalizeTimeZone(GetTimeZoneShortCode(localTz));
-      _lastLogin = TimeZoneInfo.ConvertTime(lastLoginDt.Value, localTz);
+      try
+      {
+        var localTz = await _localTz.GetLocalTimeZoneAsync(null);
+        _timezone = LocalizeTimeZone(GetTimeZoneShortCode(localTz));
+        _lastLogin = TimeZoneInfo.ConvertTime(lastLoginDt.Value, localTz);
+      }
+      catch (Microsoft.JSInterop.JSDisconnectedException)
+      {
+        // Circuit has disconnected, reload the page
+        _navigationManager.NavigateTo(_navigationManager.Uri, forceLoad: true);
+      }
     }
   }
 

--- a/Portal/src/Datahub.Portal/Controllers/IFrameMiddleware.cs
+++ b/Portal/src/Datahub.Portal/Controllers/IFrameMiddleware.cs
@@ -1,4 +1,4 @@
-﻿namespace Datahub.Portal.Controllers
+namespace Datahub.Portal.Controllers
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
     public class AllowIFrameAttribute : Attribute
@@ -7,6 +7,7 @@
 
     public class IFrameMiddleware
     {
+        private const string XFrameOptionsHeader = "X-Frame-Options";
         private readonly RequestDelegate _next;
         private readonly ILogger<IFrameMiddleware> logger;
 
@@ -18,10 +19,10 @@
 
         public async Task InvokeAsync(HttpContext context)
         {
-            var endpoint = context.GetEndpoint();
-            bool headerConfigured = false;
+            var xFrameOptionsValue = "DENY";
             try
             {
+                var endpoint = context.GetEndpoint();
                 if (endpoint != null)
                 {
                     var controllerActionDescriptor = endpoint.Metadata.GetMetadata<Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor>();
@@ -30,26 +31,29 @@
                         var methodInfo = controllerActionDescriptor.MethodInfo;
                         var allowIFrame = methodInfo.GetCustomAttributes(typeof(AllowIFrameAttribute), true).Any();
 
-                        // Add the header only if the AllowIFrameAttribute is not present
                         if (allowIFrame)
                         {
-                            context.Response.Headers.Append("X-Frame-Options", "SAMEORIGIN");
-                            headerConfigured = true;
+                            xFrameOptionsValue = "SAMEORIGIN";
                         }
                     }
                 }
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 logger.LogWarning(e, "Error while processing IFrameMiddleware");
             }
-            if (!headerConfigured)
+
+            context.Response.OnStarting(() =>
             {
-                context.Response.Headers.Append("X-Frame-Options", "DENY");
-            }
+                if (!context.Response.Headers.ContainsKey(XFrameOptionsHeader))
+                {
+                    context.Response.Headers[XFrameOptionsHeader] = xFrameOptionsValue;
+                }
+
+                return Task.CompletedTask;
+            });
 
             await _next(context);
         }
     }
-
-
 }

--- a/Portal/src/Datahub.Portal/Datahub.Portal.csproj
+++ b/Portal/src/Datahub.Portal/Datahub.Portal.csproj
@@ -10,6 +10,8 @@
 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
 		<UserSecretsId>b1e84dc3-b45f-428e-bf71-7eec3434b232</UserSecretsId>
 		<CodeAnalysisRuleSet>..\..\..\Analyzers.ruleset</CodeAnalysisRuleSet>
+    <!-- https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?view=aspnetcore-9.0#navigationmanagernavigateto-no-longer-throws-a-navigationexception -->
+    <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 	</PropertyGroup>
 	<ItemGroup>
 		<Content Remove="Data\AzureFlexServers.json" />

--- a/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
@@ -61,7 +61,6 @@
 </CommonMudProviders>
 @code {
     [Parameter] public Datahub_Project Workspace { get; set; }
-    private string hello = "hello";
     private string padding = "0px";
 
     private string _topBorderStyle;

--- a/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
@@ -147,6 +147,8 @@
 
     private async Task AuditExceptionAsync(Exception ex)
     {
+        if (_correlationId is null)
+            return;
         try
         {
             await _auditingService.TrackException(ex, (nameof(_correlationId), _correlationId));

--- a/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
@@ -60,10 +60,10 @@
     </LockedUserGatekeeper>
 </CommonMudProviders>
 @code {
-    [Parameter] public Datahub_Project Workspace { get; set; }
+    [Parameter] public Datahub_Project Workspace { get; set; } = null!;
     private string padding = "0px";
 
-    private string _topBorderStyle;
+    private string _topBorderStyle = null!;
 
     private readonly string _sideBorderStyle = new StyleBuilder()
         .AddStyle("border-color", "var(--mud-palette-divider)")
@@ -236,7 +236,7 @@
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
         var lastHour = DateTime.Now.AddHours(-1);
         var events = dbContext.TelemetryEvents;
-        if (events != null && events.Count() > 0)
+        if (_portalUser is not null && events != null && events.Count() > 0)
         {
             return await events
                 .Where(u => u.PortalUser.Id == _portalUser.Id && u.EventDate >= lastHour)

--- a/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
@@ -87,14 +87,7 @@
                     UriComponents.PathAndQuery,
                     UriFormat.Unescaped);
 
-        if (currentUrl.StartsWith($"/{PageRoutes.WorkspacePrefix}"))
-        {
-            padding = "25px";
-        }
-        else
-        {
-            padding = "0px";
-        }
+        padding = currentUrl.StartsWith($"/{PageRoutes.WorkspacePrefix}") ? "25px" : "0px";
 
         _topBorderStyle = new StyleBuilder()
           .AddStyle("border-color", "var(--mud-palette-divider)")

--- a/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
@@ -28,227 +28,236 @@
 
 <CommonMudProviders>
 
-<DatahubAchievementProvider/>
+    <DatahubAchievementProvider />
 
-<LockedUserGatekeeper>
-    <MudLayout>
-        <MudAppBar Elevation="0" Style="@_topBorderStyle">
-            <Topbar SupportFormUrl="@_datahubPortalConfiguration.SupportFormUrl"/>
-        </MudAppBar>
-        <SectionOutlet SectionName="@DatahubTheme.SideBarContentName"/>
-        <MudMainContent>
-            <ErrorBoundary @ref="_errorBoundary">
-                <ChildContent>
-                    @Body
-                </ChildContent>
-                <ErrorContent Context="ex">
-                    @if (HandleException(@ex))
-                    {
-                        <MudContainer Class="mt-8" MaxWidth="MaxWidth.Large">
-                            <Error CorrelationId=@_correlationId Exception=@ex/>
-                        </MudContainer>
-                    }
-                    else
-                    {
+    <LockedUserGatekeeper>
+        <MudLayout>
+            <MudAppBar Elevation="0" Style="@_topBorderStyle">
+                <Topbar SupportFormUrl="@_datahubPortalConfiguration.SupportFormUrl" />
+            </MudAppBar>
+            <SectionOutlet SectionName="@DatahubTheme.SideBarContentName" />
+            <MudMainContent>
+                <ErrorBoundary @ref="_errorBoundary">
+                    <ChildContent>
                         @Body
-                    }
-                </ErrorContent>
-            </ErrorBoundary>
-            <DHFooter/>
-        </MudMainContent>
-    </MudLayout>
-</LockedUserGatekeeper>
+                    </ChildContent>
+                    <ErrorContent Context="ex">
+                        @if (HandleException(@ex))
+                        {
+                            <MudContainer Class="mt-8" MaxWidth="MaxWidth.Large">
+                                <Error CorrelationId=@_correlationId Exception=@ex />
+                            </MudContainer>
+                        }
+                        else
+                        {
+                            @Body
+                        }
+                    </ErrorContent>
+                </ErrorBoundary>
+                <DHFooter />
+            </MudMainContent>
+        </MudLayout>
+    </LockedUserGatekeeper>
 </CommonMudProviders>
 @code {
-  [Parameter] public Datahub_Project Workspace { get; set; }
-  private string hello = "hello";
-  private string padding = "0px";
+    [Parameter] public Datahub_Project Workspace { get; set; }
+    private string hello = "hello";
+    private string padding = "0px";
 
-  private string _topBorderStyle;
+    private string _topBorderStyle;
 
-  private readonly string _sideBorderStyle = new StyleBuilder()
-      .AddStyle("border-color", "var(--mud-palette-divider)")
-      .AddStyle("border-width", "1px")
-      .AddStyle("border-style", "none solid none none")
-      .Build();
+    private readonly string _sideBorderStyle = new StyleBuilder()
+        .AddStyle("border-color", "var(--mud-palette-divider)")
+        .AddStyle("border-width", "1px")
+        .AddStyle("border-style", "none solid none none")
+        .Build();
 
 
-  private PortalUser _portalUser;
-  private bool _correlationIdInitialized = false;
-  private string _correlationId;
-  private IJSObjectReference _module;
-  private ErrorBoundary _errorBoundary;
-  private Exception _lastException;
+    private PortalUser? _portalUser;
+    private bool _correlationIdInitialized = false;
+    private string? _correlationId;
+    private IJSObjectReference? _module;
+    private ErrorBoundary? _errorBoundary;
+    private Exception? _lastException;
 
-  protected override void OnParametersSet()
-  {
-    _errorBoundary?.Recover();
-
-    var currentUrl = new Uri(_navigationManager.Uri).GetComponents(
-                UriComponents.PathAndQuery,
-                UriFormat.Unescaped);
-
-    if (currentUrl.StartsWith($"/{PageRoutes.WorkspacePrefix}"))
+    protected override void OnParametersSet()
     {
-      padding = "25px";
-    }
-    else
-    {
-      padding = "0px";
-    }
+        _errorBoundary?.Recover();
 
-    _topBorderStyle = new StyleBuilder()
-      .AddStyle("border-color", "var(--mud-palette-divider)")
-      .AddStyle("border-width", "1px")
-      .AddStyle("border-style", "none none solid none")
-      .AddStyle("padding-top", padding)
-      .Build();
-  }
+        var currentUrl = new Uri(_navigationManager.Uri).GetComponents(
+                    UriComponents.PathAndQuery,
+                    UriFormat.Unescaped);
 
-  protected override async Task OnAfterRenderAsync(bool firstRender)
-  {
-    if (firstRender && !_correlationIdInitialized)
-    {
-      _correlationId = await _sessionStorage.GetItemAsStringAsync("correlationId");
-      if (string.IsNullOrEmpty(_correlationId))
-      {
-        _correlationId = Guid.NewGuid().ToString();
-        await _sessionStorage.SetItemAsStringAsync("correlationId", _correlationId);
-      }
-      _correlationIdInitialized = true;
-      StateHasChanged();
-    }
-  }
-  private bool HandleException(Exception ex)
-  {
-    if (IsIgnoredException(ex))
-      return false;
-    if (ex != _lastException)
-    {
-      _lastException = ex;
-      _ = AuditExceptionAsync(ex);
+        if (currentUrl.StartsWith($"/{PageRoutes.WorkspacePrefix}"))
+        {
+            padding = "25px";
+        }
+        else
+        {
+            padding = "0px";
+        }
+
+        _topBorderStyle = new StyleBuilder()
+          .AddStyle("border-color", "var(--mud-palette-divider)")
+          .AddStyle("border-width", "1px")
+          .AddStyle("border-style", "none none solid none")
+          .AddStyle("padding-top", padding)
+          .Build();
     }
 
-    return true;
-  }
-
-  private bool IsIgnoredException(Exception ex)
-  {
-    return ex is ObjectDisposedException or MicrosoftIdentityWebChallengeUserException;
-  }
-
-  private async Task AuditExceptionAsync(Exception ex)
-  {
-    try
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-      await _auditingService.TrackException(ex, (nameof(_correlationId), _correlationId));
-      await ReportIssue(ex, _correlationId);
-      await InvokeAsync(StateHasChanged);
+        if (firstRender && !_correlationIdInitialized)
+        {
+            _correlationId = await _sessionStorage.GetItemAsStringAsync("correlationId");
+            if (string.IsNullOrEmpty(_correlationId))
+            {
+                _correlationId = Guid.NewGuid().ToString();
+                await _sessionStorage.SetItemAsStringAsync("correlationId", _correlationId);
+            }
+            _correlationIdInitialized = true;
+            StateHasChanged();
+        }
     }
-    catch (Exception)
-    {
-      // ignored
-    }
-  }
 
-  public async Task ReportIssue(Exception ex, string correlationId)
-  {
-    if (!DevTools.IsDevelopment())
+    private bool HandleException(Exception ex)
     {
-      var exceptionDetail = new Dictionary<string, string>()
+
+        if (ex is HttpRequestException hex && hex.StatusCode is not null && hex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _navigationManager.NavigateTo(PageRoutes.NotFound, forceLoad: true);
+            return true;
+        }
+
+
+        if (IsIgnoredException(ex))
+            return false;
+        if (ex != _lastException)
+        {
+            _lastException = ex;
+            _ = AuditExceptionAsync(ex);
+        }
+
+        return true;
+    }
+
+    private bool IsIgnoredException(Exception ex)
+    {
+        return ex is ObjectDisposedException or MicrosoftIdentityWebChallengeUserException or LocationChangeException;
+    }
+
+    private async Task AuditExceptionAsync(Exception ex)
+    {
+        try
+        {
+            await _auditingService.TrackException(ex, (nameof(_correlationId), _correlationId));
+            await ReportIssue(ex, _correlationId);
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
+    }
+
+    public async Task ReportIssue(Exception ex, string correlationId)
+    {
+        if (!DevTools.IsDevelopment())
+        {
+            var exceptionDetail = new Dictionary<string, string>()
             {
                 { "Type", ex.GetType().ToString() },
                 { "Message", ex.Message },
                 { "StackTrace", ex.StackTrace },
                 { "CorrelationId", correlationId }
             };
-      var exceptionData = Newtonsoft.Json.JsonConvert.SerializeObject(exceptionDetail);
+            var exceptionData = Newtonsoft.Json.JsonConvert.SerializeObject(exceptionDetail);
 
-      // collect information
-      _portalUser = await _userInformationService.GetCurrentPortalUserAsync();
-      if (_portalUser is null)
-      {
-        _portalUser = new PortalUser
+            // collect information
+            _portalUser = await _userInformationService.GetCurrentPortalUserAsync();
+            if (_portalUser is null)
+            {
+                _portalUser = new PortalUser
+                {
+                    DisplayName = "Unknown User",
+                    Email = "unknown_email",
+                };
+            }
+
+            var userLanguage = await _userSettingsService.GetUserLanguage();
+
+            IJSObjectReference _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Layout/PortalLayout.razor.js");
+
+            var url = _navigationManager.Uri; // Retrieve the active URL
+            var userAgent = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"].ToString();
+            var timeZone = await _module.InvokeAsync<string>("blazorGetTimezone");
+            var dimensions = await _module.InvokeAsync<string>("blazorGetScreenDimentions");
+
+            // Retrieve all local storage data
+            var allKeys = await _localStorage.KeysAsync();
+            var dataDict = new Dictionary<string, string>();
+            foreach (var key in allKeys)
+            {
+                var value = await _localStorage.GetItemAsStringAsync(key);
+                dataDict.Add(key, value);
+            }
+
+            var localStorageData = Newtonsoft.Json.JsonConvert.SerializeObject(dataDict);
+
+            var lastHourEvents = await GetTelemetryData();
+            var telemetryData = Newtonsoft.Json.JsonConvert.SerializeObject(lastHourEvents);
+
+            // We create the bug report message and send it to the queue.
+            var bugReport = new BugReportMessage(
+                UserName: _portalUser.DisplayName,
+                UserEmail: _portalUser.Email,
+                UserOrganization: GetOrg(_portalUser.Email),
+                PortalLanguage: userLanguage,
+                PreferredLanguage: "en",
+                Timezone: timeZone,
+                Workspaces: url,
+                Topics: "Exception",
+                URL: url,
+                UserAgent: userAgent,
+                Resolution: dimensions,
+                LocalStorage: localStorageData,
+                BugReportType: BugReportTypes.SupportRequest,
+                Description: $"Automatically recorded exception: {exceptionData}, telemetry: {telemetryData}",
+                CorrelationId: _correlationId
+            );
+
+            await _mediatr.Send(bugReport);
+        }
+    }
+
+    private async Task<List<TelemetryEvent>> GetTelemetryData()
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
+        var lastHour = DateTime.Now.AddHours(-1);
+        var events = dbContext.TelemetryEvents;
+        if (events != null && events.Count() > 0)
         {
-          DisplayName = "Unknown User",
-          Email = "unknown_email",
-        };
-      }
+            return await events
+                .Where(u => u.PortalUser.Id == _portalUser.Id && u.EventDate >= lastHour)
+                .ToListAsync();
+        }
 
-      var userLanguage = await _userSettingsService.GetUserLanguage();
-
-      IJSObjectReference _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Layout/PortalLayout.razor.js");
-
-      var url = _navigationManager.Uri; // Retrieve the active URL
-      var userAgent = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"].ToString();
-      var timeZone = await _module.InvokeAsync<string>("blazorGetTimezone");
-      var dimensions = await _module.InvokeAsync<string>("blazorGetScreenDimentions");
-
-      // Retrieve all local storage data
-      var allKeys = await _localStorage.KeysAsync();
-      var dataDict = new Dictionary<string, string>();
-      foreach (var key in allKeys)
-      {
-        var value = await _localStorage.GetItemAsStringAsync(key);
-        dataDict.Add(key, value);
-      }
-
-      var localStorageData = Newtonsoft.Json.JsonConvert.SerializeObject(dataDict);
-
-      var lastHourEvents = await GetTelemetryData();
-      var telemetryData = Newtonsoft.Json.JsonConvert.SerializeObject(lastHourEvents);
-
-      // We create the bug report message and send it to the queue.
-      var bugReport = new BugReportMessage(
-          UserName: _portalUser.DisplayName,
-          UserEmail: _portalUser.Email,
-          UserOrganization: GetOrg(_portalUser.Email),
-          PortalLanguage: userLanguage,
-          PreferredLanguage: "en",
-          Timezone: timeZone,
-          Workspaces: url,
-          Topics: "Exception",
-          URL: url,
-          UserAgent: userAgent,
-          Resolution: dimensions,
-          LocalStorage: localStorageData,
-          BugReportType: BugReportTypes.SupportRequest,
-          Description: $"Automatically recorded exception: {exceptionData}, telemetry: {telemetryData}",
-          CorrelationId: _correlationId
-      );
-
-      await _mediatr.Send(bugReport);
+        return new List<TelemetryEvent>();
     }
-  }
 
-  private async Task<List<TelemetryEvent>> GetTelemetryData()
-  {
-    await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
-    var lastHour = DateTime.Now.AddHours(-1);
-    var events = dbContext.TelemetryEvents;
-    if (events != null && events.Count() > 0)
+    private string GetOrg(string email)
     {
-      return await events
-          .Where(u => u.PortalUser.Id == _portalUser.Id && u.EventDate >= lastHour)
-          .ToListAsync();
-    }
+        var org = "";
+        try
+        {
+            org = email.Split("@")[1].Split('.')[0];
+        }
+        catch
+        {
+            org = "unknown";
+        }
 
-    return new List<TelemetryEvent>();
-  }
-
-  private string GetOrg(string email)
-  {
-    var org = "";
-    try
-    {
-      org = email.Split("@")[1].Split('.')[0];
+        return org;
     }
-    catch
-    {
-      org = "unknown";
-    }
-
-    return org;
-  }
 
 }

--- a/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
+++ b/Portal/src/Datahub.Portal/Layout/PortalLayout.razor
@@ -186,7 +186,7 @@
 
             var userLanguage = await _userSettingsService.GetUserLanguage();
 
-            IJSObjectReference _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Layout/PortalLayout.razor.js");
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Layout/PortalLayout.razor.js");
 
             var url = _navigationManager.Uri; // Retrieve the active URL
             var userAgent = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"].ToString();

--- a/Portal/src/Datahub.Portal/Pages/ViewUserBase.cs
+++ b/Portal/src/Datahub.Portal/Pages/ViewUserBase.cs
@@ -29,7 +29,10 @@ public class ViewUserBase<T> : ComponentBase
         // If the user id parameter is missing, surface a404
         if (!string.IsNullOrWhiteSpace(UserIdBase64))
         {
-
+            if (await _userInformationService.IsExternalUser())
+            {
+                throw new HttpRequestException("External users cannot view other users' profiles", null, HttpStatusCode.NotFound);
+            }
 
             try
             {
@@ -44,6 +47,10 @@ public class ViewUserBase<T> : ComponentBase
                 _portalUserWithAchievements = await _userInformationService.GetEntraUserWithAchievementsAsync(id);
                 return _portalUserWithAchievements ?? throw new HttpRequestException("User id is required", null, HttpStatusCode.NotFound);
 
+            }
+            catch (HttpRequestException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -82,6 +89,10 @@ public class ViewUserBase<T> : ComponentBase
 
                 _portalUser = await _userInformationService.GetEntraUserAsync(id);
                 return _portalUser;
+            }
+            catch (HttpRequestException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/Portal/src/Datahub.Portal/Properties/launchSettings.json
+++ b/Portal/src/Datahub.Portal/Properties/launchSettings.json
@@ -39,6 +39,17 @@
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },
+    "Console Portal (Development LocalDB External)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ConnectionStrings__datahub_mssql_project": "Server=(LocalDB)\\MSSQLLocalDB;Initial Catalog=dh-portal-projectdb",
+        "ConnectionStrings__datahub_mssql_metadata": "Server=(LocalDB)\\MSSQLLocalDB;Initial Catalog=dh-portal-metadata",
+        "GccfOidc__DevAuth__UserEmail": "dev.user@example.com",
+        "GccfOidc__DevAuth__UserName": "Dev User"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
     "Console Portal (Offline)": {
       "commandName": "Project",
       "launchBrowser": true,

--- a/Portal/src/Datahub.Portal/Startup.cs
+++ b/Portal/src/Datahub.Portal/Startup.cs
@@ -322,7 +322,7 @@ public class Startup
         app.UseAuthentication();
         app.UseAuthorization();
 
-        app.UseStatusCodePagesWithReExecute("/404");
+        app.UseStatusCodePagesWithReExecute("/404", createScopeForStatusCodePages: true);
 
         // this needs to be as late as possible in the pipeline to ensure antiforgery tokens are validated for all endpoints, including reverse proxy
         app.UseAntiforgery();


### PR DESCRIPTION
# Pull Request

## Description

- Add missing migration for ExternalUserLock
- Fixed external user profile exception
- Fixed 404 page

## Related Work Items

<!-- List any related work items or tickets. Use the format `AB#XXXX` for Azure DevOps work items. -->
AB#2980



## Testing

<!-- Identify the testing that was done and necessary steps for verification. Include screenshots, logs, or other evidence that demonstrates the changes work as expected. -->

- [X] I ran the portal locally and verified the changes in the PR
- [ ] I added unit tests and they are passing
- [ ] I included screenshots, logs, or other evidence showing the fix or feature works as expected in the "Changes" section above
- [X] Some changes cannot be tested locally. 
    - [X] I have added follow-up work items to test these changes in the appropriate environment, including documentation of the testing steps and expected results.

## Checklist

<!-- Ensure the following tasks are complete -->

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] Added a high-level description of the changes in the PR
- [X] Linked any related work items or tickets
- [X] Listed the key changes in the PR with technical details
- [X] Added screenshots, logs, or other evidence that demonstrates the changes work as expected
- [X] Identified the testing that was done and necessary steps for verification
- [X] Ensured that my code follows coding standards

