### PR TITLE
fix: Displaying activation link and pending status for external users in multiple workspaces

### DIFF
--- a/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceExternalUsersPage.razor
+++ b/Portal/src/Datahub.Portal/Pages/Workspace/Users/WorkspaceExternalUsersPage.razor
@@ -98,7 +98,7 @@ else if (_gccfEnabled)
                                 {
                                     <MudChip T="string" Color="Color.Error">@Localizer["Expired"]</MudChip>
                                 }
-                                else if (rowContext.ExternalUser.FirstLoginDateTime is null)
+                                else if (rowContext.ExternalUser.FirstLoginDateTime is null || (rowContext.LatestInvitation is not null && rowContext.LatestInvitation.InvitationCodeAccepted is null))
                                 {
                                     <MudChip T="string" Color="Color.Warning">@Localizer["Pending Invite"]</MudChip>
                                 }
@@ -485,7 +485,7 @@ else
 
     private bool ShouldShowInvitationDetails(ExternalWorkspaceUserRow projectUser)
     {
-        return projectUser.ExternalUser.FirstLoginDateTime is null && projectUser.LatestInvitation is not null;
+        return projectUser.LatestInvitation is not null && projectUser.LatestInvitation.InvitationCodeAccepted is null;
     }
 
     private string GetInvitationCode(ExternalWorkspaceUserRow projectUser)


### PR DESCRIPTION
# Pull Request

## Description

<!-- A brief description of what this PR does. The description should be at a high level that a non-technical audience can understand. -->

If you invite an external user to additional workspace, the Status shows Active because it only checks their last first login date. This PR changes this behaviour to check if the acceptance is also null.

## Related Work Items

<!-- List any related work items or tickets. Use the format `AB#XXXX` for Azure DevOps work items. -->

[AB#2993](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/2993)

## Changes

<!-- List the key changes in this PR. Provide technical details. Include screenshots, logs, or other evidence that demonstrates the changes work as expected. -->

- Updates check to verify if the workspace-specific acceptance is null or not

### Before

<img width="1900" height="652" alt="image" src="https://github.com/user-attachments/assets/6c4feca3-e29b-4454-ac9f-d2fc67ce7dc3" />

### After

<img width="1909" height="583" alt="image" src="https://github.com/user-attachments/assets/9d39ee27-2d1c-475c-a3e6-b6e0d89d926d" />

## Testing

<!-- Identify the testing that was done and necessary steps for verification. Include screenshots, logs, or other evidence that demonstrates the changes work as expected. -->

- [x] I ran the portal locally and verified the changes in the PR
- [ ] I added unit tests and they are passing
- [ ] I included screenshots, logs, or other evidence showing the fix or feature works as expected in the "Changes" section above
- [x] Some changes cannot be tested locally. 
    - [x] I have added follow-up work items to test these changes in the appropriate environment, including documentation of the testing steps and expected results.

## Checklist

<!-- Ensure the following tasks are complete -->

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] Added a high-level description of the changes in the PR
- [x] Linked any related work items or tickets
- [x] Listed the key changes in the PR with technical details
- [x] Added screenshots, logs, or other evidence that demonstrates the changes work as expected
- [x] Identified the testing that was done and necessary steps for verification
- [x] Ensured that my code follows coding standards

### Reviewers Checklist

_By approving a review, you confirm that you have reviewed the PR and that the following items have been addressed. Please request changes if any item has not been addressed or if you have any concerns._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change
- [ ] confirmed the correct target branch
- [ ] reviewed the high-level description of the changes in the PR and confirmed it is clear and accurate
- [ ] reviewed the linked work items or tickets and confirmed they are relevant and appropriately linked
- [ ] reviewed the key changes in the PR and confirmed they are clear and technically sound
- [ ] reviewed the provided screenshots, logs, or other evidence and confirmed they demonstrate the changes work as expected
- [ ] reviewed the identified testing and confirmed it is sufficient for verification
- [ ] reviewed the code and confirmed it follows coding standards
- [ ] approved the PR if all items are addressed, or requested changes if any item has not been addressed or if I have any concerns
