### PR TITLE
fix: storage button styling and rework

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor
@@ -25,7 +25,19 @@
     
 <div class="heading">
     <div class="actions">
-        @if (ShowBackToContainers)
+        @foreach(var action in _buttonActions)
+        {
+            if ((action is ButtonAction.BackToContainers && !ShowBackToContainers)
+                || (action is ButtonAction.NewFolder && !ShowNewFolder)
+                || (action is ButtonAction.DeleteFolder && !ShowDeleteFolder)
+                || (action is ButtonAction.Publish && !ShowPublish))
+            { continue; }
+
+            <DHButton @onclick="() => GetButtonActionHandler(action)" StartIcon="@GetButtonActionIcon(action)" Disabled="@IsActionDisabled(action)">
+                @Localizer[ButtonActionToString(action)]
+            </DHButton>
+        }
+@*         @if (ShowBackToContainers)
         {
             <DHButton class="button-tool" @onclick="HandleBackToContainers" StartIcon="fas fa-arrow-left">
                 @Localizer["Back to Containers"]
@@ -77,7 +89,7 @@
             <DHButton class="button-tool" @onclick="HandlePublish" StartIcon="fas fa-bullhorn" Disabled="IsActionDisabled(ButtonAction.Publish)">
                 @Localizer["Publish"]
             </DHButton>
-        }
+        } *@
     </div>
 
     <HeadingBreadcrumbs SetCurrentFolder="@SetCurrentFolder" CurrentFolder="@CurrentFolder" />
@@ -161,6 +173,18 @@
 
     private Project_Role _currentUserRole;
     private DotNetObjectReference<StorageHeading> _dotNetHelper;
+
+    private List<ButtonAction> _buttonActions = new()
+    {
+        ButtonAction.BackToContainers,
+        ButtonAction.Upload,
+        ButtonAction.Download,
+        ButtonAction.Rename,
+        ButtonAction.Delete,
+        ButtonAction.NewFolder,
+        ButtonAction.DeleteFolder,
+        ButtonAction.Publish
+    };
 
     protected override async Task OnInitializedAsync()
     {

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor
@@ -37,59 +37,6 @@
                 @Localizer[ButtonActionToString(action)]
             </DHButton>
         }
-@*         @if (ShowBackToContainers)
-        {
-            <DHButton class="button-tool" @onclick="HandleBackToContainers" StartIcon="fas fa-arrow-left">
-                @Localizer["Back to Containers"]
-            </DHButton>
-            <span class="tool-divider"></span>
-        }
-
-        <DHButton class="button-tool" @onclick="HandleUpload" StartIcon="fas fa-upload" Disabled="IsActionDisabled(ButtonAction.Upload)">
-            @Localizer["Upload"]
-        </DHButton>
-
-        <DHButton class="button-tool" @onclick="HandleDownload" StartIcon="fas fa-download" Disabled="IsActionDisabled(ButtonAction.Download)">
-            @Localizer["Download"]
-        </DHButton>
-
-        <DHButton class="button-tool" @onclick="HandleRename" StartIcon="fas fa-edit" Disabled="IsActionDisabled(ButtonAction.Rename)">
-            @Localizer["Rename"]
-        </DHButton>
-
-        <span class="tool-divider"></span>
-
-        <DHButton class="button-tool" @onclick="HandleDelete" StartIcon="fas fa-trash-alt" Disabled="IsActionDisabled(ButtonAction.Delete)">
-            @Localizer["Delete"]
-        </DHButton>
-
-        @if (ShowNewFolder || ShowDeleteFolder)
-        {
-            <span class="tool-divider"></span>
-        }
-
-        @if (ShowNewFolder)
-        {
-            <DHButton class="button-tool" @onclick="HandleNewFolder" StartIcon="fas fa-folder-plus" Disabled="IsActionDisabled(ButtonAction.NewFolder)">
-                @Localizer["New Folder"]
-            </DHButton>
-        }
-
-        @if (ShowDeleteFolder)
-        {
-            <DHButton class="button-tool" @onclick="HandleDeleteFolder" StartIcon="fas fa-folder-minus" Disabled="IsActionDisabled(ButtonAction.DeleteFolder)">
-                @Localizer["Delete Folder"]
-            </DHButton>
-        }
-
-        @if (ShowPublish)
-        {
-            <span class="tool-divider"></span>
-
-            <DHButton class="button-tool" @onclick="HandlePublish" StartIcon="fas fa-bullhorn" Disabled="IsActionDisabled(ButtonAction.Publish)">
-                @Localizer["Publish"]
-            </DHButton>
-        } *@
     </div>
 
     <HeadingBreadcrumbs SetCurrentFolder="@SetCurrentFolder" CurrentFolder="@CurrentFolder" />

