### PR TITLE
fix: Resource provisioner duplicate pull requests

### DIFF
--- a/ResourceProvisioner/src/ResourceProvisioner.Application/Services/IRepositoryService.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Application/Services/IRepositoryService.cs
@@ -13,6 +13,7 @@ public interface IRepositoryService
     public Task CheckoutInfrastructureBranch(string workspaceName);
     public Task CommitTerraformTemplate(TerraformTemplate template, string username);
     public Task PushInfrastructureRepository(string workspaceAcronym);
+    public bool HasInfrastructureChanges(string workspaceAcronym);
     public Task<PullRequestValueObject> CreateInfrastructurePullRequest(string workspaceAcrynom);
     public Task FetchRepositoriesAndCheckoutProjectBranch(TerraformWorkspace workspace);
     public Task<List<RepositoryUpdateEvent>> ExecuteResourceRuns(WorkspaceDefinition command, string username);

--- a/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/RepositoryService.cs
+++ b/ResourceProvisioner/src/ResourceProvisioner.Infrastructure/Services/RepositoryService.cs
@@ -152,9 +152,41 @@ public partial class RepositoryService(
             var repositoryUpdateEvents =
                 await ExecuteResourceRuns(workspaceDefinition, user);
 
+            var pullRequestMessage = new PullRequestUpdateMessage
+            {
+                TerraformWorkspace = workspaceDefinition.Workspace,
+                Events = repositoryUpdateEvents
+            };
+
+            if (pullRequestMessage.Events.Any(x => x.StatusCode == MessageStatusCode.Error))
+            {
+                pullRequestMessage.Events
+                    .Where(x => x.StatusCode == MessageStatusCode.Error)
+                    .ToList()
+                    .ForEach(x => logger.LogError(x.Message, x));
+                throw new Exception("Error while handling resource run request");
+            }
+
+            if (!pullRequestMessage.Events.Any(x => x.StatusCode == MessageStatusCode.Success))
+            {
+                logger.LogInformation(
+                    "No infrastructure changes were committed for {WorkspaceAcronym}; skipping pull request creation",
+                    workspaceDefinition.Workspace.Acronym);
+                return pullRequestMessage;
+            }
+
             logger.LogInformation("Pushing changes to remote repository for {WorkspaceAcronym}",
                 workspaceDefinition.Workspace.Acronym);
             await PushInfrastructureRepository(workspaceDefinition.Workspace.Acronym!);
+
+            if (!HasInfrastructureChanges(workspaceDefinition.Workspace.Acronym!))
+            {
+                logger.LogInformation(
+                    "Infrastructure branch {WorkspaceAcronym} has no changes relative to {MainBranch}; skipping pull request creation",
+                    workspaceDefinition.Workspace.Acronym,
+                    resourceProvisionerConfiguration.Value.InfrastructureRepository.MainBranch);
+                return pullRequestMessage;
+            }
 
             logger.LogInformation("Creating pull request for {WorkspaceAcronym}", workspaceDefinition.Workspace.Acronym);
             var pullRequestValueObject =
@@ -174,23 +206,8 @@ public partial class RepositoryService(
                     pullRequestValueObject.PullRequestId);
             }
 
-            var pullRequestMessage = new PullRequestUpdateMessage
-            {
-                PullRequestValueObject = pullRequestValueObject,
-                TerraformWorkspace = workspaceDefinition.Workspace,
-                Events = repositoryUpdateEvents
-            };
-
-            if (pullRequestMessage.Events.All(x => x.StatusCode != MessageStatusCode.Error))
-            {
-                return pullRequestMessage;
-            }
-
-            pullRequestMessage.Events
-                .Where(x => x.StatusCode == MessageStatusCode.Error)
-                .ToList()
-                .ForEach(x => logger.LogError(x.Message, x));
-            throw new Exception("Error while handling resource run request");
+            pullRequestMessage.PullRequestValueObject = pullRequestValueObject;
+            return pullRequestMessage;
         }
         finally
         {
@@ -400,6 +417,28 @@ public partial class RepositoryService(
 
         logger.LogInformation("Changes pushed in {LocalPath} to {Branch} branch", repositoryPath,
             branch.CanonicalName);
+    }
+
+    public bool HasInfrastructureChanges(string workspaceAcronym)
+    {
+        var repositoryPath = DirectoryUtils.GetInfrastructureRepositoryPath(resourceProvisionerConfiguration.Value);
+        using var repository = new Repository(repositoryPath);
+
+        var sourceBranch = repository.Branches[workspaceAcronym];
+        var targetBranch = repository.Branches[resourceProvisionerConfiguration.Value.InfrastructureRepository.MainBranch];
+
+        if (sourceBranch?.Tip is null)
+        {
+            throw new InvalidOperationException($"Source branch {workspaceAcronym} does not exist in {repositoryPath}");
+        }
+
+        if (targetBranch?.Tip is null)
+        {
+            throw new InvalidOperationException(
+                $"Target branch {resourceProvisionerConfiguration.Value.InfrastructureRepository.MainBranch} does not exist in {repositoryPath}");
+        }
+
+        return repository.Diff.Compare<TreeChanges>(targetBranch.Tip.Tree, sourceBranch.Tip.Tree).Any();
     }
 
     public const string HttpClientName = "InfrastructureHttpClient";

--- a/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Services/RepositoryServiceTests.cs
+++ b/ResourceProvisioner/test/ResourceProvisioner.Infrastructure.UnitTests/Services/RepositoryServiceTests.cs
@@ -162,6 +162,33 @@ public class RepositoryServiceTests : TemplateTestCollection
     }
 
     [Test]
+    public void ShouldReportNoInfrastructureChangesWhenSourceMatchesMain()
+    {
+        var workspaceAcronym = GenerateWorkspaceAcronym();
+        using var repository = InitializeTestInfrastructureRepository(workspaceAcronym);
+        EnsureMainBranch(repository);
+        repository.CreateBranch(workspaceAcronym);
+
+        Assert.That(_repositoryService.HasInfrastructureChanges(workspaceAcronym), Is.False);
+    }
+
+    [Test]
+    public void ShouldReportInfrastructureChangesWhenSourceDiffersFromMain()
+    {
+        var workspaceAcronym = GenerateWorkspaceAcronym();
+        using var repository = InitializeTestInfrastructureRepository(workspaceAcronym);
+        EnsureMainBranch(repository);
+        var workspaceBranch = repository.CreateBranch(workspaceAcronym);
+        Commands.Checkout(repository, workspaceBranch);
+        CreateFakeFileInTestProject(workspaceAcronym);
+        Commands.Stage(repository, "*");
+        var signature = new Signature(RequestingUser, RequestingUser, DateTimeOffset.Now);
+        repository.Commit("Workspace change", signature, signature);
+
+        Assert.That(_repositoryService.HasInfrastructureChanges(workspaceAcronym), Is.True);
+    }
+
+    [Test]
     public async Task ShouldExecuteResourceRun()
     {
         var workspaceAcronym = GenerateWorkspaceAcronym();
@@ -494,6 +521,14 @@ public class RepositoryServiceTests : TemplateTestCollection
         }
 
         File.WriteAllText(Path.Join(projectPath, fileName), content);
+    }
+
+    private static void EnsureMainBranch(Repository repository)
+    {
+        if (repository.Branches[_resourceProvisionerConfiguration.InfrastructureRepository.MainBranch] is null)
+        {
+            repository.CreateBranch(_resourceProvisionerConfiguration.InfrastructureRepository.MainBranch);
+        }
     }
 
     private static async Task DeleteRemotePushBranch(string branchName)


### PR DESCRIPTION
# Pull Request

## Description

<!-- A brief description of what this PR does. The description should be at a high level that a non-technical audience can understand. -->

**AI Disclosure:** Codex developed the fix for this, I have reviewed the output myself and it looks good to me. Hoping someone more familiar with resource provisioner can confirm.

The Resource Provisioner is creating multiple pull requests one after the other, both set to auto close and both targeting the same commit ID. When the first closes, the second is left stranded. This PR attempts to resolve this issue.

## Related Work Items

<!-- List any related work items or tickets. Use the format `AB#XXXX` for Azure DevOps work items. -->

[AB#4158](https://dev.azure.com/SSC-FSDH/e4102ffd-0961-4cc1-ae2b-d3d09284155c/_workitems/edit/4158)

## Changes

<!-- List the key changes in this PR. Provide technical details. Include screenshots, logs, or other evidence that demonstrates the changes work as expected. -->

- A PR is now skipped when all resource runs report no changes detected
- Before creating a PR, the provisioner compares the branch tree to main, no file diff means no new ADO PR
- Resource run errors are handled before any push/PR attempt
- Added tests for matching and differing branches

## Testing

<!-- Identify the testing that was done and necessary steps for verification. Include screenshots, logs, or other evidence that demonstrates the changes work as expected. -->

- [x] I ran the portal locally and verified the changes in the PR
- [x] I added unit tests and they are passing
- [ ] I included screenshots, logs, or other evidence showing the fix or feature works as expected in the "Changes" section above
- [ ] Some changes cannot be tested locally. 
    - [ ] I have added follow-up work items to test these changes in the appropriate environment, including documentation of the testing steps and expected results.

## Checklist

<!-- Ensure the following tasks are complete -->

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change (i.e., requires minor or major version bump)
- [x] Targeted the correct branch (see [External Collaboration](https://github.com/fsdh-pfds/.github/blob/main/CONTRIBUTING.md#external-collaboration))
- [x] Added a high-level description of the changes in the PR
- [x] Linked any related work items or tickets
- [x] Listed the key changes in the PR with technical details
- [x] Added screenshots, logs, or other evidence that demonstrates the changes work as expected
- [x] Identified the testing that was done and necessary steps for verification
- [x] Ensured that my code follows coding standards

### Reviewers Checklist

_By approving a review, you confirm that you have reviewed the PR and that the following items have been addressed. Please request changes if any item has not been addressed or if you have any concerns._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, including the `!` if the change is a breaking change
- [ ] confirmed the correct target branch
- [ ] reviewed the high-level description of the changes in the PR and confirmed it is clear and accurate
- [ ] reviewed the linked work items or tickets and confirmed they are relevant and appropriately linked
- [ ] reviewed the key changes in the PR and confirmed they are clear and technically sound
- [ ] reviewed the provided screenshots, logs, or other evidence and confirmed they demonstrate the changes work as expected
- [ ] reviewed the identified testing and confirmed it is sufficient for verification
- [ ] reviewed the code and confirmed it follows coding standards
- [ ] approved the PR if all items are addressed, or requested changes if any item has not been addressed or if I have any concerns