--- a/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor.cs
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Storage/StorageHeading.razor.cs
@@ -9,6 +9,7 @@ public partial class StorageHeading
 {
     private enum ButtonAction
     {
+        BackToContainers,
         Upload,
         Download,
         Share,
@@ -18,6 +19,79 @@ public partial class StorageHeading
         DeleteFolder,
         NewFolder,
         Publish
+    }
+
+    private string ButtonActionToString(ButtonAction action)
+    {
+        switch (action)
+        {
+            case ButtonAction.BackToContainers:
+                return "Back to Containers";
+            case ButtonAction.DeleteFolder:
+                return "Delete Folder";
+            case ButtonAction.NewFolder:
+                return "New Folder";
+            default:
+                return action.ToString();
+        }
+    }
+
+    private string GetButtonActionIcon(ButtonAction action)
+    {
+        switch (action)
+        {
+            case ButtonAction.BackToContainers:
+                return "fas fa-arrow-left";
+            case ButtonAction.Upload:
+                return "fas fa-upload";
+            case ButtonAction.Download:
+                return "fas fa-download";
+            case ButtonAction.Rename:
+                return "fas fa-edit";
+            case ButtonAction.Delete:
+                return "fas fa-trash-alt";
+            case ButtonAction.NewFolder:
+                return "fas fa-folder-plus";
+            case ButtonAction.DeleteFolder:
+                return "fas fa-folder-minus";
+            case ButtonAction.Publish:
+                return "fas fa-bullhorn";
+            default:
+                return "fas fa-arrow-left";
+        }
+    }
+
+    private async Task GetButtonActionHandler(ButtonAction action)
+    {
+        switch(action)
+        {
+            case ButtonAction.BackToContainers:
+                await HandleBackToContainers();
+                break;
+            case ButtonAction.Upload:
+                await HandleUpload();
+                break;
+            case ButtonAction.Download:
+                await HandleDownload();
+                break;
+            case ButtonAction.Rename:
+                await HandleRename();
+                break;
+            case ButtonAction.Delete:
+                await HandleDelete();
+                break;
+            case ButtonAction.NewFolder:
+                await HandleNewFolder();
+                break;
+            case ButtonAction.DeleteFolder:
+                await HandleDeleteFolder();
+                break;
+            case ButtonAction.Publish:
+                await HandlePublish();
+                break;
+            default:
+                break;
+        }
     }
     
     private async Task HandleUpload()
@@ -173,6 +247,9 @@ public partial class StorageHeading
 
     private bool IsActionDisabled(ButtonAction buttonAction)
     {
+        if(buttonAction is ButtonAction.BackToContainers)
+        { return false; }
+
         if (_currentUserRole is null)
             return true;
 


### PR DESCRIPTION
# Pull Request

## Description
Improves styling and backend for the buttons used at the top of the storage page.

## Related Work Items
[AB#2889](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/2889)

## Changes

- Changed button to be dependent on themes not independent styling class
- Simplified button so it's easier to change them/add more

New:
<img width="1216" height="177" alt="image" src="https://github.com/user-attachments/assets/56efe859-615d-478d-9e7a-2d54cdc1080e" />

Old (for comparison):
<img width="1282" height="185" alt="image" src="https://github.com/user-attachments/assets/964cbf1b-8062-4ff2-8dba-4e33bc38ddc5" />


## Testing

<!-- Identify the testing that was done and necessary steps for verification. Include screenshots, logs, or other evidence that demonstrates the changes work as expected. -->

- [X] I ran the portal locally and verified the changes in the PR
- [ ] I added unit tests and they are passing
- [ ] I included screenshots, logs, or other evidence showing the fix or feature works as expected in the "Changes" section above
- [ ] Some changes cannot be tested locally. 
    - [ ] I have added follow-up work items to test these changes in the appropriate environment, including documentation of the testing steps and expected results.

## Checklist

<!-- Ensure the following tasks are complete -->

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change (i.e., requires minor or major version bump)
- [X] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [X] Added a high-level description of the changes in the PR
- [X] Linked any related work items or tickets
- [X] Listed the key changes in the PR with technical details
- [X] Added screenshots, logs, or other evidence that demonstrates the changes work as expected
- [X] Identified the testing that was done and necessary steps for verification
- [X] Ensured that my code follows coding standards

### Reviewers Checklist

_By approving a review, you confirm that you have reviewed the PR and that the following items have been addressed. Please request changes if any item has not been addressed or if you have any concerns._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change
- [ ] confirmed the correct target branch
- [ ] reviewed the high-level description of the changes in the PR and confirmed it is clear and accurate
- [ ] reviewed the linked work items or tickets and confirmed they are relevant and appropriately linked
- [ ] reviewed the key changes in the PR and confirmed they are clear and technically sound
- [ ] reviewed the provided screenshots, logs, or other evidence and confirmed they demonstrate the changes work as expected
- [ ] reviewed the identified testing and confirmed it is sufficient for verification
- [ ] reviewed the code and confirmed it follows coding standards
- [ ] approved the PR if all items are addressed, or requested changes if any item has not been addressed or if I have any concerns
